### PR TITLE
🐛 fix(research-modes): translate VN→EN, LLM PICO, gate 0-paper, inject papers into article gen (Phase 1.5+1.6)

### DIFF
--- a/src/features/Portal/DeepResearch/Body.tsx
+++ b/src/features/Portal/DeepResearch/Body.tsx
@@ -33,7 +33,7 @@ import { Flexbox } from 'react-layout-kit';
 
 import { useChatStore } from '@/store/chat';
 
-import { buildSearchQuery } from './buildSearchQuery';
+import { buildSearchQuery } from '@/utils/research/buildSearchQuery';
 
 const { TextArea } = Input;
 

--- a/src/features/Portal/DeepResearch/Body.tsx
+++ b/src/features/Portal/DeepResearch/Body.tsx
@@ -1080,6 +1080,25 @@ Provide a thorough analysis from your perspective. Use markdown formatting with 
       })
       .join('\n');
 
+    // Bug C fix — inject the actual retrieved papers into the prompt so the
+    // model has a concrete source-of-truth for [Author, Year] citations.
+    // Without this block the model invents citations to satisfy the
+    // "include inline citations" instruction.
+    const papersContext = pubmedPapers
+      .slice(0, 6)
+      .map((p, i) => {
+        const abstract = (p.abstract || '').slice(0, 300);
+        const pmid = p.pmid ? ` PMID:${p.pmid}` : '';
+        return `[${i + 1}] ${p.authors} (${p.year}). ${p.title}.${pmid}${abstract ? `\n     Abstract: ${abstract}${p.abstract && p.abstract.length > 300 ? '...' : ''}` : ''}`;
+      })
+      .join('\n\n');
+
+    const hasLiterature = pubmedPapers.length > 0;
+    const limitedLitWarning =
+      pubmedPapers.length > 0 && pubmedPapers.length < 3
+        ? `\n\nIMPORTANT: Only ${pubmedPapers.length} paper(s) were retrieved. The literature base is very limited. Acknowledge this in the Discussion section as a limitation. Do NOT extrapolate beyond what these papers support. Do NOT fabricate additional citations to fill gaps.`
+        : '';
+
     const prompt = `You are an expert medical academic writer. Write a comprehensive literature review article based on the following outline and research findings.
 
 Clinical Question: "${question}"
@@ -1087,19 +1106,34 @@ Clinical Question: "${question}"
 Outline:
 ${outlineStr}
 
+${
+  hasLiterature
+    ? `=== RETRIEVED LITERATURE (cite ONLY these papers — use [Author, Year] inline format) ===
+${papersContext}
+=== END LITERATURE ===
+`
+    : `=== NO LITERATURE RETRIEVED ===
+No papers were found for this question. You MUST NOT cite any specific studies, authors, journals, PMIDs, or DOIs. Use only general clinical knowledge and label it as such ("general clinical practice suggests", "standard textbook teaching"). Inventing citations is strictly prohibited.
+`
+}
 Research Findings from Multiple Perspectives:
 ${agentFindings.slice(0, 15_000)}
 
 Instructions:
 1. Follow the outline structure exactly, using markdown headers (##, ###)
 2. Synthesize findings from all perspectives, don't just copy them
-3. Include inline citations in [Author, Year] format
+3. ${
+      hasLiterature
+        ? 'Include inline citations in [Author, Year] format using ONLY the papers listed in RETRIEVED LITERATURE above. Each citation must match a real paper — do NOT invent author names or years. Include PMID when available.'
+        : 'Do NOT include any author/year/PMID/DOI citations. Use generic phrasing ("evidence suggests", "clinical guidelines indicate").'
+    }
 4. Add a "Summary of Findings" table at the end
 5. Include GRADE quality assessment for major outcomes
 6. Use professional academic medical writing style
 7. Total length: 2000-4000 words
 8. End with "Key Takeaways" bullet points
 9. Write the entire article in ${outputLang === 'vi' ? 'Vietnamese (Tiếng Việt)' : 'English'}
+${limitedLitWarning}
 
 Write the full article now in markdown format.`;
 
