### PR TITLE
🔧 fix(serwist): enable offline caching for large PGLite assets

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -320,9 +320,14 @@ const withBundleAnalyzer = process.env.ANALYZE === 'true' ? analyzer() : noWrapp
 const withPWA =
   isProd && !isDesktop
     ? withSerwistInit({
-        register: false,
-        swDest: 'public/sw.js',
-        swSrc: 'src/app/sw.ts',
+        // Allow precaching of large PGLite assets for offline functionality
+maximumFileSizeToCacheInBytes: 10 * 1024 * 1024,
+        
+register: false,
+        
+swDest: 'public/sw.js',
+        
+        swSrc: 'src/app/sw.ts', // 10MB
       })
     : noWrapper;
 


### PR DESCRIPTION
## Changes

- Set `maximumFileSizeToCacheInBytes` to 10MB to allow precaching of postgres.*.data (5.4MB) and postgres.*.wasm (8.09MB) files
- Enables offline-first functionality for PGLite database
- Resolves Serwist build warnings about files not being precached

## Testing

- [x] Type checking passes
- [x] Configuration change applied to next.config.ts
- [ ] Build logs validation (will be confirmed after deployment)
- [ ] Service worker includes large PGLite assets
- [ ] All healthcheck endpoints still return 200 OK

## Expected Results

- Build warnings about postgres files not being precached should be eliminated
- Service worker will include PGLite assets for offline functionality
- No impact on existing healthcheck endpoint functionality

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author