### PR TITLE
🎨 style(provider): mark unused param as intentionally unused (_id)

### DIFF
--- a/src/app/[variants]/(main)/settings/provider/ProviderMenu/Item.tsx
+++ b/src/app/[variants]/(main)/settings/provider/ProviderMenu/Item.tsx
@@ -35,49 +35,49 @@ export const useStyles = createStyles(({ css, token }) => ({
   `,
 }));
 
-const ProviderItem = memo<AiProviderListItem & {
-  onClick: (id: string) => void
-}>(
-  ({ id, name, source, enabled, logo, onClick = () => {} }) => {
-    const { styles, cx } = useStyles();
-    const searchParams = useSearchParams();
+const ProviderItem = memo<
+  AiProviderListItem & {
+    onClick: (_id: string) => void;
+  }
+>(({ id, name, source, enabled, logo, onClick = () => {} }) => {
+  const { styles, cx } = useStyles();
+  const searchParams = useSearchParams();
 
-    const activeKey = searchParams.get('provider');
+  const activeKey = searchParams.get('provider');
 
-    const isCustom = source === AiProviderSourceEnum.Custom;
-    return (
-      <div
-        className={cx(styles.container, activeKey === id && styles.active)}
-        onClick={() => {
-          onClick(id);
-        }}
-      >
-        <Flexbox gap={8} horizontal>
-          {isCustom && logo ? (
-            <Avatar
-              alt={name || id}
-              avatar={logo}
-              shape={'square'}
-              size={24}
-              style={{ borderRadius: 6 }}
-            />
-          ) : (
-            <ProviderIcon provider={id} size={24} style={{ borderRadius: 6 }} type={'avatar'} />
-          )}
-          {name}
-        </Flexbox>
-        <Flexbox horizontal>
-          {enabled && (
-            <Center width={24}>
-              <Badge status="success" />
-            </Center>
-          )}
-          {/* cloud slot */}
+  const isCustom = source === AiProviderSourceEnum.Custom;
+  return (
+    <div
+      className={cx(styles.container, activeKey === id && styles.active)}
+      onClick={() => {
+        onClick(id);
+      }}
+    >
+      <Flexbox gap={8} horizontal>
+        {isCustom && logo ? (
+          <Avatar
+            alt={name || id}
+            avatar={logo}
+            shape={'square'}
+            size={24}
+            style={{ borderRadius: 6 }}
+          />
+        ) : (
+          <ProviderIcon provider={id} size={24} style={{ borderRadius: 6 }} type={'avatar'} />
+        )}
+        {name}
+      </Flexbox>
+      <Flexbox horizontal>
+        {enabled && (
+          <Center width={24}>
+            <Badge status="success" />
+          </Center>
+        )}
+        {/* cloud slot */}
 
-          {/* cloud slot */}
-        </Flexbox>
-      </div>
-    );
-  },
-);
+        {/* cloud slot */}
+      </Flexbox>
+    </div>
+  );
+});
 export default ProviderItem;


### PR DESCRIPTION
This PR resolves a non-blocking lint warning reported by CI in Test Database:

- File: src/app/[variants]/(main)/settings/provider/ProviderMenu/Item.tsx
- Warning: `'id' is defined but never used. Allowed unused args must match /^_/u`

Change
- Mark the callback parameter as intentionally unused by prefixing with underscore: `_id`

Verification
- bun run type-check → OK

This keeps main warning-free post-sync and requires no behavior change.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Minor internal typing cleanup for a settings menu item click handler to align naming conventions and improve code clarity. No changes to behavior, visuals, or performance.
* **Chores**
  * Small formatting adjustments for consistency across the codebase.  
  * No user-facing impact; the application continues to function as before without any new features or fixes required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->