@@ -1133,6 +1167,46 @@ Write the full article now in markdown format.`;
         setArticle(finalArticle);
         setPhase('done'); // Only switch to done AFTER successful generation
         setProgressLines((prev) => [...prev, `✅ Bài tổng quan hoàn thành! (${wordCount} từ)`]);
+
+        // Bug C — sanity-check citations against the actual retrieved papers.
+        // Cheap heuristic: compare first-name/lastname tokens. False positives
+        // are fine; we only escalate when most citations look fabricated.
+        if (hasLiterature) {
+          const citationRegex = /\[([^\]]+),\s*(\d{4})]/g;
+          const matches = [...result.matchAll(citationRegex)];
+          const validAuthors = new Set(
+            pubmedPapers
+              .flatMap((p) =>
+                p.authors
+                  .split(/[,;]/)
+                  .map((a) => a.trim().toLowerCase().split(/\s+/)[0])
+              )
+              .filter(Boolean),
+          );
+
+          let invalidCount = 0;
+          for (const m of matches) {
+            const citedAuthor = m[1].trim().toLowerCase().split(/[\s,]+/)[0];
+            if (citedAuthor && !validAuthors.has(citedAuthor)) {
+              invalidCount++;
+            }
+          }
+
+          (window as any).posthog?.capture('article_citation_validation', {
+            invalid_count: invalidCount,
+            paper_count: pubmedPapers.length,
+            surface: 'deep_research',
+            total_citations: matches.length,
+            validation_passed: invalidCount === 0,
+          });
+
+          if (matches.length > 0 && invalidCount / matches.length > 0.5) {
+            setProgressLines((prev) => [
+              ...prev,
+              `⚠️ Phát hiện ${invalidCount}/${matches.length} citation có thể không khớp papers — vui lòng kiểm tra lại.`,
+            ]);
+          }
+        }
 
         (window as any).posthog?.capture('article_generation_complete', {
           generation_time_seconds: Math.round((Date.now() - articleStartTime) / 1000),

--- a/src/features/Portal/Research/Body/Discovery/index.tsx
+++ b/src/features/Portal/Research/Body/Discovery/index.tsx
@@ -3,7 +3,7 @@
 import { Button, Input, Tag } from '@lobehub/ui';
 import { InputNumber, Select, Slider, Spin } from 'antd';
 import { createStyles } from 'antd-style';
-import { ArrowRight, ExternalLink, Search, SlidersHorizontal } from 'lucide-react';
+import { ArrowRight, ExternalLink, Pencil, RefreshCw, Search, SlidersHorizontal } from 'lucide-react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
@@ -144,6 +144,8 @@ const DiscoveryPhase = memo(() => {
     const totalResults = useResearchStore((s) => s.totalResults);
     const isSearching = useResearchStore((s) => s.isSearching);
     const searchError = useResearchStore((s) => s.searchError);
+    const noPapersFound = useResearchStore((s) => s.noPapersFound);
+    const translatedQuery = useResearchStore((s) => s.translatedQuery);
 
     const setSearchQuery = useResearchStore((s) => s.setSearchQuery);
     const toggleSource = useResearchStore((s) => s.toggleSource);
@@ -153,6 +155,11 @@ const DiscoveryPhase = memo(() => {
     const loadMoreResults = useResearchStore((s) => s.loadMoreResults);
     const hasMore = useResearchStore((s) => s.hasMore);
     const isLoadingMore = useResearchStore((s) => s.isLoadingMore);
+
+    const focusSearchInput = useCallback(() => {
+        const input = document.querySelector<HTMLInputElement>('input[placeholder*="câu hỏi"]');
+        input?.focus();
+    }, []);
 
     const [expandedAbstracts, setExpandedAbstracts] = useState<Set<string>>(new Set());
 
@@ -367,13 +374,73 @@ const DiscoveryPhase = memo(() => {
                 </Flexbox>
             )}
 
+            {/* No-papers gate (Phase 1.5) — surfaced when search succeeded with 0 results */}
+            {noPapersFound && !isSearching && (
+                <Flexbox
+                    gap={8}
+                    style={{
+                        background: 'rgba(234,179,8,0.08)',
+                        border: '1px solid rgba(234,179,8,0.4)',
+                        borderRadius: 8,
+                        marginTop: 4,
+                        padding: 12,
+                    }}
+                >
+                    <Flexbox align={'center'} gap={8} horizontal>
+                        <span style={{ fontSize: 18 }}>⚠️</span>
+                        <span style={{ fontSize: 14, fontWeight: 600 }}>
+                            Không tìm thấy bài báo phù hợp
+                        </span>
+                    </Flexbox>
+                    <span style={{ color: '#888', fontSize: 12, lineHeight: 1.55 }}>
+                        Cả {selectedSources.join(', ')} đều không trả về bài báo cho truy vấn này.
+                        {translatedQuery && (
+                            <>
+                                {' '}Đã dịch sang tiếng Anh: <code>{translatedQuery}</code>.
+                            </>
+                        )}
+                        {' '}Việc viết bài tổng quan không có y văn sẽ không có trích dẫn xác thực và{' '}
+                        <strong>không khuyến nghị cho mục đích lâm sàng</strong>.
+                    </span>
+                    <Flexbox gap={6} horizontal style={{ flexWrap: 'wrap' }}>
+                        <Button
+                            icon={<Pencil size={12} />}
+                            onClick={focusSearchInput}
+                            size={'small'}
+                            type={'primary'}
+                        >
+                            Tinh chỉnh câu hỏi
+                        </Button>
+                        <Button
+                            icon={<RefreshCw size={12} />}
+                            onClick={() => searchQuery && searchPapers(searchQuery)}
+                            size={'small'}
+                        >
+                            Thử lại
+                        </Button>
+                        <Button
+                            icon={<SlidersHorizontal size={12} />}
+                            onClick={() => setShowFilters(true)}
+                            size={'small'}
+                        >
+                            Đổi nguồn
+                        </Button>
+                    </Flexbox>
+                </Flexbox>
+            )}
+
             {/* Search Results */}
             {papers.length > 0 && !isSearching && (
                 <Flexbox gap={8}>
-                    <Flexbox align={'center'} horizontal justify={'space-between'}>
+                    <Flexbox align={'center'} horizontal justify={'space-between'} wrap={'wrap'}>
                         <span className={styles.sectionTitle}>
                             📄 Kết quả tìm kiếm ({filteredPapers.length}
                             {filteredPapers.length !== totalResults ? ` / ${totalResults}` : ''} papers)
+                            {translatedQuery && (
+                                <span style={{ color: '#888', fontSize: 11, fontWeight: 400, marginLeft: 8 }}>
+                                    🌐 Tìm bằng: <code>{translatedQuery}</code>
+                                </span>
+                            )}
                         </span>
                         {filteredPapers.length !== totalResults && (
                             <span style={{ fontSize: 11, opacity: 0.6 }}>Đang lọc — {totalResults - filteredPapers.length} ẩn</span>
@@ -469,8 +536,8 @@ const DiscoveryPhase = memo(() => {
                 </Flexbox>
             )}
 
-            {/* Empty state */}
-            {papers.length === 0 && !isSearching && !searchError && (
+            {/* Empty state — only when user has not searched yet (noPapersFound has its own gate above) */}
+            {papers.length === 0 && !isSearching && !searchError && !noPapersFound && (
                 <>
                     <div className={styles.emptyState}>
                         <span style={{ fontSize: 48 }}>🔬</span>

--- a/src/features/Portal/Research/Body/Writing/index.tsx
+++ b/src/features/Portal/Research/Body/Writing/index.tsx
@@ -40,7 +40,10 @@ const aiWriteSection = async (
         '',
         picoText,
         existingContent ? `\nExisting draft (improve this):\n${existingContent}` : '',
-        context.refs ? `\nKey references:\n${context.refs}` : '',
+        context.refs
+            ? `\n=== KEY REFERENCES (cite ONLY these — use [Author, Year] format) ===\n${context.refs}\n=== END REFERENCES ===`
+            : `\n=== NO REFERENCES AVAILABLE ===\nDo NOT cite any specific studies, authors, or PMIDs. Use generic phrasing only.`,
+        '\nIMPORTANT: When citing, use ONLY papers from the references above. Format: [Author, Year]. Do NOT invent citations.',
         '\nRespond in English. Academic register. Use markdown formatting.',
     ].join('\n');
 
@@ -230,9 +233,13 @@ const WritingPhase = memo(() => {
     const handleAIWrite = useCallback(async (sectionKey: string, sectionLabel: string, existingContent: string) => {
         setAiGenerating((prev) => ({ ...prev, [sectionKey]: true }));
         setExpandedSection(sectionKey); // open the section
-        const refsText = includedPapers.slice(0, 8).map((p) =>
-            `- ${p.authors} (${p.year}). ${p.title}`,
-        ).join('\n');
+        const refsText = includedPapers.slice(0, 8).map((p, i) => {
+            const abstract = (p.abstract || '').slice(0, 250);
+            const id = p.id?.startsWith('pubmed-')
+                ? ` PMID:${p.id.replace('pubmed-', '')}`
+                : (p.doi ? ` DOI:${p.doi}` : '');
+            return `[${i + 1}] ${p.authors} (${p.year}). ${p.title}.${id}${abstract ? `\n    Abstract: ${abstract}${p.abstract && p.abstract.length > 250 ? '...' : ''}` : ''}`;
+        }).join('\n\n');
         try {
             const result = await aiWriteSection(sectionKey, sectionLabel, existingContent, {
                 pico, query: searchQuery, refs: refsText,

--- a/src/store/research/index.ts
+++ b/src/store/research/index.ts
@@ -7,6 +7,9 @@
 import { create } from 'zustand';
 import { devtools, persist } from 'zustand/middleware';
 
+import { buildSearchQuery, type DetectedLanguage } from '@/utils/research/buildSearchQuery';
+import { extractPICO as llmExtractPICO } from '@/utils/research/extractPICO';
+
 // ========== Types ==========
 
 export interface PaperResult {
@@ -32,6 +35,28 @@ export interface PICOQuery {
     outcome: string;
     population: string;
 }
+
+// ========== AI helper (translate + PICO) ==========
+//
+// Hardcoded to a small/cheap deterministic model — translate quality must be
+// stable across users (free tier, paid tier, custom keys).
+const TRANSLATE_MODEL = 'gpt-4o-mini';
+
+const callAI = async (model: string, prompt: string): Promise<string> => {
+    const res = await fetch('/api/chat/direct', {
+        body: JSON.stringify({
+            messages: [{ content: prompt, role: 'user' }],
+            model,
+            stream: false,
+            temperature: 0.3,
+        }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+    });
+    if (!res.ok) throw new Error(`AI call failed: ${res.status}`);
+    const data = await res.json();
+    return data?.choices?.[0]?.message?.content ?? data?.content ?? '';
+};
 
 export type ResearchPhase = 'discovery' | 'screening' | 'analysis' | 'writing' | 'publishing';
 
@@ -64,8 +89,10 @@ interface ResearchState {
     autoScreenByYearRange: (yearFrom: number, yearTo: number) => void;
     // Pagination (MED-33)
     currentPage: number;
+    // Translation context (Phase 1.5)
+    detectedLanguage: DetectedLanguage | null;
     excludeAllPapers: () => void;
-    extractPICO: (query: string) => void;
+    extractPICO: (query: string) => Promise<void>;
 
     getExcludedPapers: () => PaperResult[];
     // Getters
@@ -79,6 +106,8 @@ interface ResearchState {
 
     isSearching: boolean;
     loadMoreResults: () => Promise<void>;
+    // Gate state (Phase 1.5): true when last search returned 0 papers from all sources.
+    noPapersFound: boolean;
     papers: PaperResult[];
     pico: PICOQuery | null;
     removePapers: (ids: string[]) => void;
@@ -101,6 +130,8 @@ interface ResearchState {
     setSearchQuery: (query: string) => void;
     toggleSource: (source: SearchSource) => void;
     totalResults: number;
+    // English search query actually sent to PubMed/OpenAlex/etc when input was VN.
+    translatedQuery: string | null;
 
     updateScreeningCriteria: (criteria: Partial<ScreeningCriteria>) => void;
 }
@@ -117,17 +148,22 @@ const defaultCriteria: ScreeningCriteria = {
 const initialState = {
     activePhase: 'discovery' as ResearchPhase,
     currentPage: 1,
+    detectedLanguage: null as DetectedLanguage | null,
     hasMore: true,
     isLoadingMore: false,
     isSearching: false,
+    noPapersFound: false,
     papers: [] as PaperResult[],
     pico: null as PICOQuery | null,
     screeningCriteria: defaultCriteria,
     screeningDecisions: {} as Record<string, ScreeningEntry>,
     searchError: null as string | null,
     searchQuery: '',
-    selectedSources: ['PubMed', 'OpenAlex', 'ArXiv', 'ClinicalTrials.gov'] as SearchSource[],
+    // ArXiv default OFF — heavy CS bias polluted clinical results for our primary
+    // user (BS Đỗ Tiến Sơn, endocrinology). Users can re-enable per search.
+    selectedSources: ['PubMed', 'OpenAlex', 'ClinicalTrials.gov'] as SearchSource[],
     totalResults: 0,
+    translatedQuery: null as string | null,
 };
 
 // ========== API Services ==========
@@ -260,49 +296,6 @@ const searchClinicalTrials = async (query: string, maxResults = 10, offset = 0):
     }
 };
 
-// ========== PICO extraction (keyword-based) ==========
-
-const extractPICOFromQuery = (query: string): PICOQuery => {
-    const lower = query.toLowerCase();
-    const words = query.split(/\s+/);
-
-    let population = '';
-    let intervention = '';
-    let comparison = '';
-    let outcome = '';
-
-    const interventionKeywords = ['metformin', 'aspirin', 'statin', 'insulin', 'therapy', 'treatment', 'drug', 'vaccine', 'surgery'];
-    const outcomeKeywords = ['prevention', 'mortality', 'survival', 'risk', 'efficacy', 'outcome', 'effect', 'incidence', 'reduction'];
-    const comparisonKeywords = ['placebo', 'control', 'versus', 'vs', 'compared', 'alternative'];
-
-    for (const word of words) {
-        const w = word.toLowerCase().replaceAll(/[,.:;]/g, '');
-        if (interventionKeywords.some((k) => w.includes(k))) {
-            intervention = intervention ? `${intervention}, ${word}` : word;
-        }
-        if (outcomeKeywords.some((k) => w.includes(k))) {
-            outcome = outcome ? `${outcome}, ${word}` : word;
-        }
-        if (comparisonKeywords.some((k) => w.includes(k))) {
-            comparison = comparison ? `${comparison}, ${word}` : word;
-        }
-    }
-
-    population = query
-        .replaceAll(new RegExp(intervention.replaceAll(/[$()*+.?[\\\]^{|}]/g, '\\$&'), 'gi'), '')
-        .replaceAll(new RegExp(outcome.replaceAll(/[$()*+.?[\\\]^{|}]/g, '\\$&'), 'gi'), '')
-        .replaceAll(new RegExp(comparison.replaceAll(/[$()*+.?[\\\]^{|}]/g, '\\$&'), 'gi'), '')
-        .replaceAll(/\s+/g, ' ')
-        .trim() || query;
-
-    return {
-        comparison: comparison || 'Placebo / Standard care',
-        intervention: intervention || lower,
-        outcome: outcome || 'Clinical outcomes',
-        population: population || 'Study population',
-    };
-};
-
 // ========== Store ==========
 
 export const useResearchStore = create<ResearchState>()(
@@ -373,9 +366,13 @@ export const useResearchStore = create<ResearchState>()(
                     set({ screeningDecisions: decisions }, false, 'excludeAllPapers');
                 },
 
-                extractPICO: (query) => {
-                    const pico = extractPICOFromQuery(query);
-                    set({ pico }, false, 'extractPICO');
+                extractPICO: async (query) => {
+                    const { translatedQuery } = get();
+                    // Prefer the English translated query when available — keyword
+                    // matching against MeSH-style terminology is far more reliable.
+                    const queryForExtraction = translatedQuery || query;
+                    const result = await llmExtractPICO(queryForExtraction, callAI, TRANSLATE_MODEL);
+                    set({ pico: result.pico }, false, 'extractPICO');
                 },
 
                 getExcludedPapers: () => {
@@ -415,19 +412,23 @@ export const useResearchStore = create<ResearchState>()(
                 },
 
                 loadMoreResults: async () => {
-                    const { currentPage, isLoadingMore, searchQuery, selectedSources, papers } = get();
+                    const { currentPage, isLoadingMore, searchQuery, selectedSources, papers, translatedQuery } = get();
                     if (isLoadingMore || !searchQuery) return;
 
+                    // Reuse the same English query as the initial search so
+                    // pagination doesn't suddenly switch to raw VN and return
+                    // unrelated results.
+                    const queryToUse = translatedQuery || searchQuery;
                     const nextPage = currentPage + 1;
                     const offset = currentPage * 10;
                     set({ isLoadingMore: true }, false, 'loadMoreResults/start');
 
                     try {
                         const promises: Promise<PaperResult[]>[] = [];
-                        if (selectedSources.includes('PubMed')) promises.push(searchPubMed(searchQuery, 10, offset));
-                        if (selectedSources.includes('OpenAlex')) promises.push(searchOpenAlex(searchQuery, 10, offset));
-                        if (selectedSources.includes('ArXiv')) promises.push(searchArXiv(searchQuery, 10, offset));
-                        if (selectedSources.includes('ClinicalTrials.gov')) promises.push(searchClinicalTrials(searchQuery, 10, offset));
+                        if (selectedSources.includes('PubMed')) promises.push(searchPubMed(queryToUse, 10, offset));
+                        if (selectedSources.includes('OpenAlex')) promises.push(searchOpenAlex(queryToUse, 10, offset));
+                        if (selectedSources.includes('ArXiv')) promises.push(searchArXiv(queryToUse, 10, offset));
+                        if (selectedSources.includes('ClinicalTrials.gov')) promises.push(searchClinicalTrials(queryToUse, 10, offset));
 
                         const results = await Promise.allSettled(promises);
                         const newPapers: PaperResult[] = [];
@@ -496,28 +497,65 @@ export const useResearchStore = create<ResearchState>()(
 
                 searchPapers: async (query) => {
                     const { selectedSources } = get();
-                    set({ currentPage: 1, hasMore: true, isSearching: true, searchError: null, searchQuery: query }, false, 'searchPapers/start');
+                    set({
+                        currentPage: 1,
+                        detectedLanguage: null,
+                        hasMore: true,
+                        isSearching: true,
+                        noPapersFound: false,
+                        searchError: null,
+                        searchQuery: query,
+                        translatedQuery: null,
+                    }, false, 'searchPapers/start');
 
                     try {
-                        const promises: Promise<PaperResult[]>[] = [];
-                        if (selectedSources.includes('PubMed')) promises.push(searchPubMed(query));
-                        if (selectedSources.includes('OpenAlex')) promises.push(searchOpenAlex(query));
-                        if (selectedSources.includes('ArXiv')) promises.push(searchArXiv(query));
-                        if (selectedSources.includes('ClinicalTrials.gov')) promises.push(searchClinicalTrials(query));
+                        // Step 1 — translate VN → EN (Bug A). EN/other passes through unchanged.
+                        const queryInfo = await buildSearchQuery(query, callAI, TRANSLATE_MODEL);
+                        const finalQuery = queryInfo.searchQuery;
 
-                        const results = await Promise.allSettled(promises);
+                        set({
+                            detectedLanguage: queryInfo.detectedLanguage,
+                            translatedQuery: queryInfo.translated ? queryInfo.searchQuery : null,
+                        }, false, 'searchPapers/translated');
+
+                        (window as any).posthog?.capture('research_query_translated', {
+                            detected_language: queryInfo.detectedLanguage,
+                            duration_ms: queryInfo.durationMs,
+                            fell_back_to_original: queryInfo.fellBackToOriginal,
+                            original_query: queryInfo.originalQuery.slice(0, 200),
+                            surface: 'research_mode',
+                            translated: queryInfo.translated,
+                            translated_query: queryInfo.searchQuery.slice(0, 200),
+                        });
+
+                        // Step 2 — fan out to selected sources using the (possibly translated) query.
+                        const sourceOrder: SearchSource[] = ['PubMed', 'OpenAlex', 'ArXiv', 'ClinicalTrials.gov'];
+                        const fetchers: Record<SearchSource, (_q: string) => Promise<PaperResult[]>> = {
+                            ArXiv: (q) => searchArXiv(q),
+                            'ClinicalTrials.gov': (q) => searchClinicalTrials(q),
+                            OpenAlex: (q) => searchOpenAlex(q),
+                            PubMed: (q) => searchPubMed(q),
+                        };
+                        const usedSources = sourceOrder.filter((s) => selectedSources.includes(s));
+                        const results = await Promise.allSettled(usedSources.map((s) => fetchers[s](finalQuery)));
+
                         const allPapers: PaperResult[] = [];
-                        const seenDois = new Set<string>();
+                        const seenKeys = new Set<string>();
+                        const sourceTracker: Record<string, number> = {};
 
-                        for (const result of results) {
-                            if (result.status === 'fulfilled') {
+                        for (const [idx, source] of usedSources.entries()) {
+                            const result = results[idx];
+                            if (result?.status === 'fulfilled') {
+                                sourceTracker[source] = result.value.length;
                                 for (const paper of result.value) {
                                     const key = paper.doi || paper.title;
-                                    if (!seenDois.has(key)) {
-                                        seenDois.add(key);
+                                    if (!seenKeys.has(key)) {
+                                        seenKeys.add(key);
                                         allPapers.push(paper);
                                     }
                                 }
+                            } else {
+                                sourceTracker[source] = 0;
                             }
                         }
 
@@ -526,17 +564,47 @@ export const useResearchStore = create<ResearchState>()(
                             return b.year - a.year;
                         });
 
-                        // If any source returned 10 results (max per page), there may be more
                         const hasMore = allPapers.length >= 10;
+
+                        (window as any).posthog?.capture('research_papers_found', {
+                            detected_language: queryInfo.detectedLanguage,
+                            original_question: queryInfo.originalQuery.slice(0, 200),
+                            paper_count: allPapers.length,
+                            papers_per_source: sourceTracker,
+                            sources: Array.from(selectedSources),
+                            surface: 'research_mode',
+                            translated_query: queryInfo.searchQuery.slice(0, 200),
+                        });
+
+                        if (allPapers.length === 0) {
+                            set({
+                                hasMore: false,
+                                isSearching: false,
+                                noPapersFound: true,
+                                papers: [],
+                                screeningDecisions: {},
+                                totalResults: 0,
+                            }, false, 'searchPapers/noPapers');
+
+                            (window as any).posthog?.capture('research_no_papers', {
+                                original_question: queryInfo.originalQuery.slice(0, 200),
+                                sources: Array.from(selectedSources),
+                                surface: 'research_mode',
+                                translated_query: queryInfo.searchQuery.slice(0, 200),
+                            });
+                            return;
+                        }
 
                         set({
                             hasMore,
                             isSearching: false,
+                            noPapersFound: false,
                             papers: allPapers,
                             screeningDecisions: {},
                             totalResults: allPapers.length,
                         }, false, 'searchPapers/done');
-                    } catch {
+                    } catch (e) {
+                        console.error('[searchPapers] error', e);
                         set({ isSearching: false, searchError: 'Search failed. Please try again.' }, false, 'searchPapers/error');
                     }
                 },

--- a/src/utils/research/__tests__/buildSearchQuery.test.ts
+++ b/src/utils/research/__tests__/buildSearchQuery.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildSearchQuery, detectLanguage } from '../buildSearchQuery';
+
+describe('detectLanguage', () => {
+    it('returns "en" for plain ASCII English', () => {
+        expect(detectLanguage('hello world')).toBe('en');
+    });
+
+    it('returns "vi" for Vietnamese with diacritics', () => {
+        expect(detectLanguage('xin chào bác sĩ')).toBe('vi');
+    });
+
+    it('returns "other" for non-ASCII non-Vietnamese (e.g. Chinese)', () => {
+        expect(detectLanguage('北京大学')).toBe('other');
+    });
+
+    it('returns "vi" for mixed EN/VN when any Vietnamese diacritic appears', () => {
+        expect(detectLanguage('GLP-1 và semaglutide')).toBe('vi');
+    });
+
+    it('returns "en" for empty string (no non-ASCII)', () => {
+        expect(detectLanguage('')).toBe('en');
+    });
+});
+
+describe('buildSearchQuery', () => {
+    const model = 'test-model';
+
+    it('returns the original query unchanged for English input (no callAI call)', async () => {
+        const callAI = vi.fn().mockResolvedValue('SHOULD_NOT_BE_USED');
+        const result = await buildSearchQuery('metformin diabetes prevention', callAI, model);
+
+        expect(result.translated).toBe(false);
+        expect(result.searchQuery).toBe('metformin diabetes prevention');
+        expect(result.detectedLanguage).toBe('en');
+        expect(result.fellBackToOriginal).toBe(false);
+        expect(callAI).not.toHaveBeenCalled();
+    });
+
+    it('translates Vietnamese input via callAI', async () => {
+        const callAI = vi
+            .fn()
+            .mockResolvedValue('liraglutide cardiovascular outcomes type 2 diabetes');
+        const result = await buildSearchQuery(
+            'liraglutide kết cục tim mạch ở bệnh nhân đái tháo đường tuýp 2',
+            callAI,
+            model,
+        );
+
+        expect(result.translated).toBe(true);
+        expect(result.detectedLanguage).toBe('vi');
+        expect(result.searchQuery).toBe('liraglutide cardiovascular outcomes type 2 diabetes');
+        expect(result.fellBackToOriginal).toBe(false);
+        expect(callAI).toHaveBeenCalledTimes(1);
+    });
+
+    it('strips quotes, "Query:" prefix, and collapses whitespace from LLM output', async () => {
+        const callAI = vi
+            .fn()
+            .mockResolvedValue('  Query: "tirzepatide   weight loss obesity"  ');
+        const result = await buildSearchQuery(
+            'tirzepatide giảm cân ở bệnh nhân béo phì câu test sạch hóa',
+            callAI,
+            model,
+        );
+
+        expect(result.searchQuery).toBe('tirzepatide weight loss obesity');
+        expect(result.translated).toBe(true);
+    });
+
+    it('falls back to the original Vietnamese query when callAI throws', async () => {
+        const callAI = vi.fn().mockRejectedValue(new Error('boom'));
+        const original = 'sàng lọc ung thư đại tràng nội soi (test fallback throw)';
+        const result = await buildSearchQuery(original, callAI, model);
+
+        expect(result.translated).toBe(false);
+        expect(result.fellBackToOriginal).toBe(true);
+        expect(result.searchQuery).toBe(original);
+        expect(result.detectedLanguage).toBe('vi');
+    });
+
+    it('falls back when LLM returns an empty / non-letter response', async () => {
+        const callAI = vi.fn().mockResolvedValue('   ');
+        const result = await buildSearchQuery(
+            'điều trị tăng huyết áp ở người cao tuổi (test empty)',
+            callAI,
+            model,
+        );
+
+        expect(result.translated).toBe(false);
+        expect(result.fellBackToOriginal).toBe(true);
+    });
+
+    it('returns input unchanged for empty string', async () => {
+        const callAI = vi.fn();
+        const result = await buildSearchQuery('', callAI, model);
+
+        expect(result.translated).toBe(false);
+        expect(result.searchQuery).toBe('');
+        expect(callAI).not.toHaveBeenCalled();
+    });
+});

--- a/src/utils/research/__tests__/extractPICO.test.ts
+++ b/src/utils/research/__tests__/extractPICO.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { extractPICO } from '../extractPICO';
+
+const VALID_PICO = JSON.stringify({
+    comparison: 'Placebo',
+    intervention: 'Liraglutide 3 mg subcutaneous',
+    outcome: 'Body weight reduction at 56 weeks',
+    population: 'Adults with obesity (BMI ≥ 30)',
+});
+
+describe('extractPICO', () => {
+    const model = 'test-model';
+
+    it('parses a clean JSON response into PICO fields', async () => {
+        const callAI = vi.fn().mockResolvedValue(VALID_PICO);
+        const result = await extractPICO('liraglutide 3 mg for obesity', callAI, model);
+
+        expect(result.fellBack).toBe(false);
+        expect(result.pico.population).toBe('Adults with obesity (BMI ≥ 30)');
+        expect(result.pico.intervention).toBe('Liraglutide 3 mg subcutaneous');
+        expect(result.pico.comparison).toBe('Placebo');
+        expect(result.pico.outcome).toBe('Body weight reduction at 56 weeks');
+    });
+
+    it('strips ```json ... ``` fences before parsing', async () => {
+        const callAI = vi.fn().mockResolvedValue('```json\n' + VALID_PICO + '\n```');
+        const result = await extractPICO('any query', callAI, model);
+
+        expect(result.fellBack).toBe(false);
+        expect(result.pico.population).toBe('Adults with obesity (BMI ≥ 30)');
+    });
+
+    it('strips bare ``` fences before parsing', async () => {
+        const callAI = vi.fn().mockResolvedValue('```\n' + VALID_PICO + '\n```');
+        const result = await extractPICO('any query', callAI, model);
+
+        expect(result.fellBack).toBe(false);
+        expect(result.pico.intervention).toBe('Liraglutide 3 mg subcutaneous');
+    });
+
+    it('falls back gracefully when JSON is malformed', async () => {
+        const callAI = vi.fn().mockResolvedValue('this is not json at all');
+        const result = await extractPICO('semaglutide for T2DM', callAI, model);
+
+        expect(result.fellBack).toBe(true);
+        expect(result.pico.population).toBe('Study population');
+        expect(result.pico.intervention).toBe('semaglutide for T2DM');
+        expect(result.pico.comparison).toBe('Placebo / Standard care');
+        expect(result.pico.outcome).toBe('Clinical outcomes');
+    });
+
+    it('falls back when JSON shape is missing required fields', async () => {
+        const callAI = vi.fn().mockResolvedValue('{"population": "kids", "intervention": "vaccine"}');
+        const result = await extractPICO('q', callAI, model);
+
+        expect(result.fellBack).toBe(true);
+    });
+
+    it('falls back when callAI throws', async () => {
+        const callAI = vi.fn().mockRejectedValue(new Error('network down'));
+        const result = await extractPICO('any query', callAI, model);
+
+        expect(result.fellBack).toBe(true);
+        expect(result.pico.population).toBe('Study population');
+    });
+
+    it('truncates over-long fields to the field cap', async () => {
+        const long = 'x'.repeat(500);
+        const overLong = JSON.stringify({
+            comparison: long,
+            intervention: long,
+            outcome: long,
+            population: long,
+        });
+        const callAI = vi.fn().mockResolvedValue(overLong);
+        const result = await extractPICO('q', callAI, model);
+
+        expect(result.fellBack).toBe(false);
+        expect(result.pico.population.length).toBeLessThanOrEqual(200);
+        expect(result.pico.intervention.length).toBeLessThanOrEqual(200);
+        expect(result.pico.comparison.length).toBeLessThanOrEqual(200);
+        expect(result.pico.outcome.length).toBeLessThanOrEqual(200);
+    });
+});

--- a/src/utils/research/buildSearchQuery.ts
+++ b/src/utils/research/buildSearchQuery.ts
@@ -46,7 +46,17 @@ Rules:
 - Use standard English medical terminology (MeSH-style when natural, e.g., "growth hormone", "central precocious puberty", "GLP-1 receptor agonists").
 - Preserve every clinically meaningful concept (population, intervention, comparison, outcome).
 - Drop filler words ("xin", "cho tôi", "viết", "tổng quan về", "đánh giá", "review", "search", "tìm kiếm").
-- Output ONLY the search query, no quotes, no explanation, no leading "Query:", maximum 25 words.
+- Output ONLY the search query on a single line, no quotes, no markdown, no code fence, no explanation, no leading "Query:", maximum 25 words.
+
+Examples:
+Input: "tổng quan tác động GLP1a lên khí sắc semaglutide"
+Output: GLP-1 receptor agonists semaglutide mood psychiatric effects
+
+Input: "vai trò của metformin trong tiền tiểu đường"
+Output: metformin prediabetes prevention
+
+Input: "tăng trưởng chiều cao trẻ SGA non tháng dùng GH"
+Output: growth hormone therapy small for gestational age preterm short stature
 
 Vietnamese question:
 ${question}
@@ -94,10 +104,17 @@ export const buildSearchQuery = async (
 
   try {
     const raw = await callAI(model, buildTranslatePrompt(trimmed), 'translate-search-query');
+    // NOTE: `String.prototype.replaceAll` throws TypeError when given a non-global
+    // RegExp. The anchored "Query:" prefix only matches once, so use `.replace`
+    // (single replacement) — using `replaceAll` here previously made every
+    // translation throw and silently fall back to the original VN query.
+    // Order matters: collapse whitespace + trim FIRST so the `^` anchors can
+    // actually match leading prefixes the model loves to add.
     const cleaned = raw
-      .replaceAll(/^["']|["']$/g, '')
-      .replaceAll(/^(query|search query|english query)\s*:\s*/i, '')
       .replaceAll(/\s+/g, ' ')
+      .trim()
+      .replace(/^(query|search query|english query)\s*:\s*/i, '')
+      .replaceAll(/^["']|["']$/g, '')
       .trim()
       .slice(0, 240);
 

--- a/src/utils/research/extractPICO.ts
+++ b/src/utils/research/extractPICO.ts
@@ -1,0 +1,90 @@
+/**
+ * LLM-based PICO extraction for clinical research questions.
+ *
+ * Replaces the previous keyword-regex approach (English-only, missed VN
+ * questions, and produced primitive splits like Population="find about
+ * SGA GH" / Intervention="therapy"). The LLM returns structured JSON in
+ * English regardless of the source language. On any parse / network /
+ * call failure, we fall back to a generic shape so the UI still renders.
+ */
+
+export interface PICOQuery {
+  comparison: string;
+  intervention: string;
+  outcome: string;
+  population: string;
+}
+
+export interface ExtractPICOResult {
+  durationMs: number;
+  fellBack: boolean;
+  pico: PICOQuery;
+}
+
+type CallAI = (model: string, prompt: string, label?: string) => Promise<string>;
+
+const PICO_PROMPT = (query: string) => `Extract PICO elements from this clinical research question.
+
+Question: "${query}"
+
+Return ONLY valid JSON in this exact shape (no markdown, no code fence, no explanation):
+{
+  "population": "<who is being studied — patient group, condition, age, etc>",
+  "intervention": "<the treatment or exposure being evaluated>",
+  "comparison": "<comparator group or alternative — use 'Placebo / Standard care' if not stated>",
+  "outcome": "<what is being measured — efficacy, mortality, side effects, etc — use 'Clinical outcomes' if not stated>"
+}
+
+Use English for all values, even if the question is in another language.
+If the question is too vague to extract a field, use a reasonable default ('Adult patients', 'Standard care', 'Clinical outcomes').
+Maximum 15 words per field.`;
+
+const FIELD_MAX_LEN = 200;
+
+const buildFallback = (query: string): PICOQuery => ({
+  comparison: 'Placebo / Standard care',
+  intervention: query.slice(0, FIELD_MAX_LEN) || 'Intervention under study',
+  outcome: 'Clinical outcomes',
+  population: 'Study population',
+});
+
+export const extractPICO = async (
+  query: string,
+  callAI: CallAI,
+  model: string,
+): Promise<ExtractPICOResult> => {
+  const startedAt = Date.now();
+  const fallback = buildFallback(query);
+
+  try {
+    const raw = await callAI(model, PICO_PROMPT(query), 'extract-pico');
+    const cleaned = raw
+      .replace(/^```(?:json)?\s*/i, '')
+      .replace(/```\s*$/i, '')
+      .trim();
+    const parsed = JSON.parse(cleaned);
+
+    if (
+      parsed &&
+      typeof parsed.population === 'string' &&
+      typeof parsed.intervention === 'string' &&
+      typeof parsed.comparison === 'string' &&
+      typeof parsed.outcome === 'string'
+    ) {
+      return {
+        durationMs: Date.now() - startedAt,
+        fellBack: false,
+        pico: {
+          comparison: parsed.comparison.slice(0, FIELD_MAX_LEN),
+          intervention: parsed.intervention.slice(0, FIELD_MAX_LEN),
+          outcome: parsed.outcome.slice(0, FIELD_MAX_LEN),
+          population: parsed.population.slice(0, FIELD_MAX_LEN),
+        },
+      };
+    }
+  } catch (e) {
+    console.warn('[extractPICO] failed, falling back', e);
+  }
+
+  return { durationMs: Date.now() - startedAt, fellBack: true, pico: fallback };
+};


### PR DESCRIPTION
## Why

BS Đỗ Tiến Sơn (heavy user, endocrinologist) reported via Zalo:
- *"Research mode hoàn toàn vô hiệu trong việc tìm tài liệu"*
- *"Deep research kia anh cho chủ đề thì KQ trả về 1 bài nhưng no citation"*

Test reproduction (Hien) confirmed 4 root causes — 3 fixed in this PR, 1 deferred to Phase 1.7:

| Bug | Symptom | Status |
|---|---|---|
| **A** | Research Mode raw VN query → CS noise from ArXiv (Seen2Scene 3D, EconLogicQA top results) | ✅ fixed |
| **B** | PICO regex extractor produces primitive splits like Population=`"find about SGA GH"` | ✅ fixed (LLM-based) |
| **C** | Deep Research article gen prompt doesn't see retrieved papers → can't cite or invents citations | ✅ fixed |
| **D** | UX/discoverability: side panel cramped, 2 confusing entry points, ArXiv default for clinical | ⏸ Phase 1.7 |

Bonus: while writing the new test suite I found **two latent Phase 1 bugs** in `buildSearchQuery`:
- `String.prototype.replaceAll` throws TypeError when given a non-global RegExp — every VN translation silently fell back to original
- The `^` anchor cleanup ran before whitespace collapse, so leading whitespace prevented `Query:` prefix stripping

These are now fixed too — meaning the Phase 1 translate path was actually never working in production. This PR is the first time VN translation will land working end-to-end.

## What

**Refactor (commit 1)** — `bd8e510607`
- Move `buildSearchQuery.ts` from `features/Portal/DeepResearch/` to shared `src/utils/research/`
- New `extractPICO.ts` (LLM-based) replaces 38-line regex function
- Few-shot examples + stricter output rules in translate prompt
- 18 unit tests (vitest) covering language detection, translation happy path, fallbacks, JSON-fence stripping, field truncation

**Research Mode wire-up (commit 2)** — `b76fec2ea8`
- `searchPapers()`: translates VN→EN first, fans out to selected sources with English query, gates on 0-paper, telemetry tagged `surface=research_mode`
- `extractPICO()`: now async + LLM-based, prefers translated query
- `loadMoreResults()`: reuses `translatedQuery` so pagination stays consistent
- New state: `noPapersFound`, `translatedQuery`, `detectedLanguage`
- Default `selectedSources`: ArXiv removed (CS bias); user can re-enable per search
- Discovery UI: yellow gate alert with 3 actions when 0 papers; `🌐 Tìm bằng: <translated>` badge in results header
- Writing prompt: refs carry PMID/DOI + abstract excerpt, wrapped in `=== KEY REFERENCES ===` block with hard `cite ONLY these / do NOT invent` guard

**Deep Research Bug C (commit 3)** — `b9e02b96e8`
- `handleGenerateArticle`: new `RETRIEVED LITERATURE` block with top 6 papers (author/year/title/PMID/abstract excerpt) injected into prompt
- Hard "use ONLY these papers" instruction; mirrored "no literature retrieved" branch forbids any citations
- Limited-literature warning (1-2 papers) asks model to flag in Discussion instead of extrapolating
- Post-gen citation validation: lastname-token heuristic against retrieved authors; emits `article_citation_validation` telemetry; surfaces a yellow warning in progress when >50% citations look fabricated

## Test plan

Manual test cases on Vercel Preview (after build):

- [ ] **Case 1 — Research Mode VN translate**: `tổng quan tác động GLP1a lên khí sắc semaglutide` → badge shows English query, ≥5 papers from PubMed/OpenAlex, top results on-topic for endocrinology/psychiatry, PICO fields are English
- [ ] **Case 2 — Research Mode EN regression**: `Efficacy of SGLT2 inhibitors vs GLP-1 agonists for HFpEF` → no badge (not translated), ≥8 papers, PICO mentions HFpEF
- [ ] **Case 3 — Gate UI**: `asdfgh xyz qwerty` → yellow alert with 3 buttons; PostHog `research_no_papers` event fires
- [ ] **Case 4 — Deep Research Bug C**: rerun the GLP1a query → article has ≥3 inline `[Author, Year]` citations matching real retrieved papers; PostHog `article_citation_validation` with `validation_passed=true`
- [ ] **Case 5 — Limited literature**: when only 1-2 papers retrieved → article has limited-literature warning in Discussion, no fabricated citations

Local verification done:
- `bunx tsc --noEmit` exit 0 (12 GB heap; project default `tsgo` panics with Go runtime OOM on this machine)
- `bunx eslint --no-fix` clean on all touched files
- `bunx vitest run src/utils/research/__tests__/` → 18/18 pass

## Out of scope (Phase 1.7+)

- Full-screen route for Research Mode (cramped side panel)
- Deprecate Deep Research / unify entry points
- MeSH-aware query expansion
- Embedding-based relevance ranking
- Specialty hint in translate prompt (use specialty from user profile)
- Caching layer for search APIs (NCBI rate limit)

## Telemetry to monitor post-merge

- `research_query_translated` — fires for both `surface=research_mode` and `surface=deep_research`
- `research_no_papers` — rate should drop after merge for VN doctor cohort
- `article_citation_validation` — `validation_passed=true` should be ≥80%

## Rollback

If post-deploy critical, promote the last good production deployment from before the Phase 1 + 1.5 series. Do not rebuild from `main` while the issue is being investigated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translate Vietnamese queries to English, replace the PICO extractor, add a 0-result gate, and inject retrieved papers into article generation so Research Mode returns relevant papers and Deep Research cites real literature.

- **Bug Fixes**
  - Research Mode: translate VN→EN before querying; reuse for pagination; show a translated-query badge; add a 0-result gate with quick actions; default `ArXiv` off to avoid CS noise.
  - Article generation: include top retrieved papers (with PMID/DOI + abstract snippet) in prompts; enforce “cite only these”; validate citations and warn if most look fabricated.
  - Fixed `buildSearchQuery` cleanup bugs (non‑global replaceAll, prefix stripping order) so translation works end‑to‑end.

- **Refactors**
  - Moved `buildSearchQuery` to `src/utils/research/` and replaced the regex PICO logic with a structured extractor that returns English PICO fields.
  - Store updates: new `translatedQuery`, `detectedLanguage`, `noPapersFound`; added 18 unit tests for translation and PICO paths.

<sup>Written for commit b9e02b96e86cfaa82aa448b465b465d5961ac8aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-language query translation support for non-English research searches.
  * Implemented citation validation and inline reference formatting `[Author, Year]` for generated content.
  * Enhanced "no papers found" state with dedicated feedback panel and retry options.

* **Improvements**
  * Upgraded PICO extraction to use AI-driven analysis instead of keyword-based detection.
  * Enhanced reference formatting in research writing with structured metadata and abstract snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->