### PR TITLE
🚑 hotfix(research-modes): wrong API endpoint, persist migration, output cleanup, gate race (Phase 1.5.1)

### DIFF
--- a/src/features/Portal/DeepResearch/Body.tsx
+++ b/src/features/Portal/DeepResearch/Body.tsx
@@ -32,7 +32,6 @@ import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
 import { useChatStore } from '@/store/chat';
-
 import { buildSearchQuery } from '@/utils/research/buildSearchQuery';
 
 const { TextArea } = Input;
@@ -943,15 +942,9 @@ Provide a thorough analysis from your perspective. Use markdown formatting with 
       setProgressLines((prev) => [...prev, '🌐 Đang chuẩn bị truy vấn tìm kiếm...']);
       const queryInfo = await buildSearchQuery(question, callAI, model);
       if (queryInfo.translated) {
-        setProgressLines((prev) => [
-          ...prev,
-          `🌐 Dịch sang tiếng Anh: "${queryInfo.searchQuery}"`,
-        ]);
+        setProgressLines((prev) => [...prev, `🌐 Dịch sang tiếng Anh: "${queryInfo.searchQuery}"`]);
       } else if (queryInfo.fellBackToOriginal) {
-        setProgressLines((prev) => [
-          ...prev,
-          '⚠️ Dịch truy vấn thất bại, dùng câu hỏi gốc.',
-        ]);
+        setProgressLines((prev) => [...prev, '⚠️ Dịch truy vấn thất bại, dùng câu hỏi gốc.']);
       }
       (window as any).posthog?.capture('research_query_translated', {
         detected_language: queryInfo.detectedLanguage,
@@ -1009,6 +1002,12 @@ Provide a thorough analysis from your perspective. Use markdown formatting with 
         setStartTime(null);
         return;
       }
+
+      // Defensive: clear gate flag in case a prior racing instance left it set.
+      // The useEffect that auto-triggers startResearch can fire twice across
+      // re-renders; an older raw-VN search may have set noPapersFound=true
+      // before the translated re-run finished and produced papers.
+      setNoPapersFound(false);
 
       const sourceSummary = [
         pubmedCount > 0 ? `PubMed: ${pubmedCount}` : '',
@@ -1177,16 +1176,17 @@ Write the full article now in markdown format.`;
           const validAuthors = new Set(
             pubmedPapers
               .flatMap((p) =>
-                p.authors
-                  .split(/[,;]/)
-                  .map((a) => a.trim().toLowerCase().split(/\s+/)[0])
+                p.authors.split(/[,;]/).map((a) => a.trim().toLowerCase().split(/\s+/)[0]),
               )
               .filter(Boolean),
           );
 
           let invalidCount = 0;
           for (const m of matches) {
-            const citedAuthor = m[1].trim().toLowerCase().split(/[\s,]+/)[0];
+            const citedAuthor = m[1]
+              .trim()
+              .toLowerCase()
+              .split(/[\s,]+/)[0];
             if (citedAuthor && !validAuthors.has(citedAuthor)) {
               invalidCount++;
             }
@@ -2169,11 +2169,7 @@ ER  - `;
                   />
                 </Flexbox>
               ))}
-              <Button
-                icon={<Search size={14} />}
-                onClick={() => startResearch()}
-                type="primary"
-              >
+              <Button icon={<Search size={14} />} onClick={() => startResearch()} type="primary">
                 Tiếp tục nghiên cứu →
               </Button>
             </>
@@ -2194,13 +2190,11 @@ ER  - `;
         >
           <Flexbox align={'center'} gap={8} horizontal>
             <span style={{ fontSize: 18 }}>⚠️</span>
-            <span style={{ fontSize: 14, fontWeight: 600 }}>
-              Không tìm thấy bài báo phù hợp
-            </span>
+            <span style={{ fontSize: 14, fontWeight: 600 }}>Không tìm thấy bài báo phù hợp</span>
           </Flexbox>
           <span style={{ color: '#888', fontSize: 12 }}>
-            Cả PubMed và Semantic Scholar đều không trả về bài báo cho truy vấn này. Việc viết
-            bài tổng quan không có y văn sẽ không có trích dẫn xác thực và{' '}
+            Cả PubMed và Semantic Scholar đều không trả về bài báo cho truy vấn này. Việc viết bài
+            tổng quan không có y văn sẽ không có trích dẫn xác thực và{' '}
             <strong>không khuyến nghị cho mục đích lâm sàng</strong>.
           </span>
           <Flexbox gap={6} horizontal style={{ flexWrap: 'wrap' }}>
@@ -2246,68 +2240,70 @@ ER  - `;
       {/* ────── PHASE: RESEARCH + AGENTS ────── */}
       {(phase === 'research' || phase === 'outline' || phase === 'article' || phase === 'done') &&
         !noPapersFound && (
-        <Flexbox gap={8}>
-          <Flexbox align={'center'} gap={8} horizontal justify={'space-between'}>
-            <Flexbox align={'center'} gap={8} horizontal>
-              <span style={{ fontWeight: 600 }}>{'🤖 AI Research Agents:'}</span>
+          <Flexbox gap={8}>
+            <Flexbox align={'center'} gap={8} horizontal justify={'space-between'}>
+              <Flexbox align={'center'} gap={8} horizontal>
+                <span style={{ fontWeight: 600 }}>{'🤖 AI Research Agents:'}</span>
+                {phase === 'research' && (
+                  <Tag color="processing" style={{ fontSize: 11 }}>
+                    ⏱️ {Math.floor(elapsed / 60)}:{String(elapsed % 60).padStart(2, '0')} —{' '}
+                    {agents.filter((a) => a.status === 'done').length}/{agents.length} xong
+                  </Tag>
+                )}
+              </Flexbox>
               {phase === 'research' && (
-                <Tag color="processing" style={{ fontSize: 11 }}>
-                  ⏱️ {Math.floor(elapsed / 60)}:{String(elapsed % 60).padStart(2, '0')} —{' '}
-                  {agents.filter((a) => a.status === 'done').length}/{agents.length} xong
-                </Tag>
+                <Button danger icon={<StopCircle size={14} />} onClick={handleStop} size="small">
+                  Dừng
+                </Button>
               )}
             </Flexbox>
-            {phase === 'research' && (
-              <Button danger icon={<StopCircle size={14} />} onClick={handleStop} size="small">
-                Dừng
-              </Button>
-            )}
+            <div style={{ display: 'grid', gap: 8, gridTemplateColumns: 'repeat(2, 1fr)' }}>
+              {agents.map((agent, idx) => (
+                <div
+                  className={cx(
+                    styles.agentCard,
+                    agent.status === 'running' && styles.agentRunning,
+                    agent.status === 'done' && styles.agentDone,
+                    agent.status === 'error' && styles.agentError,
+                  )}
+                  key={agent.name}
+                  onClick={() => setExpandedAgent(expandedAgent === idx ? null : idx)}
+                >
+                  <Flexbox align={'center'} gap={6} horizontal>
+                    <span>{AGENTS[idx].emoji}</span>
+                    <span style={{ fontSize: 12, fontWeight: 600 }}>{agent.name}</span>
+                    {agent.status === 'running' && <Loader2 className="animate-spin" size={12} />}
+                    {agent.status === 'done' && (
+                      <Tag color="success" style={{ fontSize: 10 }}>
+                        \u2713
+                      </Tag>
+                    )}
+                    {agent.status === 'error' && (
+                      <Tag color="error" style={{ fontSize: 10 }}>
+                        \u2717
+                      </Tag>
+                    )}
+                    {agent.status === 'done' && (
+                      <Tooltip
+                        title={
+                          expandedAgent === idx ? '\u1EA8n chi ti\u1EBFt' : 'Xem chi ti\u1EBFt'
+                        }
+                      >
+                        {expandedAgent === idx ? <EyeOff size={12} /> : <Eye size={12} />}
+                      </Tooltip>
+                    )}
+                  </Flexbox>
+                  <span style={{ color: '#888', fontSize: 11 }}>{AGENTS[idx].desc}</span>
+                  {expandedAgent === idx && agent.content && (
+                    <div className={styles.agentContent}>
+                      <Markdown>{agent.content.slice(0, 3000)}</Markdown>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
           </Flexbox>
-          <div style={{ display: 'grid', gap: 8, gridTemplateColumns: 'repeat(2, 1fr)' }}>
-            {agents.map((agent, idx) => (
-              <div
-                className={cx(
-                  styles.agentCard,
-                  agent.status === 'running' && styles.agentRunning,
-                  agent.status === 'done' && styles.agentDone,
-                  agent.status === 'error' && styles.agentError,
-                )}
-                key={agent.name}
-                onClick={() => setExpandedAgent(expandedAgent === idx ? null : idx)}
-              >
-                <Flexbox align={'center'} gap={6} horizontal>
-                  <span>{AGENTS[idx].emoji}</span>
-                  <span style={{ fontSize: 12, fontWeight: 600 }}>{agent.name}</span>
-                  {agent.status === 'running' && <Loader2 className="animate-spin" size={12} />}
-                  {agent.status === 'done' && (
-                    <Tag color="success" style={{ fontSize: 10 }}>
-                      \u2713
-                    </Tag>
-                  )}
-                  {agent.status === 'error' && (
-                    <Tag color="error" style={{ fontSize: 10 }}>
-                      \u2717
-                    </Tag>
-                  )}
-                  {agent.status === 'done' && (
-                    <Tooltip
-                      title={expandedAgent === idx ? '\u1EA8n chi ti\u1EBFt' : 'Xem chi ti\u1EBFt'}
-                    >
-                      {expandedAgent === idx ? <EyeOff size={12} /> : <Eye size={12} />}
-                    </Tooltip>
-                  )}
-                </Flexbox>
-                <span style={{ color: '#888', fontSize: 11 }}>{AGENTS[idx].desc}</span>
-                {expandedAgent === idx && agent.content && (
-                  <div className={styles.agentContent}>
-                    <Markdown>{agent.content.slice(0, 3000)}</Markdown>
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        </Flexbox>
-      )}
+        )}
 
       {/* PubMed Papers */}
       {pubmedPapers.length > 0 &&

--- a/src/features/Portal/Research/Body/Screening/index.tsx
+++ b/src/features/Portal/Research/Body/Screening/index.tsx
@@ -13,92 +13,99 @@ import { type ScreeningDecision, useResearchStore } from '@/store/research';
 type AIVerdict = { decision: 'excluded' | 'included'; paperId: string; reason: string };
 
 const aiScreenBatch = async (
-    papers: Array<{ abstract?: string; id: string; title: string }>,
-    pico: { comparison: string; intervention: string; outcome: string; population: string } | null,
-    query: string,
+  papers: Array<{ abstract?: string; id: string; title: string }>,
+  pico: { comparison: string; intervention: string; outcome: string; population: string } | null,
+  query: string,
 ): Promise<AIVerdict[]> => {
-    // Build a concise screener prompt
-    const picoTxt = pico
-        ? `PICO: P=${pico.population}, I=${pico.intervention}, C=${pico.comparison}, O=${pico.outcome}`
-        : `Research question: ${query}`;
+  // Build a concise screener prompt
+  const picoTxt = pico
+    ? `PICO: P=${pico.population}, I=${pico.intervention}, C=${pico.comparison}, O=${pico.outcome}`
+    : `Research question: ${query}`;
 
-    const papersList = papers.map((p, i) =>
+  const papersList = papers
+    .map(
+      (p, i) =>
         `[${i + 1}] ID:${p.id}\nTitle: ${p.title}\nAbstract: ${p.abstract ? p.abstract.slice(0, 300) : 'N/A'}`,
-    ).join('\n---\n');
+    )
+    .join('\n---\n');
 
-    const prompt = [
-        `You are a systematic review assistant. Screen these papers for inclusion.`,
-        `${picoTxt}`,
-        `For each paper, respond ONLY with a JSON array (no markdown fences) like:`,
-        `[{"id":"...","decision":"included"|"excluded","reason":"1 short phrase"}]`,
-        `Papers:\n${papersList}`,
-    ].join('\n');
+  const prompt = [
+    `You are a systematic review assistant. Screen these papers for inclusion.`,
+    `${picoTxt}`,
+    `For each paper, respond ONLY with a JSON array (no markdown fences) like:`,
+    `[{"id":"...","decision":"included"|"excluded","reason":"1 short phrase"}]`,
+    `Papers:\n${papersList}`,
+  ].join('\n');
 
-    try {
-        const res = await fetch('/api/chat/direct', {
-            body: JSON.stringify({
-                messages: [{ content: prompt, role: 'user' }],
-                model: 'gpt-4o-mini',
-                stream: false,
-                temperature: 0,
-            }),
-            headers: { 'Content-Type': 'application/json' },
-            method: 'POST',
-        });
-        if (!res.ok) throw new Error('API error');
-        const data = await res.json();
-        const text: string = data?.choices?.[0]?.message?.content ?? data?.content ?? '';
-        const parsed = JSON.parse(text.replaceAll(/```[\s\w]*/g, '').trim()) as AIVerdict[];
-        return parsed;
-    } catch {
-        // Fallback: AI not available — return heuristic decisions based on keywords
-        return papers.map((p) => {
-            const titleLower = (p.title + (p.abstract ?? '')).toLowerCase();
-            const queryWords = query.toLowerCase().split(' ').filter((w) => w.length > 4);
-            const matches = queryWords.filter((w) => titleLower.includes(w)).length;
-            const score = queryWords.length > 0 ? matches / queryWords.length : 0;
-            return {
-                decision: score >= 0.3 ? 'included' : 'excluded',
-                paperId: p.id,
-                reason: score >= 0.3 ? 'Keyword match ≥30%' : 'Low keyword relevance',
-            };
-        });
-    }
+  try {
+    const res = await fetch('/api/research/ai-summary', {
+      body: JSON.stringify({
+        model: 'gemini-2.5-flash',
+        prompt,
+        stream: false,
+      }),
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    });
+    if (!res.ok) throw new Error(`API error: ${res.status}`);
+    const data = await res.json();
+    const text: string = data?.text ?? '';
+    const parsed = JSON.parse(text.replaceAll(/```[\s\w]*/g, '').trim()) as AIVerdict[];
+    return parsed;
+  } catch {
+    // Fallback: AI not available — return heuristic decisions based on keywords
+    return papers.map((p) => {
+      const titleLower = (p.title + (p.abstract ?? '')).toLowerCase();
+      const queryWords = query
+        .toLowerCase()
+        .split(' ')
+        .filter((w) => w.length > 4);
+      const matches = queryWords.filter((w) => titleLower.includes(w)).length;
+      const score = queryWords.length > 0 ? matches / queryWords.length : 0;
+      return {
+        decision: score >= 0.3 ? 'included' : 'excluded',
+        paperId: p.id,
+        reason: score >= 0.3 ? 'Keyword match ≥30%' : 'Low keyword relevance',
+      };
+    });
+  }
 };
 
 const useStyles = createStyles(({ css, token }) => ({
-    actionBtn: css`
+  actionBtn: css`
     cursor: pointer;
 
     display: flex;
     gap: 4px;
     align-items: center;
 
-    padding: 4px 10px;
+    padding-block: 4px;
+    padding-inline: 10px;
+    border-radius: 6px;
 
     font-size: 11px;
     font-weight: 600;
 
-    border-radius: 6px;
-
     transition: all 0.15s ease;
   `,
-    container: css`
+  container: css`
     width: 100%;
   `,
-    emptyState: css`
+  emptyState: css`
     display: flex;
     flex-direction: column;
     gap: 8px;
     align-items: center;
     justify-content: center;
 
-    padding: 48px 24px;
+    padding-block: 48px;
+    padding-inline: 24px;
 
     color: ${token.colorTextQuaternary};
     text-align: center;
   `,
-    excludeBtn: css`
+  excludeBtn: css`
     color: ${token.colorError};
     background: ${token.colorErrorBg};
 
@@ -106,7 +113,7 @@ const useStyles = createStyles(({ css, token }) => ({
       background: ${token.colorErrorBgHover};
     }
   `,
-    includeBtn: css`
+  includeBtn: css`
     color: ${token.colorSuccess};
     background: ${token.colorSuccessBg};
 
@@ -114,14 +121,13 @@ const useStyles = createStyles(({ css, token }) => ({
       background: ${token.colorSuccessBgHover};
     }
   `,
-    paperAbstract: css`
+  paperAbstract: css`
     font-size: 11px;
     line-height: 1.5;
     color: ${token.colorTextTertiary};
   `,
-    paperAbstractToggle: css`
+  paperAbstractToggle: css`
     cursor: pointer;
-
     font-size: 10px;
     font-weight: 500;
     color: ${token.colorPrimary};
@@ -130,36 +136,36 @@ const useStyles = createStyles(({ css, token }) => ({
       text-decoration: underline;
     }
   `,
-    paperCard: css`
-    padding: 12px 16px;
-
+  paperCard: css`
+    padding-block: 12px;
+    padding-inline: 16px;
     border: 1px solid ${token.colorBorderSecondary};
     border-radius: ${token.borderRadiusLG}px;
 
     transition: all 0.2s ease;
   `,
-    paperExcluded: css`
-    background: ${token.colorErrorBg};
+  paperExcluded: css`
     border-color: ${token.colorErrorBorder};
+    background: ${token.colorErrorBg};
   `,
-    paperIncluded: css`
-    background: ${token.colorSuccessBg};
+  paperIncluded: css`
     border-color: ${token.colorSuccessBorder};
+    background: ${token.colorSuccessBg};
   `,
-    paperMeta: css`
+  paperMeta: css`
     font-size: 11px;
     color: ${token.colorTextSecondary};
   `,
-    paperPending: css`
+  paperPending: css`
     background: ${token.colorFillQuaternary};
   `,
-    paperTitle: css`
+  paperTitle: css`
     font-size: 13px;
     font-weight: 600;
     line-height: 1.4;
     color: ${token.colorText};
   `,
-    statItem: css`
+  statItem: css`
     display: flex;
     gap: 6px;
     align-items: center;
@@ -167,28 +173,29 @@ const useStyles = createStyles(({ css, token }) => ({
     font-size: 13px;
     font-weight: 600;
   `,
-    statsBar: css`
+  statsBar: css`
     display: flex;
     gap: 16px;
     align-items: center;
     justify-content: space-between;
 
-    padding: 12px 16px;
-
-    background: ${token.colorFillQuaternary};
+    padding-block: 12px;
+    padding-inline: 16px;
     border: 1px solid ${token.colorBorderSecondary};
     border-radius: ${token.borderRadiusLG}px;
+
+    background: ${token.colorFillQuaternary};
   `,
-    tab: css`
+  tab: css`
     cursor: pointer;
 
-    padding: 6px 14px;
+    padding-block: 6px;
+    padding-inline: 14px;
+    border-radius: ${token.borderRadius}px;
 
     font-size: 12px;
     font-weight: 500;
     color: ${token.colorTextSecondary};
-
-    border-radius: ${token.borderRadius}px;
 
     transition: all 0.2s;
 
@@ -196,310 +203,327 @@ const useStyles = createStyles(({ css, token }) => ({
       color: ${token.colorText};
     }
   `,
-    tabActive: css`
+  tabActive: css`
     font-weight: 600;
     color: ${token.colorText};
-
     background: ${token.colorBgElevated};
     box-shadow: 0 1px 3px ${token.colorFillSecondary};
   `,
-    tabBar: css`
+  tabBar: css`
     display: flex;
     gap: 4px;
 
     padding: 4px;
+    border-radius: ${token.borderRadiusLG}px;
 
     background: ${token.colorFillQuaternary};
-    border-radius: ${token.borderRadiusLG}px;
   `,
 }));
 
 type ScreeningTab = 'all' | 'excluded' | 'included' | 'pending';
 
 const ScreeningPhase = memo(() => {
-    const { styles, cx } = useStyles();
-    const [tab, setTab] = useState<ScreeningTab>('all');
+  const { styles, cx } = useStyles();
+  const [tab, setTab] = useState<ScreeningTab>('all');
 
-    const papers = useResearchStore((s) => s.papers);
-    const screeningDecisions = useResearchStore((s) => s.screeningDecisions);
-    const screenPaper = useResearchStore((s) => s.screenPaper);
-    const getScreeningStats = useResearchStore((s) => s.getScreeningStats);
-    const includeAllPapers = useResearchStore((s) => s.includeAllPapers);
-    const resetScreening = useResearchStore((s) => s.resetScreening);
-    const setActivePhase = useResearchStore((s) => s.setActivePhase);
-    const pico = useResearchStore((s) => s.pico);
-    const searchQuery = useResearchStore((s) => s.searchQuery);
+  const papers = useResearchStore((s) => s.papers);
+  const screeningDecisions = useResearchStore((s) => s.screeningDecisions);
+  const screenPaper = useResearchStore((s) => s.screenPaper);
+  const getScreeningStats = useResearchStore((s) => s.getScreeningStats);
+  const includeAllPapers = useResearchStore((s) => s.includeAllPapers);
+  const resetScreening = useResearchStore((s) => s.resetScreening);
+  const setActivePhase = useResearchStore((s) => s.setActivePhase);
+  const pico = useResearchStore((s) => s.pico);
+  const searchQuery = useResearchStore((s) => s.searchQuery);
 
-    const [expandedAbstracts, setExpandedAbstracts] = useState<Set<string>>(new Set());
-    const [pendingExclude, setPendingExclude] = useState<string | null>(null);
-    const [aiLoading, setAiLoading] = useState(false);
-    const [aiScreenedCount, setAiScreenedCount] = useState(0);
+  const [expandedAbstracts, setExpandedAbstracts] = useState<Set<string>>(new Set());
+  const [pendingExclude, setPendingExclude] = useState<string | null>(null);
+  const [aiLoading, setAiLoading] = useState(false);
+  const [aiScreenedCount, setAiScreenedCount] = useState(0);
 
-    const EXCLUSION_REASONS = [
-        { label: 'Wrong population', value: 'Wrong population' },
-        { label: 'Wrong intervention', value: 'Wrong intervention' },
-        { label: 'Wrong outcome', value: 'Wrong outcome' },
-        { label: 'Wrong study type', value: 'Wrong study type' },
-        { label: 'Irrelevant topic', value: 'Irrelevant topic' },
-        { label: 'Duplicate', value: 'Duplicate' },
-        { label: 'Not enough data', value: 'Not enough data' },
-        { label: 'Animal study', value: 'Animal study' },
-        { label: 'Non-English', value: 'Non-English' },
-    ];
+  const EXCLUSION_REASONS = [
+    { label: 'Wrong population', value: 'Wrong population' },
+    { label: 'Wrong intervention', value: 'Wrong intervention' },
+    { label: 'Wrong outcome', value: 'Wrong outcome' },
+    { label: 'Wrong study type', value: 'Wrong study type' },
+    { label: 'Irrelevant topic', value: 'Irrelevant topic' },
+    { label: 'Duplicate', value: 'Duplicate' },
+    { label: 'Not enough data', value: 'Not enough data' },
+    { label: 'Animal study', value: 'Animal study' },
+    { label: 'Non-English', value: 'Non-English' },
+  ];
 
-    const handleExcludeClick = (paperId: string, currentDecision: ScreeningDecision) => {
-        if (currentDecision === 'excluded') {
-            // Toggle back to pending
-            screenPaper(paperId, 'pending');
-            setPendingExclude(null);
-        } else {
-            setPendingExclude(paperId);
-        }
-    };
-
-    const handleReasonSelect = (paperId: string, reason: string) => {
-        screenPaper(paperId, 'excluded', reason);
-        setPendingExclude(null);
-    };
-
-    const toggleAbstract = useCallback((paperId: string) => {
-        setExpandedAbstracts((prev) => {
-            const next = new Set(prev);
-            if (next.has(paperId)) next.delete(paperId);
-            else next.add(paperId);
-            return next;
-        });
-    }, []);
-
-    // ── AI Auto-Screen ───────────────────────────────────────────────────
-    const handleAIScreen = useCallback(async () => {
-        const pendingPapers = papers.filter(
-            (p) => !screeningDecisions[p.id] || screeningDecisions[p.id]?.decision === 'pending',
-        );
-        if (pendingPapers.length === 0) return;
-        setAiLoading(true);
-        try {
-            const verdicts = await aiScreenBatch(pendingPapers, pico, searchQuery);
-            let count = 0;
-            for (const v of verdicts) {
-                const id = v.paperId ?? (v as { id?: string }).id;
-                if (id) {
-                    screenPaper(id, v.decision, v.reason);
-                    count++;
-                }
-            }
-            setAiScreenedCount(count);
-        } finally {
-            setAiLoading(false);
-        }
-    }, [papers, screeningDecisions, pico, searchQuery, screenPaper]);
-
-    const stats = getScreeningStats();
-
-    const filteredPapers = useMemo(() => {
-        switch (tab) {
-            case 'excluded': {
-                return papers.filter((p) => screeningDecisions[p.id]?.decision === 'excluded');
-            }
-            case 'included': {
-                return papers.filter((p) => screeningDecisions[p.id]?.decision === 'included');
-            }
-            case 'pending': {
-                return papers.filter((p) => !screeningDecisions[p.id] || screeningDecisions[p.id]?.decision === 'pending');
-            }
-            default: {
-                return papers;
-            }
-        }
-    }, [papers, screeningDecisions, tab]);
-
-    const getDecision = (paperId: string): ScreeningDecision => {
-        return screeningDecisions[paperId]?.decision || 'pending';
-    };
-
-    const getCardClass = (paperId: string) => {
-        const decision = getDecision(paperId);
-        if (decision === 'included') return cx(styles.paperCard, styles.paperIncluded);
-        if (decision === 'excluded') return cx(styles.paperCard, styles.paperExcluded);
-        return cx(styles.paperCard, styles.paperPending);
-    };
-
-    if (papers.length === 0) {
-        return (
-            <div className={styles.emptyState}>
-                <span style={{ fontSize: 48 }}>📋</span>
-                <span style={{ fontSize: 16, fontWeight: 600 }}>No papers to screen</span>
-                <span style={{ fontSize: 13 }}>
-                    Go back to Discovery phase and search for papers first.
-                </span>
-                <Button onClick={() => setActivePhase('discovery')} size={'small'} type={'primary'}>
-                    <ChevronLeft size={14} /> Back to Discovery
-                </Button>
-            </div>
-        );
+  const handleExcludeClick = (paperId: string, currentDecision: ScreeningDecision) => {
+    if (currentDecision === 'excluded') {
+      // Toggle back to pending
+      screenPaper(paperId, 'pending');
+      setPendingExclude(null);
+    } else {
+      setPendingExclude(paperId);
     }
+  };
 
-    return (
-        <Flexbox className={styles.container} gap={12}>
-            {/* PRISMA Stats Bar */}
-            <div className={styles.statsBar}>
-                <Flexbox gap={16} horizontal wrap={'wrap'}>
-                    <span className={styles.statItem}>
-                        📄 Total: <strong>{stats.total}</strong>
-                    </span>
-                    <span className={styles.statItem} style={{ color: '#52c41a' }}>
-                        ✅ Included: <strong>{stats.included}</strong>
-                    </span>
-                    <span className={styles.statItem} style={{ color: '#ff4d4f' }}>
-                        ❌ Excluded: <strong>{stats.excluded}</strong>
-                    </span>
-                    <span className={styles.statItem} style={{ color: '#faad14' }}>
-                        ⏳ Pending: <strong>{stats.pending}</strong>
-                    </span>
-                </Flexbox>
-            </div>
+  const handleReasonSelect = (paperId: string, reason: string) => {
+    screenPaper(paperId, 'excluded', reason);
+    setPendingExclude(null);
+  };
 
-            {/* Quick Actions */}
-            <Flexbox gap={8} horizontal wrap={'wrap'}>
-                {/* AI Screen Button — MED-39 */}
-                <Tooltip title={aiLoading ? 'AI đang sàng lọc...' : 'AI tự động phân tích abstract và gợi ý include/exclude'}>
-                    <Button
-                        icon={aiLoading ? <Loader2 className="animate-spin" size={14} /> : <Sparkles size={14} />}
-                        loading={aiLoading}
-                        onClick={handleAIScreen}
-                        size={'small'}
-                        style={{
-                            background: 'linear-gradient(135deg, rgba(114,46,209,0.15), rgba(22,119,255,0.1))',
-                            borderColor: 'rgba(114,46,209,0.4)',
-                            color: '#722ed1',
-                            fontWeight: 600,
-                        }}
-                    >
-                        <Bot size={13} />
-                        AI Sàng lọc tự động
-                        {aiScreenedCount > 0 && (
-                            <Tag bordered={false} style={{ fontSize: 9, marginLeft: 4 }}>{aiScreenedCount} đã xử lý</Tag>
-                        )}
-                    </Button>
-                </Tooltip>
-                <Button onClick={includeAllPapers} size={'small'}>
-                    ✅ Include All
-                </Button>
-                <Button onClick={resetScreening} size={'small'}>
-                    🔄 Reset
-                </Button>
-                {stats.included > 0 && (
-                    <Button onClick={() => setActivePhase('analysis')} size={'small'} type={'primary'}>
-                        → Analysis ({stats.included} papers)
-                    </Button>
-                )}
-            </Flexbox>
+  const toggleAbstract = useCallback((paperId: string) => {
+    setExpandedAbstracts((prev) => {
+      const next = new Set(prev);
+      if (next.has(paperId)) next.delete(paperId);
+      else next.add(paperId);
+      return next;
+    });
+  }, []);
 
-            {/* Tab Bar */}
-            <div className={styles.tabBar}>
-                {([
-                    { count: papers.length, key: 'all' as const, label: 'All' },
-                    { count: stats.pending, key: 'pending' as const, label: 'Pending' },
-                    { count: stats.included, key: 'included' as const, label: 'Included' },
-                    { count: stats.excluded, key: 'excluded' as const, label: 'Excluded' },
-                ]).map((t) => (
-                    <span
-                        className={cx(styles.tab, tab === t.key && styles.tabActive)}
-                        key={t.key}
-                        onClick={() => setTab(t.key)}
-                    >
-                        {t.label} ({t.count})
-                    </span>
-                ))}
-            </div>
-
-            {/* Paper Cards */}
-            {filteredPapers.map((paper) => {
-                const decision = getDecision(paper.id);
-                return (
-                    <div className={getCardClass(paper.id)} key={paper.id}>
-                        <Flexbox gap={8}>
-                            <Flexbox align={'flex-start'} gap={8} horizontal justify={'space-between'}>
-                                <span className={styles.paperTitle}>{paper.title}</span>
-                                <Flexbox gap={4} horizontal style={{ flexShrink: 0 }}>
-                                    <span
-                                        className={cx(styles.actionBtn, styles.includeBtn)}
-                                        onClick={() => {
-                                            screenPaper(paper.id, decision === 'included' ? 'pending' : 'included');
-                                            setPendingExclude(null);
-                                        }}
-                                        style={{ opacity: decision === 'included' ? 1 : 0.6 }}
-                                    >
-                                        <CheckCircle size={12} />
-                                        {decision === 'included' ? '✓' : 'Include'}
-                                    </span>
-                                    {pendingExclude === paper.id ? (
-                                        <Select
-                                            autoFocus
-                                            onBlur={() => setPendingExclude(null)}
-                                            onChange={(reason) => handleReasonSelect(paper.id, reason)}
-                                            options={EXCLUSION_REASONS}
-                                            placeholder="Lý do loại..."
-                                            size="small"
-                                            style={{ fontSize: 11, minWidth: 140 }}
-                                        />
-                                    ) : (
-                                        <span
-                                            className={cx(styles.actionBtn, styles.excludeBtn)}
-                                            onClick={() => handleExcludeClick(paper.id, decision)}
-                                            style={{ opacity: decision === 'excluded' ? 1 : 0.6 }}
-                                        >
-                                            <XCircle size={12} />
-                                            {decision === 'excluded' ? '✗' : 'Exclude'}
-                                        </span>
-                                    )}
-                                </Flexbox>
-                            </Flexbox>
-                            <span className={styles.paperMeta}>{paper.authors}</span>
-                            {/* Abstract */}
-                            {paper.abstract && (
-                                <Flexbox gap={2}>
-                                    <span className={styles.paperAbstract}>
-                                        {expandedAbstracts.has(paper.id)
-                                            ? paper.abstract
-                                            : paper.abstract.length > 150
-                                                ? `${paper.abstract.slice(0, 150)}...`
-                                                : paper.abstract}
-                                    </span>
-                                    {paper.abstract.length > 150 && (
-                                        <span
-                                            className={styles.paperAbstractToggle}
-                                            onClick={() => toggleAbstract(paper.id)}
-                                        >
-                                            {expandedAbstracts.has(paper.id) ? '▲ Thu gọn' : '▼ Xem abstract'}
-                                        </span>
-                                    )}
-                                </Flexbox>
-                            )}
-                            <Flexbox align={'center'} gap={6} horizontal wrap={'wrap'}>
-                                <Tag
-                                    color={paper.source === 'PubMed' ? 'blue' : paper.source === 'ArXiv' ? 'purple' : 'green'}
-                                    style={{ fontSize: 10 }}
-                                >
-                                    {paper.source}
-                                </Tag>
-                                {paper.journal && <span className={styles.paperMeta}>{paper.journal}</span>}
-                                {paper.year > 0 && <span className={styles.paperMeta}>· {paper.year}</span>}
-                                {paper.citations !== undefined && paper.citations > 0 && (
-                                    <span className={styles.paperMeta}>📝 {paper.citations.toLocaleString()}</span>
-                                )}
-                                {screeningDecisions[paper.id]?.reason && (
-                                    <Tag color="orange" style={{ fontSize: 10 }}>
-                                        {screeningDecisions[paper.id].reason}
-                                    </Tag>
-                                )}
-                            </Flexbox>
-                        </Flexbox>
-                    </div>
-                );
-            })}
-        </Flexbox>
+  // ── AI Auto-Screen ───────────────────────────────────────────────────
+  const handleAIScreen = useCallback(async () => {
+    const pendingPapers = papers.filter(
+      (p) => !screeningDecisions[p.id] || screeningDecisions[p.id]?.decision === 'pending',
     );
+    if (pendingPapers.length === 0) return;
+    setAiLoading(true);
+    try {
+      const verdicts = await aiScreenBatch(pendingPapers, pico, searchQuery);
+      let count = 0;
+      for (const v of verdicts) {
+        const id = v.paperId ?? (v as { id?: string }).id;
+        if (id) {
+          screenPaper(id, v.decision, v.reason);
+          count++;
+        }
+      }
+      setAiScreenedCount(count);
+    } finally {
+      setAiLoading(false);
+    }
+  }, [papers, screeningDecisions, pico, searchQuery, screenPaper]);
+
+  const stats = getScreeningStats();
+
+  const filteredPapers = useMemo(() => {
+    switch (tab) {
+      case 'excluded': {
+        return papers.filter((p) => screeningDecisions[p.id]?.decision === 'excluded');
+      }
+      case 'included': {
+        return papers.filter((p) => screeningDecisions[p.id]?.decision === 'included');
+      }
+      case 'pending': {
+        return papers.filter(
+          (p) => !screeningDecisions[p.id] || screeningDecisions[p.id]?.decision === 'pending',
+        );
+      }
+      default: {
+        return papers;
+      }
+    }
+  }, [papers, screeningDecisions, tab]);
+
+  const getDecision = (paperId: string): ScreeningDecision => {
+    return screeningDecisions[paperId]?.decision || 'pending';
+  };
+
+  const getCardClass = (paperId: string) => {
+    const decision = getDecision(paperId);
+    if (decision === 'included') return cx(styles.paperCard, styles.paperIncluded);
+    if (decision === 'excluded') return cx(styles.paperCard, styles.paperExcluded);
+    return cx(styles.paperCard, styles.paperPending);
+  };
+
+  if (papers.length === 0) {
+    return (
+      <div className={styles.emptyState}>
+        <span style={{ fontSize: 48 }}>📋</span>
+        <span style={{ fontSize: 16, fontWeight: 600 }}>No papers to screen</span>
+        <span style={{ fontSize: 13 }}>
+          Go back to Discovery phase and search for papers first.
+        </span>
+        <Button onClick={() => setActivePhase('discovery')} size={'small'} type={'primary'}>
+          <ChevronLeft size={14} /> Back to Discovery
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <Flexbox className={styles.container} gap={12}>
+      {/* PRISMA Stats Bar */}
+      <div className={styles.statsBar}>
+        <Flexbox gap={16} horizontal wrap={'wrap'}>
+          <span className={styles.statItem}>
+            📄 Total: <strong>{stats.total}</strong>
+          </span>
+          <span className={styles.statItem} style={{ color: '#52c41a' }}>
+            ✅ Included: <strong>{stats.included}</strong>
+          </span>
+          <span className={styles.statItem} style={{ color: '#ff4d4f' }}>
+            ❌ Excluded: <strong>{stats.excluded}</strong>
+          </span>
+          <span className={styles.statItem} style={{ color: '#faad14' }}>
+            ⏳ Pending: <strong>{stats.pending}</strong>
+          </span>
+        </Flexbox>
+      </div>
+
+      {/* Quick Actions */}
+      <Flexbox gap={8} horizontal wrap={'wrap'}>
+        {/* AI Screen Button — MED-39 */}
+        <Tooltip
+          title={
+            aiLoading
+              ? 'AI đang sàng lọc...'
+              : 'AI tự động phân tích abstract và gợi ý include/exclude'
+          }
+        >
+          <Button
+            icon={
+              aiLoading ? <Loader2 className="animate-spin" size={14} /> : <Sparkles size={14} />
+            }
+            loading={aiLoading}
+            onClick={handleAIScreen}
+            size={'small'}
+            style={{
+              background: 'linear-gradient(135deg, rgba(114,46,209,0.15), rgba(22,119,255,0.1))',
+              borderColor: 'rgba(114,46,209,0.4)',
+              color: '#722ed1',
+              fontWeight: 600,
+            }}
+          >
+            <Bot size={13} />
+            AI Sàng lọc tự động
+            {aiScreenedCount > 0 && (
+              <Tag bordered={false} style={{ fontSize: 9, marginLeft: 4 }}>
+                {aiScreenedCount} đã xử lý
+              </Tag>
+            )}
+          </Button>
+        </Tooltip>
+        <Button onClick={includeAllPapers} size={'small'}>
+          ✅ Include All
+        </Button>
+        <Button onClick={resetScreening} size={'small'}>
+          🔄 Reset
+        </Button>
+        {stats.included > 0 && (
+          <Button onClick={() => setActivePhase('analysis')} size={'small'} type={'primary'}>
+            → Analysis ({stats.included} papers)
+          </Button>
+        )}
+      </Flexbox>
+
+      {/* Tab Bar */}
+      <div className={styles.tabBar}>
+        {[
+          { count: papers.length, key: 'all' as const, label: 'All' },
+          { count: stats.pending, key: 'pending' as const, label: 'Pending' },
+          { count: stats.included, key: 'included' as const, label: 'Included' },
+          { count: stats.excluded, key: 'excluded' as const, label: 'Excluded' },
+        ].map((t) => (
+          <span
+            className={cx(styles.tab, tab === t.key && styles.tabActive)}
+            key={t.key}
+            onClick={() => setTab(t.key)}
+          >
+            {t.label} ({t.count})
+          </span>
+        ))}
+      </div>
+
+      {/* Paper Cards */}
+      {filteredPapers.map((paper) => {
+        const decision = getDecision(paper.id);
+        return (
+          <div className={getCardClass(paper.id)} key={paper.id}>
+            <Flexbox gap={8}>
+              <Flexbox align={'flex-start'} gap={8} horizontal justify={'space-between'}>
+                <span className={styles.paperTitle}>{paper.title}</span>
+                <Flexbox gap={4} horizontal style={{ flexShrink: 0 }}>
+                  <span
+                    className={cx(styles.actionBtn, styles.includeBtn)}
+                    onClick={() => {
+                      screenPaper(paper.id, decision === 'included' ? 'pending' : 'included');
+                      setPendingExclude(null);
+                    }}
+                    style={{ opacity: decision === 'included' ? 1 : 0.6 }}
+                  >
+                    <CheckCircle size={12} />
+                    {decision === 'included' ? '✓' : 'Include'}
+                  </span>
+                  {pendingExclude === paper.id ? (
+                    <Select
+                      autoFocus
+                      onBlur={() => setPendingExclude(null)}
+                      onChange={(reason) => handleReasonSelect(paper.id, reason)}
+                      options={EXCLUSION_REASONS}
+                      placeholder="Lý do loại..."
+                      size="small"
+                      style={{ fontSize: 11, minWidth: 140 }}
+                    />
+                  ) : (
+                    <span
+                      className={cx(styles.actionBtn, styles.excludeBtn)}
+                      onClick={() => handleExcludeClick(paper.id, decision)}
+                      style={{ opacity: decision === 'excluded' ? 1 : 0.6 }}
+                    >
+                      <XCircle size={12} />
+                      {decision === 'excluded' ? '✗' : 'Exclude'}
+                    </span>
+                  )}
+                </Flexbox>
+              </Flexbox>
+              <span className={styles.paperMeta}>{paper.authors}</span>
+              {/* Abstract */}
+              {paper.abstract && (
+                <Flexbox gap={2}>
+                  <span className={styles.paperAbstract}>
+                    {expandedAbstracts.has(paper.id)
+                      ? paper.abstract
+                      : paper.abstract.length > 150
+                        ? `${paper.abstract.slice(0, 150)}...`
+                        : paper.abstract}
+                  </span>
+                  {paper.abstract.length > 150 && (
+                    <span
+                      className={styles.paperAbstractToggle}
+                      onClick={() => toggleAbstract(paper.id)}
+                    >
+                      {expandedAbstracts.has(paper.id) ? '▲ Thu gọn' : '▼ Xem abstract'}
+                    </span>
+                  )}
+                </Flexbox>
+              )}
+              <Flexbox align={'center'} gap={6} horizontal wrap={'wrap'}>
+                <Tag
+                  color={
+                    paper.source === 'PubMed'
+                      ? 'blue'
+                      : paper.source === 'ArXiv'
+                        ? 'purple'
+                        : 'green'
+                  }
+                  style={{ fontSize: 10 }}
+                >
+                  {paper.source}
+                </Tag>
+                {paper.journal && <span className={styles.paperMeta}>{paper.journal}</span>}
+                {paper.year > 0 && <span className={styles.paperMeta}>· {paper.year}</span>}
+                {paper.citations !== undefined && paper.citations > 0 && (
+                  <span className={styles.paperMeta}>📝 {paper.citations.toLocaleString()}</span>
+                )}
+                {screeningDecisions[paper.id]?.reason && (
+                  <Tag color="orange" style={{ fontSize: 10 }}>
+                    {screeningDecisions[paper.id].reason}
+                  </Tag>
+                )}
+              </Flexbox>
+            </Flexbox>
+          </div>
+        );
+      })}
+    </Flexbox>
+  );
 });
 
 ScreeningPhase.displayName = 'ScreeningPhase';

--- a/src/features/Portal/Research/Body/Writing/index.tsx
+++ b/src/features/Portal/Research/Body/Writing/index.tsx
@@ -11,107 +11,157 @@ import { useResearchStore } from '@/store/research';
 
 // ── AI Writing helper ────────────────────────────────────────────────────
 const aiWriteSection = async (
-    sectionKey: string,
-    sectionLabel: string,
-    existingContent: string,
-    context: {
-        pico: { comparison: string; intervention: string; outcome: string; population: string } | null;
-        query: string;
-        refs: string;
-    },
+  sectionKey: string,
+  sectionLabel: string,
+  existingContent: string,
+  context: {
+    pico: { comparison: string; intervention: string; outcome: string; population: string } | null;
+    query: string;
+    refs: string;
+  },
 ): Promise<string> => {
-    const systemInstructions: Record<string, string> = {
-        abstract: 'Write a structured abstract with Background, Objectives, Methods, Results, Conclusions sections. 250 words max.',
-        conclusion: 'Write a concise conclusion paragraph summarizing key findings and recommendations for practice. 150 words.',
-        discussion: 'Write an academic discussion section addressing: summary of findings, comparison with literature, limitations, and clinical implications.',
-        introduction: 'Write an academic introduction with: background context, problem statement, and study objectives. 3 paragraphs.',
-        methods: 'Write a systematic review Methods section covering: search strategy, inclusion/exclusion criteria, data extraction, and quality assessment.',
-        results: 'Write a systematic review Results section covering: study selection (with numbers), study characteristics, and main findings synthesis.',
-        title: 'Generate 3 alternative academic titles for this systematic review. Format as a numbered list.',
+  const systemInstructions: Record<string, string> = {
+    abstract:
+      'Write a structured abstract with Background, Objectives, Methods, Results, Conclusions sections. 250 words max.',
+    conclusion:
+      'Write a concise conclusion paragraph summarizing key findings and recommendations for practice. 150 words.',
+    discussion:
+      'Write an academic discussion section addressing: summary of findings, comparison with literature, limitations, and clinical implications.',
+    introduction:
+      'Write an academic introduction with: background context, problem statement, and study objectives. 3 paragraphs.',
+    methods:
+      'Write a systematic review Methods section covering: search strategy, inclusion/exclusion criteria, data extraction, and quality assessment.',
+    results:
+      'Write a systematic review Results section covering: study selection (with numbers), study characteristics, and main findings synthesis.',
+    title:
+      'Generate 3 alternative academic titles for this systematic review. Format as a numbered list.',
+  };
+
+  const instruction =
+    systemInstructions[sectionKey] ?? `Write the ${sectionLabel} section for a systematic review.`;
+  const picoText = context.pico
+    ? `PICO: P=${context.pico.population}, I=${context.pico.intervention}, C=${context.pico.comparison}, O=${context.pico.outcome}`
+    : `Research question: ${context.query}`;
+
+  const prompt = [
+    instruction,
+    '',
+    picoText,
+    existingContent ? `\nExisting draft (improve this):\n${existingContent}` : '',
+    context.refs
+      ? `\n=== KEY REFERENCES (cite ONLY these — use [Author, Year] format) ===\n${context.refs}\n=== END REFERENCES ===`
+      : `\n=== NO REFERENCES AVAILABLE ===\nDo NOT cite any specific studies, authors, or PMIDs. Use generic phrasing only.`,
+    '\nIMPORTANT: When citing, use ONLY papers from the references above. Format: [Author, Year]. Do NOT invent citations.',
+    '\nRespond in English. Academic register. Use markdown formatting.',
+  ].join('\n');
+
+  try {
+    const res = await fetch('/api/research/ai-summary', {
+      body: JSON.stringify({
+        model: 'gemini-2.5-flash',
+        prompt,
+        stream: false,
+      }),
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    });
+    if (!res.ok) throw new Error(`fail: ${res.status}`);
+    const data = await res.json();
+    return data?.text ?? '';
+  } catch {
+    // Fallback: template scaffold
+    const templates: Record<string, string> = {
+      abstract: `## Abstract\n\n**Background:** ${context.query}\n\n**Methods:** Systematic review following PRISMA guidelines.\n\n**Results:** [number] studies included.\n\n**Conclusions:** Further research warranted.`,
+      conclusion: `This systematic review examined ${context.query}. The evidence suggests that [key finding]. Future research should focus on [gap].`,
+      discussion: `## Discussion\n\nThis review identified [n] relevant studies. Our findings are consistent with [prior work]. Limitations include [search scope, language bias]. Clinical implications: [recommendation].`,
+      introduction: `## Introduction\n\n${context.query} represents an important area of clinical inquiry.\n\nThe objective of this systematic review was to synthesize available evidence on this topic.`,
+      methods: `## Methods\n\n### Search Strategy\nSearched PubMed, OpenAlex, and ClinicalTrials.gov.\n\n### ${picoText}\n\n### Eligibility Criteria\nIncluded: peer-reviewed studies addressing the PICO.`,
+      results: `## Results\n\n### Study Selection\n[n] records identified, [m] included after screening.\n\n### Characteristics of Included Studies\n[Describe study designs, sample sizes, populations].`,
+      title: `1. Effectiveness of ${context.pico?.intervention ?? '[intervention]'} in ${context.pico?.population ?? '[population]'}: A Systematic Review\n2. ${context.query}: A Systematic Review and Meta-Analysis\n3. ${context.pico?.intervention ?? '[intervention]'} versus ${context.pico?.comparison ?? '[comparison]'}: Evidence from a Systematic Review`,
     };
-
-    const instruction = systemInstructions[sectionKey] ?? `Write the ${sectionLabel} section for a systematic review.`;
-    const picoText = context.pico
-        ? `PICO: P=${context.pico.population}, I=${context.pico.intervention}, C=${context.pico.comparison}, O=${context.pico.outcome}`
-        : `Research question: ${context.query}`;
-
-    const prompt = [
-        instruction,
-        '',
-        picoText,
-        existingContent ? `\nExisting draft (improve this):\n${existingContent}` : '',
-        context.refs
-            ? `\n=== KEY REFERENCES (cite ONLY these — use [Author, Year] format) ===\n${context.refs}\n=== END REFERENCES ===`
-            : `\n=== NO REFERENCES AVAILABLE ===\nDo NOT cite any specific studies, authors, or PMIDs. Use generic phrasing only.`,
-        '\nIMPORTANT: When citing, use ONLY papers from the references above. Format: [Author, Year]. Do NOT invent citations.',
-        '\nRespond in English. Academic register. Use markdown formatting.',
-    ].join('\n');
-
-    try {
-        const res = await fetch('/api/chat/direct', {
-            body: JSON.stringify({
-                messages: [{ content: prompt, role: 'user' }],
-                model: 'gpt-4o-mini',
-                stream: false,
-                temperature: 0.6,
-            }),
-            headers: { 'Content-Type': 'application/json' },
-            method: 'POST',
-        });
-        if (!res.ok) throw new Error('fail');
-        const data = await res.json();
-        return data?.choices?.[0]?.message?.content ?? data?.content ?? '';
-    } catch {
-        // Fallback: template scaffold
-        const templates: Record<string, string> = {
-            abstract: `## Abstract\n\n**Background:** ${context.query}\n\n**Methods:** Systematic review following PRISMA guidelines.\n\n**Results:** [number] studies included.\n\n**Conclusions:** Further research warranted.`,
-            conclusion: `This systematic review examined ${context.query}. The evidence suggests that [key finding]. Future research should focus on [gap].`,
-            discussion: `## Discussion\n\nThis review identified [n] relevant studies. Our findings are consistent with [prior work]. Limitations include [search scope, language bias]. Clinical implications: [recommendation].`,
-            introduction: `## Introduction\n\n${context.query} represents an important area of clinical inquiry.\n\nThe objective of this systematic review was to synthesize available evidence on this topic.`,
-            methods: `## Methods\n\n### Search Strategy\nSearched PubMed, OpenAlex, and ClinicalTrials.gov.\n\n### ${picoText}\n\n### Eligibility Criteria\nIncluded: peer-reviewed studies addressing the PICO.`,
-            results: `## Results\n\n### Study Selection\n[n] records identified, [m] included after screening.\n\n### Characteristics of Included Studies\n[Describe study designs, sample sizes, populations].`,
-            title: `1. Effectiveness of ${context.pico?.intervention ?? '[intervention]'} in ${context.pico?.population ?? '[population]'}: A Systematic Review\n2. ${context.query}: A Systematic Review and Meta-Analysis\n3. ${context.pico?.intervention ?? '[intervention]'} versus ${context.pico?.comparison ?? '[comparison]'}: Evidence from a Systematic Review`,
-        };
-        return templates[sectionKey] ?? `[AI-generated ${sectionLabel} section - edit as needed]`;
-    }
+    return templates[sectionKey] ?? `[AI-generated ${sectionLabel} section - edit as needed]`;
+  }
 };
 
 const { TextArea } = Input;
 
 // Standard systematic review sections
 const DEFAULT_SECTIONS = [
-    { content: '', key: 'title', label: 'Title', placeholder: 'Systematic Review: [Your research question]' },
-    { content: '', key: 'abstract', label: 'Abstract', placeholder: 'Background, Methods, Results, Conclusions...' },
-    { content: '', key: 'introduction', label: 'Introduction', placeholder: 'Background context, rationale, and objectives...' },
-    { content: '', key: 'methods', label: 'Methods', placeholder: 'Search strategy, eligibility criteria, data extraction, quality assessment...' },
-    { content: '', key: 'results', label: 'Results', placeholder: 'Study selection (PRISMA), study characteristics, synthesis of results...' },
-    { content: '', key: 'discussion', label: 'Discussion', placeholder: 'Summary of evidence, limitations, implications for practice...' },
-    { content: '', key: 'conclusion', label: 'Conclusion', placeholder: 'Key findings and recommendations...' },
-    { content: '', key: 'references', label: 'References', placeholder: 'Auto-generated from included papers...' },
+  {
+    content: '',
+    key: 'title',
+    label: 'Title',
+    placeholder: 'Systematic Review: [Your research question]',
+  },
+  {
+    content: '',
+    key: 'abstract',
+    label: 'Abstract',
+    placeholder: 'Background, Methods, Results, Conclusions...',
+  },
+  {
+    content: '',
+    key: 'introduction',
+    label: 'Introduction',
+    placeholder: 'Background context, rationale, and objectives...',
+  },
+  {
+    content: '',
+    key: 'methods',
+    label: 'Methods',
+    placeholder: 'Search strategy, eligibility criteria, data extraction, quality assessment...',
+  },
+  {
+    content: '',
+    key: 'results',
+    label: 'Results',
+    placeholder: 'Study selection (PRISMA), study characteristics, synthesis of results...',
+  },
+  {
+    content: '',
+    key: 'discussion',
+    label: 'Discussion',
+    placeholder: 'Summary of evidence, limitations, implications for practice...',
+  },
+  {
+    content: '',
+    key: 'conclusion',
+    label: 'Conclusion',
+    placeholder: 'Key findings and recommendations...',
+  },
+  {
+    content: '',
+    key: 'references',
+    label: 'References',
+    placeholder: 'Auto-generated from included papers...',
+  },
 ];
 
 const useStyles = createStyles(({ css, token }) => ({
-    container: css`
+  container: css`
     width: 100%;
   `,
-    emptyState: css`
+  emptyState: css`
     display: flex;
     flex-direction: column;
     gap: 8px;
     align-items: center;
     justify-content: center;
 
-    padding: 48px 24px;
+    padding-block: 48px;
+    padding-inline: 24px;
 
     color: ${token.colorTextQuaternary};
     text-align: center;
   `,
-    sectionCard: css`
-    padding: 12px 16px;
-
-    background: ${token.colorFillQuaternary};
+  sectionCard: css`
+    padding-block: 12px;
+    padding-inline: 16px;
     border: 1px solid ${token.colorBorderSecondary};
     border-radius: ${token.borderRadiusLG}px;
+
+    background: ${token.colorFillQuaternary};
 
     transition: all 0.2s;
 
@@ -119,7 +169,7 @@ const useStyles = createStyles(({ css, token }) => ({
       border-color: ${token.colorPrimaryBorder};
     }
   `,
-    sectionHeader: css`
+  sectionHeader: css`
     cursor: pointer;
 
     display: flex;
@@ -131,7 +181,7 @@ const useStyles = createStyles(({ css, token }) => ({
     font-weight: 700;
     color: ${token.colorText};
   `,
-    sectionLabel: css`
+  sectionLabel: css`
     display: flex;
     gap: 8px;
     align-items: center;
@@ -140,12 +190,12 @@ const useStyles = createStyles(({ css, token }) => ({
     font-weight: 700;
     color: ${token.colorText};
   `,
-    sectionTitle: css`
+  sectionTitle: css`
     font-size: 13px;
     font-weight: 600;
     color: ${token.colorTextSecondary};
   `,
-    statItem: css`
+  statItem: css`
     display: flex;
     gap: 6px;
     align-items: center;
@@ -153,19 +203,24 @@ const useStyles = createStyles(({ css, token }) => ({
     font-size: 13px;
     font-weight: 600;
   `,
-    statsCard: css`
+  statsCard: css`
     display: flex;
     gap: 16px;
     align-items: center;
     justify-content: space-between;
 
-    padding: 12px 16px;
-
-    background: linear-gradient(135deg, ${token.colorPrimaryBg} 0%, ${token.colorFillQuaternary} 100%);
+    padding-block: 12px;
+    padding-inline: 16px;
     border: 1px solid ${token.colorPrimaryBorder};
     border-radius: ${token.borderRadiusLG}px;
+
+    background: linear-gradient(
+      135deg,
+      ${token.colorPrimaryBg} 0%,
+      ${token.colorFillQuaternary} 100%
+    );
   `,
-    wordCount: css`
+  wordCount: css`
     font-size: 11px;
     font-weight: 400;
     color: ${token.colorTextQuaternary};
@@ -173,188 +228,215 @@ const useStyles = createStyles(({ css, token }) => ({
 }));
 
 const WritingPhase = memo(() => {
-    const { styles } = useStyles();
+  const { styles } = useStyles();
 
-    const papers = useResearchStore((s) => s.papers);
-    const screeningDecisions = useResearchStore((s) => s.screeningDecisions);
-    const pico = useResearchStore((s) => s.pico);
-    const searchQuery = useResearchStore((s) => s.searchQuery);
-    const setActivePhase = useResearchStore((s) => s.setActivePhase);
+  const papers = useResearchStore((s) => s.papers);
+  const screeningDecisions = useResearchStore((s) => s.screeningDecisions);
+  const pico = useResearchStore((s) => s.pico);
+  const searchQuery = useResearchStore((s) => s.searchQuery);
+  const setActivePhase = useResearchStore((s) => s.setActivePhase);
 
-    const includedPapers = papers.filter((p) => screeningDecisions[p.id]?.decision === 'included');
+  const includedPapers = papers.filter((p) => screeningDecisions[p.id]?.decision === 'included');
 
-    // Section state
-    const [sections, setSections] = useState(() => {
-        const filled = DEFAULT_SECTIONS.map((s) => ({ ...s }));
+  // Section state
+  const [sections, setSections] = useState(() => {
+    const filled = DEFAULT_SECTIONS.map((s) => ({ ...s }));
 
-        if (searchQuery) filled[0].content = `Systematic Review: ${searchQuery}`;
+    if (searchQuery) filled[0].content = `Systematic Review: ${searchQuery}`;
 
-        const methodsIdx = filled.findIndex((s) => s.key === 'methods');
-        if (methodsIdx >= 0 && pico) {
-            filled[methodsIdx].content = [
-                '## Search Strategy',
-                `Research Question: ${searchQuery}`,
-                '',
-                '### PICO Framework',
-                `- **Population:** ${pico.population}`,
-                `- **Intervention:** ${pico.intervention}`,
-                `- **Comparison:** ${pico.comparison}`,
-                `- **Outcome:** ${pico.outcome}`,
-                '',
-                '### Databases Searched',
-                '- PubMed (MEDLINE)',
-                '- OpenAlex',
-                '',
-                '### Selection Criteria',
-                `- ${includedPapers.length} studies included after screening`,
-                `- ${papers.length - includedPapers.length} studies excluded`,
-            ].join('\n');
-        }
+    const methodsIdx = filled.findIndex((s) => s.key === 'methods');
+    if (methodsIdx >= 0 && pico) {
+      filled[methodsIdx].content = [
+        '## Search Strategy',
+        `Research Question: ${searchQuery}`,
+        '',
+        '### PICO Framework',
+        `- **Population:** ${pico.population}`,
+        `- **Intervention:** ${pico.intervention}`,
+        `- **Comparison:** ${pico.comparison}`,
+        `- **Outcome:** ${pico.outcome}`,
+        '',
+        '### Databases Searched',
+        '- PubMed (MEDLINE)',
+        '- OpenAlex',
+        '',
+        '### Selection Criteria',
+        `- ${includedPapers.length} studies included after screening`,
+        `- ${papers.length - includedPapers.length} studies excluded`,
+      ].join('\n');
+    }
 
-        const refsIdx = filled.findIndex((s) => s.key === 'references');
-        if (refsIdx >= 0) {
-            filled[refsIdx].content = includedPapers.map((p, i) =>
-                `${i + 1}. ${p.authors}. ${p.title}. ${p.journal || 'N/A'}. ${p.year}. ${p.doi ? `DOI: ${p.doi}` : ''}`,
-            ).join('\n');
-        }
+    const refsIdx = filled.findIndex((s) => s.key === 'references');
+    if (refsIdx >= 0) {
+      filled[refsIdx].content = includedPapers
+        .map(
+          (p, i) =>
+            `${i + 1}. ${p.authors}. ${p.title}. ${p.journal || 'N/A'}. ${p.year}. ${p.doi ? `DOI: ${p.doi}` : ''}`,
+        )
+        .join('\n');
+    }
 
-        return filled;
-    });
+    return filled;
+  });
 
-    const [expandedSection, setExpandedSection] = useState<string | null>('title');
-    // Track which sections are AI-generating
-    const [aiGenerating, setAiGenerating] = useState<Record<string, boolean>>({});
+  const [expandedSection, setExpandedSection] = useState<string | null>('title');
+  // Track which sections are AI-generating
+  const [aiGenerating, setAiGenerating] = useState<Record<string, boolean>>({});
 
-    const updateSection = (key: string, content: string) => {
-        setSections((prev) => prev.map((s) => s.key === key ? { ...s, content } : s));
-    };
+  const updateSection = (key: string, content: string) => {
+    setSections((prev) => prev.map((s) => (s.key === key ? { ...s, content } : s)));
+  };
 
-    // AI write a section — MED-40
-    const handleAIWrite = useCallback(async (sectionKey: string, sectionLabel: string, existingContent: string) => {
-        setAiGenerating((prev) => ({ ...prev, [sectionKey]: true }));
-        setExpandedSection(sectionKey); // open the section
-        const refsText = includedPapers.slice(0, 8).map((p, i) => {
-            const abstract = (p.abstract || '').slice(0, 250);
-            const id = p.id?.startsWith('pubmed-')
-                ? ` PMID:${p.id.replace('pubmed-', '')}`
-                : (p.doi ? ` DOI:${p.doi}` : '');
-            return `[${i + 1}] ${p.authors} (${p.year}). ${p.title}.${id}${abstract ? `\n    Abstract: ${abstract}${p.abstract && p.abstract.length > 250 ? '...' : ''}` : ''}`;
-        }).join('\n\n');
-        try {
-            const result = await aiWriteSection(sectionKey, sectionLabel, existingContent, {
-                pico, query: searchQuery, refs: refsText,
-            });
-            updateSection(sectionKey, result);
-        } finally {
-            setAiGenerating((prev) => ({ ...prev, [sectionKey]: false }));
-        }
-    }, [includedPapers, pico, searchQuery]);
+  // AI write a section — MED-40
+  const handleAIWrite = useCallback(
+    async (sectionKey: string, sectionLabel: string, existingContent: string) => {
+      setAiGenerating((prev) => ({ ...prev, [sectionKey]: true }));
+      setExpandedSection(sectionKey); // open the section
+      const refsText = includedPapers
+        .slice(0, 8)
+        .map((p, i) => {
+          const abstract = (p.abstract || '').slice(0, 250);
+          const id = p.id?.startsWith('pubmed-')
+            ? ` PMID:${p.id.replace('pubmed-', '')}`
+            : p.doi
+              ? ` DOI:${p.doi}`
+              : '';
+          return `[${i + 1}] ${p.authors} (${p.year}). ${p.title}.${id}${abstract ? `\n    Abstract: ${abstract}${p.abstract && p.abstract.length > 250 ? '...' : ''}` : ''}`;
+        })
+        .join('\n\n');
+      try {
+        const result = await aiWriteSection(sectionKey, sectionLabel, existingContent, {
+          pico,
+          query: searchQuery,
+          refs: refsText,
+        });
+        updateSection(sectionKey, result);
+      } finally {
+        setAiGenerating((prev) => ({ ...prev, [sectionKey]: false }));
+      }
+    },
+    [includedPapers, pico, searchQuery],
+  );
 
-    const totalWords = sections.reduce((sum, s) => sum + (s.content ? s.content.split(/\s+/).filter(Boolean).length : 0), 0);
-    const completedSections = sections.filter((s) => s.content.trim().length > 0).length;
+  const totalWords = sections.reduce(
+    (sum, s) => sum + (s.content ? s.content.split(/\s+/).filter(Boolean).length : 0),
+    0,
+  );
+  const completedSections = sections.filter((s) => s.content.trim().length > 0).length;
 
-    const handleCopyAll = () => {
-        const fullText = sections
-            .filter((s) => s.content.trim())
-            .map((s) => `# ${s.label}\n\n${s.content}`)
-            .join('\n\n---\n\n');
-        navigator.clipboard.writeText(fullText);
-    };
+  const handleCopyAll = () => {
+    const fullText = sections
+      .filter((s) => s.content.trim())
+      .map((s) => `# ${s.label}\n\n${s.content}`)
+      .join('\n\n---\n\n');
+    navigator.clipboard.writeText(fullText);
+  };
 
-    return (
-        <Flexbox className={styles.container} gap={12}>
-            {/* Writing Stats */}
-            <div className={styles.statsCard}>
-                <Flexbox gap={16} horizontal wrap={'wrap'}>
-                    <span className={styles.statItem}>📝 {totalWords} words</span>
-                    <span className={styles.statItem}>📄 {completedSections}/{sections.length} sections</span>
-                    <span className={styles.statItem}>📚 {includedPapers.length} references</span>
-                </Flexbox>
-                <Button icon={<Copy size={14} />} onClick={handleCopyAll} size={'small'}>
-                    Copy All
-                </Button>
-            </div>
-
-            {/* Section Cards */}
-            <Flexbox gap={8}>
-                <span className={styles.sectionTitle}>✍️ Manuscript Sections</span>
-                {sections.map((section, idx) => (
-                    <div className={styles.sectionCard} key={section.key}>
-                        <div
-                            className={styles.sectionHeader}
-                            onClick={() => setExpandedSection(expandedSection === section.key ? null : section.key)}
-                        >
-                            <span className={styles.sectionLabel}>
-                                <FileText size={14} />
-                                {idx + 1}. {section.label}
-                                {section.content.trim() && (
-                                    <Tag color="green" style={{ fontSize: 10 }}>✓</Tag>
-                                )}
-                                {aiGenerating[section.key] && (
-                                    <Tag color="purple" style={{ fontSize: 9 }}>AI đang viết...</Tag>
-                                )}
-                            </span>
-                            <Flexbox align={'center'} gap={4} horizontal onClick={(e) => e.stopPropagation()}>
-                                {/* AI Write Button — MED-40 */}
-                                {section.key !== 'references' && (
-                                    <Tooltip title={`AI viết ${section.label} dựa trên PICO và paper chọn`}>
-                                        <button
-                                            disabled={aiGenerating[section.key]}
-                                            onClick={() => handleAIWrite(section.key, section.label, section.content)}
-                                            style={{
-                                                alignItems: 'center',
-                                                background: 'linear-gradient(135deg, rgba(114,46,209,0.12), rgba(22,119,255,0.08))',
-                                                border: '1px solid rgba(114,46,209,0.3)',
-                                                borderRadius: 6,
-                                                color: '#722ed1',
-                                                cursor: aiGenerating[section.key] ? 'not-allowed' : 'pointer',
-                                                display: 'flex',
-                                                fontSize: 11,
-                                                fontWeight: 600,
-                                                gap: 4,
-                                                padding: '3px 8px',
-                                            }}
-                                            type="button"
-                                        >
-                                            {aiGenerating[section.key]
-                                                ? <Loader2 size={11} style={{ animation: 'spin 1s linear infinite' }} />
-                                                : <Sparkles size={11} />}
-                                            AI
-                                        </button>
-                                    </Tooltip>
-                                )}
-                                <span className={styles.wordCount}>
-                                    {section.content ? section.content.split(/\s+/).filter(Boolean).length : 0} words
-                                    {expandedSection === section.key ? ' ▲' : ' ▼'}
-                                </span>
-                            </Flexbox>
-                        </div>
-                        {expandedSection === section.key && (
-                            <div style={{ marginTop: 8 }}>
-                                <TextArea
-                                    autoSize={{ maxRows: 20, minRows: 4 }}
-                                    onChange={(e) => updateSection(section.key, e.target.value)}
-                                    placeholder={section.placeholder}
-                                    style={{ fontSize: 13, lineHeight: 1.6 }}
-                                    value={section.content}
-                                />
-                            </div>
-                        )}
-                    </div>
-                ))}
-            </Flexbox>
-
-            {/* Phase Navigation */}
-            <Flexbox gap={8} horizontal justify={'space-between'}>
-                <Button onClick={() => setActivePhase('analysis')} size={'small'}>
-                    ← Back to Analysis
-                </Button>
-                <Button onClick={() => setActivePhase('publishing')} size={'small'} type={'primary'}>
-                    → Proceed to Publishing
-                </Button>
-            </Flexbox>
+  return (
+    <Flexbox className={styles.container} gap={12}>
+      {/* Writing Stats */}
+      <div className={styles.statsCard}>
+        <Flexbox gap={16} horizontal wrap={'wrap'}>
+          <span className={styles.statItem}>📝 {totalWords} words</span>
+          <span className={styles.statItem}>
+            📄 {completedSections}/{sections.length} sections
+          </span>
+          <span className={styles.statItem}>📚 {includedPapers.length} references</span>
         </Flexbox>
-    );
+        <Button icon={<Copy size={14} />} onClick={handleCopyAll} size={'small'}>
+          Copy All
+        </Button>
+      </div>
+
+      {/* Section Cards */}
+      <Flexbox gap={8}>
+        <span className={styles.sectionTitle}>✍️ Manuscript Sections</span>
+        {sections.map((section, idx) => (
+          <div className={styles.sectionCard} key={section.key}>
+            <div
+              className={styles.sectionHeader}
+              onClick={() =>
+                setExpandedSection(expandedSection === section.key ? null : section.key)
+              }
+            >
+              <span className={styles.sectionLabel}>
+                <FileText size={14} />
+                {idx + 1}. {section.label}
+                {section.content.trim() && (
+                  <Tag color="green" style={{ fontSize: 10 }}>
+                    ✓
+                  </Tag>
+                )}
+                {aiGenerating[section.key] && (
+                  <Tag color="purple" style={{ fontSize: 9 }}>
+                    AI đang viết...
+                  </Tag>
+                )}
+              </span>
+              <Flexbox align={'center'} gap={4} horizontal onClick={(e) => e.stopPropagation()}>
+                {/* AI Write Button — MED-40 */}
+                {section.key !== 'references' && (
+                  <Tooltip title={`AI viết ${section.label} dựa trên PICO và paper chọn`}>
+                    <button
+                      disabled={aiGenerating[section.key]}
+                      onClick={() => handleAIWrite(section.key, section.label, section.content)}
+                      style={{
+                        alignItems: 'center',
+                        background:
+                          'linear-gradient(135deg, rgba(114,46,209,0.12), rgba(22,119,255,0.08))',
+                        border: '1px solid rgba(114,46,209,0.3)',
+                        borderRadius: 6,
+                        color: '#722ed1',
+                        cursor: aiGenerating[section.key] ? 'not-allowed' : 'pointer',
+                        display: 'flex',
+                        fontSize: 11,
+                        fontWeight: 600,
+                        gap: 4,
+                        padding: '3px 8px',
+                      }}
+                      type="button"
+                    >
+                      {aiGenerating[section.key] ? (
+                        <Loader2 size={11} style={{ animation: 'spin 1s linear infinite' }} />
+                      ) : (
+                        <Sparkles size={11} />
+                      )}
+                      AI
+                    </button>
+                  </Tooltip>
+                )}
+                <span className={styles.wordCount}>
+                  {section.content ? section.content.split(/\s+/).filter(Boolean).length : 0} words
+                  {expandedSection === section.key ? ' ▲' : ' ▼'}
+                </span>
+              </Flexbox>
+            </div>
+            {expandedSection === section.key && (
+              <div style={{ marginTop: 8 }}>
+                <TextArea
+                  autoSize={{ maxRows: 20, minRows: 4 }}
+                  onChange={(e) => updateSection(section.key, e.target.value)}
+                  placeholder={section.placeholder}
+                  style={{ fontSize: 13, lineHeight: 1.6 }}
+                  value={section.content}
+                />
+              </div>
+            )}
+          </div>
+        ))}
+      </Flexbox>
+
+      {/* Phase Navigation */}
+      <Flexbox gap={8} horizontal justify={'space-between'}>
+        <Button onClick={() => setActivePhase('analysis')} size={'small'}>
+          ← Back to Analysis
+        </Button>
+        <Button onClick={() => setActivePhase('publishing')} size={'small'} type={'primary'}>
+          → Proceed to Publishing
+        </Button>
+      </Flexbox>
+    </Flexbox>
+  );
 });
 
 WritingPhase.displayName = 'WritingPhase';

--- a/src/store/research/index.ts
+++ b/src/store/research/index.ts
@@ -749,6 +749,28 @@ export const useResearchStore = create<ResearchState>()(
         },
       }),
       {
+        migrate: (persistedState: any, fromVersion: number) => {
+          // v0/v1 had ArXiv on by default for clinical queries.
+          // v2 removes ArXiv from default to reduce CS-paper noise.
+          // Only auto-migrate users who still have the legacy 4-source default;
+          // preserve any explicit customization (added or removed sources).
+          if (fromVersion < 2 && persistedState) {
+            const oldSources: string[] = persistedState.selectedSources ?? [];
+            const looksLikeLegacyDefault =
+              oldSources.length === 4 &&
+              oldSources.includes('PubMed') &&
+              oldSources.includes('OpenAlex') &&
+              oldSources.includes('ArXiv') &&
+              oldSources.includes('ClinicalTrials.gov');
+            if (looksLikeLegacyDefault) {
+              return {
+                ...persistedState,
+                selectedSources: ['PubMed', 'OpenAlex', 'ClinicalTrials.gov'],
+              };
+            }
+          }
+          return persistedState;
+        },
         name: 'pho-research-store',
         partialize: (state) => ({
           activePhase: state.activePhase,
@@ -760,6 +782,7 @@ export const useResearchStore = create<ResearchState>()(
           selectedSources: state.selectedSources,
           totalResults: state.totalResults,
         }),
+        version: 2,
       },
     ),
     { name: 'ResearchStore' },

--- a/src/store/research/index.ts
+++ b/src/store/research/index.ts
@@ -7,33 +7,33 @@
 import { create } from 'zustand';
 import { devtools, persist } from 'zustand/middleware';
 
-import { buildSearchQuery, type DetectedLanguage } from '@/utils/research/buildSearchQuery';
+import { type DetectedLanguage, buildSearchQuery } from '@/utils/research/buildSearchQuery';
 import { extractPICO as llmExtractPICO } from '@/utils/research/extractPICO';
 
 // ========== Types ==========
 
 export interface PaperResult {
-    abstract?: string;
-    authors: string;
-    citations?: number;
-    doi?: string;
-    doiUrl?: string;
-    id: string;
-    isOpenAccess?: boolean;
-    journal?: string;
-    pmid?: string;
-    pubmedUrl?: string;
-    source: 'PubMed' | 'OpenAlex' | 'ArXiv' | 'ClinicalTrials.gov';
-    title: string;
-    url?: string;
-    year: number;
+  abstract?: string;
+  authors: string;
+  citations?: number;
+  doi?: string;
+  doiUrl?: string;
+  id: string;
+  isOpenAccess?: boolean;
+  journal?: string;
+  pmid?: string;
+  pubmedUrl?: string;
+  source: 'PubMed' | 'OpenAlex' | 'ArXiv' | 'ClinicalTrials.gov';
+  title: string;
+  url?: string;
+  year: number;
 }
 
 export interface PICOQuery {
-    comparison: string;
-    intervention: string;
-    outcome: string;
-    population: string;
+  comparison: string;
+  intervention: string;
+  outcome: string;
+  population: string;
 }
 
 // ========== AI helper (translate + PICO) ==========
@@ -42,20 +42,33 @@ export interface PICOQuery {
 // stable across users (free tier, paid tier, custom keys).
 const TRANSLATE_MODEL = 'gpt-4o-mini';
 
+// Calls /api/research/ai-summary which is Clerk-authenticated and has full
+// billing/tier enforcement. Phase 1.5 used /api/chat/direct, but that endpoint
+// does not exist in this repo — every translate/PICO call silently fell back
+// to the original VN query. Phase 1.5.1 fixes this by routing to the same
+// endpoint Deep Research already uses successfully.
 const callAI = async (model: string, prompt: string): Promise<string> => {
-    const res = await fetch('/api/chat/direct', {
-        body: JSON.stringify({
-            messages: [{ content: prompt, role: 'user' }],
-            model,
-            stream: false,
-            temperature: 0.3,
-        }),
-        headers: { 'Content-Type': 'application/json' },
-        method: 'POST',
-    });
-    if (!res.ok) throw new Error(`AI call failed: ${res.status}`);
-    const data = await res.json();
-    return data?.choices?.[0]?.message?.content ?? data?.content ?? '';
+  const res = await fetch('/api/research/ai-summary', {
+    body: JSON.stringify({ model, prompt, stream: false }),
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    method: 'POST',
+  });
+
+  if (res.status === 401) {
+    throw new Error('Unauthorized – please sign in to use Research Mode AI features');
+  }
+  if (res.status === 402 || res.status === 403) {
+    throw new Error('Insufficient credits or plan tier');
+  }
+  if (!res.ok) {
+    const errBody = await res.text().catch(() => '');
+    throw new Error(`AI call failed (${res.status}): ${errBody.slice(0, 200)}`);
+  }
+
+  const data = await res.json();
+  // ai-summary returns { model, provider, text }
+  return data?.text ?? '';
 };
 
 export type ResearchPhase = 'discovery' | 'screening' | 'analysis' | 'writing' | 'publishing';
@@ -65,579 +78,690 @@ export type SearchSource = 'PubMed' | 'OpenAlex' | 'ArXiv' | 'ClinicalTrials.gov
 export type ScreeningDecision = 'included' | 'excluded' | 'pending';
 
 export interface ScreeningEntry {
-    decision: ScreeningDecision;
-    paperId: string;
-    reason?: string;
+  decision: ScreeningDecision;
+  paperId: string;
+  reason?: string;
 }
 
 export interface ScreeningCriteria {
-    exclusionCriteria: string[];
-    inclusionCriteria: string[];
-    minCitations?: number;
-    studyTypes?: string[];
-    yearFrom?: number;
-    yearTo?: number;
+  exclusionCriteria: string[];
+  inclusionCriteria: string[];
+  minCitations?: number;
+  studyTypes?: string[];
+  yearFrom?: number;
+  yearTo?: number;
 }
 
 interface ResearchState {
-    // Phase tracking
-    activePhase: ResearchPhase;
+  // Phase tracking
+  activePhase: ResearchPhase;
 
-    addPaper: (paper: PaperResult) => void;
-    addPapers: (papers: PaperResult[]) => void;
-    autoScreenByCitations: (minCitations: number) => void;
-    autoScreenByYearRange: (yearFrom: number, yearTo: number) => void;
-    // Pagination (MED-33)
-    currentPage: number;
-    // Translation context (Phase 1.5)
-    detectedLanguage: DetectedLanguage | null;
-    excludeAllPapers: () => void;
-    extractPICO: (query: string) => Promise<void>;
+  addPaper: (paper: PaperResult) => void;
+  addPapers: (papers: PaperResult[]) => void;
+  autoScreenByCitations: (minCitations: number) => void;
+  autoScreenByYearRange: (yearFrom: number, yearTo: number) => void;
+  // Pagination (MED-33)
+  currentPage: number;
+  // Translation context (Phase 1.5)
+  detectedLanguage: DetectedLanguage | null;
+  excludeAllPapers: () => void;
+  extractPICO: (query: string) => Promise<void>;
 
-    getExcludedPapers: () => PaperResult[];
-    // Getters
-    getIncludedPapers: () => PaperResult[];
+  getExcludedPapers: () => PaperResult[];
+  // Getters
+  getIncludedPapers: () => PaperResult[];
 
-    getPendingPapers: () => PaperResult[];
-    getScreeningStats: () => { excluded: number; included: number; pending: number; total: number };
-    hasMore: boolean;
-    includeAllPapers: () => void;
-    isLoadingMore: boolean;
+  getPendingPapers: () => PaperResult[];
+  getScreeningStats: () => { excluded: number; included: number; pending: number; total: number };
+  hasMore: boolean;
+  includeAllPapers: () => void;
+  isLoadingMore: boolean;
 
-    isSearching: boolean;
-    loadMoreResults: () => Promise<void>;
-    // Gate state (Phase 1.5): true when last search returned 0 papers from all sources.
-    noPapersFound: boolean;
-    papers: PaperResult[];
-    pico: PICOQuery | null;
-    removePapers: (ids: string[]) => void;
-    reset: () => void;
-    resetScreening: () => void;
+  isSearching: boolean;
+  loadMoreResults: () => Promise<void>;
+  // Gate state (Phase 1.5): true when last search returned 0 papers from all sources.
+  noPapersFound: boolean;
+  papers: PaperResult[];
+  pico: PICOQuery | null;
+  removePapers: (ids: string[]) => void;
+  reset: () => void;
+  resetScreening: () => void;
 
-    // Screening Actions
-    screenPaper: (paperId: string, decision: ScreeningDecision, reason?: string) => void;
-    screeningCriteria: ScreeningCriteria;
-    // Screening
-    screeningDecisions: Record<string, ScreeningEntry>;
-    searchError: string | null;
-    searchPapers: (query: string) => Promise<void>;
-    // Discovery
-    searchQuery: string;
-    selectedSources: SearchSource[];
+  // Screening Actions
+  screenPaper: (paperId: string, decision: ScreeningDecision, reason?: string) => void;
+  screeningCriteria: ScreeningCriteria;
+  // Screening
+  screeningDecisions: Record<string, ScreeningEntry>;
+  searchError: string | null;
+  searchPapers: (query: string) => Promise<void>;
+  // Discovery
+  searchQuery: string;
+  selectedSources: SearchSource[];
 
-    setActivePhase: (phase: ResearchPhase) => void;
-    // Discovery Actions
-    setSearchQuery: (query: string) => void;
-    toggleSource: (source: SearchSource) => void;
-    totalResults: number;
-    // English search query actually sent to PubMed/OpenAlex/etc when input was VN.
-    translatedQuery: string | null;
+  setActivePhase: (phase: ResearchPhase) => void;
+  // Discovery Actions
+  setSearchQuery: (query: string) => void;
+  toggleSource: (source: SearchSource) => void;
+  totalResults: number;
+  // English search query actually sent to PubMed/OpenAlex/etc when input was VN.
+  translatedQuery: string | null;
 
-    updateScreeningCriteria: (criteria: Partial<ScreeningCriteria>) => void;
+  updateScreeningCriteria: (criteria: Partial<ScreeningCriteria>) => void;
 }
 
 const defaultCriteria: ScreeningCriteria = {
-    exclusionCriteria: ['Case reports', 'Animal studies', 'Non-English language'],
-    inclusionCriteria: ['Randomized controlled trial', 'Systematic review', 'Meta-analysis'],
-    minCitations: 0,
-    studyTypes: ['RCT', 'Systematic Review', 'Meta-analysis', 'Cohort Study'],
-    yearFrom: 2015,
-    yearTo: new Date().getFullYear(),
+  exclusionCriteria: ['Case reports', 'Animal studies', 'Non-English language'],
+  inclusionCriteria: ['Randomized controlled trial', 'Systematic review', 'Meta-analysis'],
+  minCitations: 0,
+  studyTypes: ['RCT', 'Systematic Review', 'Meta-analysis', 'Cohort Study'],
+  yearFrom: 2015,
+  yearTo: new Date().getFullYear(),
 };
 
 const initialState = {
-    activePhase: 'discovery' as ResearchPhase,
-    currentPage: 1,
-    detectedLanguage: null as DetectedLanguage | null,
-    hasMore: true,
-    isLoadingMore: false,
-    isSearching: false,
-    noPapersFound: false,
-    papers: [] as PaperResult[],
-    pico: null as PICOQuery | null,
-    screeningCriteria: defaultCriteria,
-    screeningDecisions: {} as Record<string, ScreeningEntry>,
-    searchError: null as string | null,
-    searchQuery: '',
-    // ArXiv default OFF — heavy CS bias polluted clinical results for our primary
-    // user (BS Đỗ Tiến Sơn, endocrinology). Users can re-enable per search.
-    selectedSources: ['PubMed', 'OpenAlex', 'ClinicalTrials.gov'] as SearchSource[],
-    totalResults: 0,
-    translatedQuery: null as string | null,
+  activePhase: 'discovery' as ResearchPhase,
+  currentPage: 1,
+  detectedLanguage: null as DetectedLanguage | null,
+  hasMore: true,
+  isLoadingMore: false,
+  isSearching: false,
+  noPapersFound: false,
+  papers: [] as PaperResult[],
+  pico: null as PICOQuery | null,
+  screeningCriteria: defaultCriteria,
+  screeningDecisions: {} as Record<string, ScreeningEntry>,
+  searchError: null as string | null,
+  searchQuery: '',
+  // ArXiv default OFF — heavy CS bias polluted clinical results for our primary
+  // user (BS Đỗ Tiến Sơn, endocrinology). Users can re-enable per search.
+  selectedSources: ['PubMed', 'OpenAlex', 'ClinicalTrials.gov'] as SearchSource[],
+  totalResults: 0,
+  translatedQuery: null as string | null,
 };
 
 // ========== API Services ==========
 
 const searchPubMed = async (query: string, maxResults = 10, offset = 0): Promise<PaperResult[]> => {
-    try {
-        const response = await fetch('/api/plugins/pubmed/search', {
-            body: JSON.stringify({ maxResults, offset, query }),
-            headers: { 'Content-Type': 'application/json' },
-            method: 'POST',
-        });
-        if (!response.ok) throw new Error('PubMed search failed');
+  try {
+    const response = await fetch('/api/plugins/pubmed/search', {
+      body: JSON.stringify({ maxResults, offset, query }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    });
+    if (!response.ok) throw new Error('PubMed search failed');
 
-        const data = await response.json();
-        const articles = data.articles || [];
-        return articles.map((a: any) => ({
-            abstract: a.abstract,
-            authors: (a.authors || []).join(', '),
-            citations: undefined,
-            doi: a.doi,
-            doiUrl: a.doiUrl,
-            id: `pubmed-${a.pmid}`,
-            journal: a.journal,
-            pubmedUrl: a.pubmedUrl,
-            source: 'PubMed' as const,
-            title: a.title,
-            year: a.pubDate ? new Date(a.pubDate).getFullYear() : 0,
-        }));
-    } catch (error) {
-        console.error('[Research] PubMed search error:', error);
-        return [];
-    }
+    const data = await response.json();
+    const articles = data.articles || [];
+    return articles.map((a: any) => ({
+      abstract: a.abstract,
+      authors: (a.authors || []).join(', '),
+      citations: undefined,
+      doi: a.doi,
+      doiUrl: a.doiUrl,
+      id: `pubmed-${a.pmid}`,
+      journal: a.journal,
+      pubmedUrl: a.pubmedUrl,
+      source: 'PubMed' as const,
+      title: a.title,
+      year: a.pubDate ? new Date(a.pubDate).getFullYear() : 0,
+    }));
+  } catch (error) {
+    console.error('[Research] PubMed search error:', error);
+    return [];
+  }
 };
 
-const searchOpenAlex = async (query: string, maxResults = 10, offset = 0): Promise<PaperResult[]> => {
-    try {
-        const response = await fetch('/api/plugins/openalex/search', {
-            body: JSON.stringify({ maxResults, offset, query }),
-            headers: { 'Content-Type': 'application/json' },
-            method: 'POST',
-        });
-        if (!response.ok) throw new Error('OpenAlex search failed');
+const searchOpenAlex = async (
+  query: string,
+  maxResults = 10,
+  offset = 0,
+): Promise<PaperResult[]> => {
+  try {
+    const response = await fetch('/api/plugins/openalex/search', {
+      body: JSON.stringify({ maxResults, offset, query }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    });
+    if (!response.ok) throw new Error('OpenAlex search failed');
 
-        const data = await response.json();
-        const articles = data.articles || [];
-        return articles.map((a: any) => ({
-            authors: a.firstAuthor || 'Unknown',
-            citations: a.citedByCount,
-            doi: a.doi,
-            doiUrl: a.doiUrl,
-            id: `openalex-${a.doi || a.title}`,
-            isOpenAccess: a.isOpenAccess,
-            journal: a.journal,
-            source: 'OpenAlex' as const,
-            title: a.title,
-            year: a.year || 0,
-        }));
-    } catch (error) {
-        console.error('[Research] OpenAlex search error:', error);
-        return [];
-    }
+    const data = await response.json();
+    const articles = data.articles || [];
+    return articles.map((a: any) => ({
+      authors: a.firstAuthor || 'Unknown',
+      citations: a.citedByCount,
+      doi: a.doi,
+      doiUrl: a.doiUrl,
+      id: `openalex-${a.doi || a.title}`,
+      isOpenAccess: a.isOpenAccess,
+      journal: a.journal,
+      source: 'OpenAlex' as const,
+      title: a.title,
+      year: a.year || 0,
+    }));
+  } catch (error) {
+    console.error('[Research] OpenAlex search error:', error);
+    return [];
+  }
 };
 
 const searchArXiv = async (query: string, maxResults = 10, offset = 0): Promise<PaperResult[]> => {
-    try {
-        const response = await fetch('/api/plugins/arxiv/search', {
-            body: JSON.stringify({ maxResults, offset, query }),
-            headers: { 'Content-Type': 'application/json' },
-            method: 'POST',
-        });
-        if (!response.ok) throw new Error('ArXiv search failed');
+  try {
+    const response = await fetch('/api/plugins/arxiv/search', {
+      body: JSON.stringify({ maxResults, offset, query }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    });
+    if (!response.ok) throw new Error('ArXiv search failed');
 
-        const data = await response.json();
-        const papers = data.papers || [];
-        return papers.map((a: any) => ({
-            abstract: a.abstract,
-            authors: (a.authors || []).join(', '),
-            citations: undefined,
-            doi: a.doi,
-            doiUrl: a.doi ? `https://doi.org/${a.doi}` : undefined,
-            id: `arxiv-${a.arxivId}`,
-            journal: `arXiv:${a.arxivId}`,
-            pubmedUrl: `https://arxiv.org/abs/${a.arxivId}`,
-            source: 'ArXiv' as const,
-            title: a.title,
-            year: a.published ? new Date(a.published).getFullYear() : 0,
-        }));
-    } catch (error) {
-        console.error('[Research] ArXiv search error:', error);
-        return [];
-    }
+    const data = await response.json();
+    const papers = data.papers || [];
+    return papers.map((a: any) => ({
+      abstract: a.abstract,
+      authors: (a.authors || []).join(', '),
+      citations: undefined,
+      doi: a.doi,
+      doiUrl: a.doi ? `https://doi.org/${a.doi}` : undefined,
+      id: `arxiv-${a.arxivId}`,
+      journal: `arXiv:${a.arxivId}`,
+      pubmedUrl: `https://arxiv.org/abs/${a.arxivId}`,
+      source: 'ArXiv' as const,
+      title: a.title,
+      year: a.published ? new Date(a.published).getFullYear() : 0,
+    }));
+  } catch (error) {
+    console.error('[Research] ArXiv search error:', error);
+    return [];
+  }
 };
 
 // ========== ClinicalTrials.gov ==========
 
-const searchClinicalTrials = async (query: string, maxResults = 10, offset = 0): Promise<PaperResult[]> => {
-    try {
-        const response = await fetch('/api/plugins/clinical-trials/search', {
-            body: JSON.stringify({ maxResults, offset, query }),
-            headers: { 'Content-Type': 'application/json' },
-            method: 'POST',
-        });
-        if (!response.ok) throw new Error('ClinicalTrials.gov search failed');
+const searchClinicalTrials = async (
+  query: string,
+  maxResults = 10,
+  offset = 0,
+): Promise<PaperResult[]> => {
+  try {
+    const response = await fetch('/api/plugins/clinical-trials/search', {
+      body: JSON.stringify({ maxResults, offset, query }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    });
+    if (!response.ok) throw new Error('ClinicalTrials.gov search failed');
 
-        const data = await response.json();
-        const trials = data.trials || [];
-        return trials.map((t: any) => ({
-            abstract: [
-                t.status ? `Status: ${t.status}` : '',
-                t.phase && t.phase !== 'N/A' ? `Phase: ${t.phase}` : '',
-                t.enrollmentCount ? `Enrollment: ${t.enrollmentCount} participants` : '',
-                t.conditions?.length ? `Conditions: ${t.conditions.slice(0, 3).join(', ')}` : '',
-                t.interventions?.length ? `Interventions: ${t.interventions.slice(0, 3).join(', ')}` : '',
-                t.eligibility ? t.eligibility : '',
-            ].filter(Boolean).join(' | '),
-            authors: t.sponsor || 'Unknown sponsor',
-            citations: t.enrollmentCount,
-            doi: undefined,
-            doiUrl: t.url,
-            id: `ct-${t.nctId}`,
-            journal: `ClinicalTrials.gov · ${t.nctId}`,
-            pubmedUrl: t.url,
-            source: 'ClinicalTrials.gov' as const,
-            title: t.title,
-            year: t.startDate ? new Date(t.startDate).getFullYear() : new Date().getFullYear(),
-        }));
-    } catch (error) {
-        console.error('[Research] ClinicalTrials.gov search error:', error);
-        return [];
-    }
+    const data = await response.json();
+    const trials = data.trials || [];
+    return trials.map((t: any) => ({
+      abstract: [
+        t.status ? `Status: ${t.status}` : '',
+        t.phase && t.phase !== 'N/A' ? `Phase: ${t.phase}` : '',
+        t.enrollmentCount ? `Enrollment: ${t.enrollmentCount} participants` : '',
+        t.conditions?.length ? `Conditions: ${t.conditions.slice(0, 3).join(', ')}` : '',
+        t.interventions?.length ? `Interventions: ${t.interventions.slice(0, 3).join(', ')}` : '',
+        t.eligibility ? t.eligibility : '',
+      ]
+        .filter(Boolean)
+        .join(' | '),
+      authors: t.sponsor || 'Unknown sponsor',
+      citations: t.enrollmentCount,
+      doi: undefined,
+      doiUrl: t.url,
+      id: `ct-${t.nctId}`,
+      journal: `ClinicalTrials.gov · ${t.nctId}`,
+      pubmedUrl: t.url,
+      source: 'ClinicalTrials.gov' as const,
+      title: t.title,
+      year: t.startDate ? new Date(t.startDate).getFullYear() : new Date().getFullYear(),
+    }));
+  } catch (error) {
+    console.error('[Research] ClinicalTrials.gov search error:', error);
+    return [];
+  }
 };
 
 // ========== Store ==========
 
 export const useResearchStore = create<ResearchState>()(
-    devtools(
-        persist(
-            (set, get) => ({
-                ...initialState,
+  devtools(
+    persist(
+      (set, get) => ({
+        ...initialState,
 
-                addPaper: (paper: PaperResult) => {
-                    const { papers, screeningDecisions } = get();
-                    // Avoid duplicates by id
-                    if (papers.some((p) => p.id === paper.id)) return;
-                    set({
-                        papers: [paper, ...papers],
-                        // Auto-include the manually added paper
-                        screeningDecisions: {
-                            ...screeningDecisions,
-                            [paper.id]: { decision: 'included', paperId: paper.id, reason: 'Manually added via DOI resolver' },
-                        },
-                        totalResults: papers.length + 1,
-                    }, false, 'addPaper');
-                },
-
-                addPapers: (toAdd: PaperResult[]) => {
-                    const { papers, screeningDecisions } = get();
-                    const existingIds = new Set(papers.map((p) => p.id));
-                    const newPapers = toAdd.filter((p) => !existingIds.has(p.id));
-                    if (newPapers.length === 0) return;
-                    const newDecisions = { ...screeningDecisions };
-                    for (const p of newPapers) {
-                        newDecisions[p.id] = { decision: 'pending', paperId: p.id, reason: 'Imported via RIS/BibTeX' };
-                    }
-                    set({
-                        papers: [...newPapers, ...papers],
-                        screeningDecisions: newDecisions,
-                        totalResults: papers.length + newPapers.length,
-                    }, false, 'addPapers');
-                },
-
-                autoScreenByCitations: (minCitations) => {
-                    const { papers, screeningDecisions } = get();
-                    const updated = { ...screeningDecisions };
-                    for (const paper of papers) {
-                        if ((paper.citations || 0) < minCitations) {
-                            updated[paper.id] = { decision: 'excluded', paperId: paper.id, reason: `< ${minCitations} citations` };
-                        }
-                    }
-                    set({ screeningCriteria: { ...get().screeningCriteria, minCitations }, screeningDecisions: updated }, false, 'autoScreenByCitations');
-                },
-
-                autoScreenByYearRange: (yearFrom, yearTo) => {
-                    const { papers, screeningDecisions } = get();
-                    const updated = { ...screeningDecisions };
-                    for (const paper of papers) {
-                        if (paper.year < yearFrom || paper.year > yearTo) {
-                            updated[paper.id] = { decision: 'excluded', paperId: paper.id, reason: `Outside ${yearFrom}-${yearTo}` };
-                        }
-                    }
-                    set({ screeningCriteria: { ...get().screeningCriteria, yearFrom, yearTo }, screeningDecisions: updated }, false, 'autoScreenByYearRange');
-                },
-
-                excludeAllPapers: () => {
-                    const { papers } = get();
-                    const decisions: Record<string, ScreeningEntry> = {};
-                    for (const paper of papers) {
-                        decisions[paper.id] = { decision: 'excluded', paperId: paper.id };
-                    }
-                    set({ screeningDecisions: decisions }, false, 'excludeAllPapers');
-                },
-
-                extractPICO: async (query) => {
-                    const { translatedQuery } = get();
-                    // Prefer the English translated query when available — keyword
-                    // matching against MeSH-style terminology is far more reliable.
-                    const queryForExtraction = translatedQuery || query;
-                    const result = await llmExtractPICO(queryForExtraction, callAI, TRANSLATE_MODEL);
-                    set({ pico: result.pico }, false, 'extractPICO');
-                },
-
-                getExcludedPapers: () => {
-                    const { papers, screeningDecisions } = get();
-                    return papers.filter((p) => screeningDecisions[p.id]?.decision === 'excluded');
-                },
-
-                getIncludedPapers: () => {
-                    const { papers, screeningDecisions } = get();
-                    return papers.filter((p) => screeningDecisions[p.id]?.decision === 'included');
-                },
-
-                getPendingPapers: () => {
-                    const { papers, screeningDecisions } = get();
-                    return papers.filter((p) => !screeningDecisions[p.id] || screeningDecisions[p.id]?.decision === 'pending');
-                },
-
-                getScreeningStats: () => {
-                    const { papers, screeningDecisions } = get();
-                    let included = 0;
-                    let excluded = 0;
-                    for (const paper of papers) {
-                        const d = screeningDecisions[paper.id]?.decision;
-                        if (d === 'included') included++;
-                        else if (d === 'excluded') excluded++;
-                    }
-                    return { excluded, included, pending: papers.length - included - excluded, total: papers.length };
-                },
-
-                includeAllPapers: () => {
-                    const { papers } = get();
-                    const decisions: Record<string, ScreeningEntry> = {};
-                    for (const paper of papers) {
-                        decisions[paper.id] = { decision: 'included', paperId: paper.id };
-                    }
-                    set({ screeningDecisions: decisions }, false, 'includeAllPapers');
-                },
-
-                loadMoreResults: async () => {
-                    const { currentPage, isLoadingMore, searchQuery, selectedSources, papers, translatedQuery } = get();
-                    if (isLoadingMore || !searchQuery) return;
-
-                    // Reuse the same English query as the initial search so
-                    // pagination doesn't suddenly switch to raw VN and return
-                    // unrelated results.
-                    const queryToUse = translatedQuery || searchQuery;
-                    const nextPage = currentPage + 1;
-                    const offset = currentPage * 10;
-                    set({ isLoadingMore: true }, false, 'loadMoreResults/start');
-
-                    try {
-                        const promises: Promise<PaperResult[]>[] = [];
-                        if (selectedSources.includes('PubMed')) promises.push(searchPubMed(queryToUse, 10, offset));
-                        if (selectedSources.includes('OpenAlex')) promises.push(searchOpenAlex(queryToUse, 10, offset));
-                        if (selectedSources.includes('ArXiv')) promises.push(searchArXiv(queryToUse, 10, offset));
-                        if (selectedSources.includes('ClinicalTrials.gov')) promises.push(searchClinicalTrials(queryToUse, 10, offset));
-
-                        const results = await Promise.allSettled(promises);
-                        const newPapers: PaperResult[] = [];
-                        const seenKeys = new Set(papers.map((p) => p.doi || p.title));
-
-                        for (const result of results) {
-                            if (result.status === 'fulfilled') {
-                                for (const paper of result.value) {
-                                    const key = paper.doi || paper.title;
-                                    if (!seenKeys.has(key)) {
-                                        seenKeys.add(key);
-                                        newPapers.push(paper);
-                                    }
-                                }
-                            }
-                        }
-
-                        const combined = [...papers, ...newPapers];
-                        combined.sort((a, b) => {
-                            if ((b.citations || 0) !== (a.citations || 0)) return (b.citations || 0) - (a.citations || 0);
-                            return b.year - a.year;
-                        });
-
-                        set({
-                            currentPage: nextPage,
-                            hasMore: newPapers.length >= 10,
-                            isLoadingMore: false,
-                            papers: combined,
-                            totalResults: combined.length,
-                        }, false, 'loadMoreResults/done');
-                    } catch {
-                        set({ isLoadingMore: false }, false, 'loadMoreResults/error');
-                    }
-                },
-
-                removePapers: (ids: string[]) => {
-                    const { papers, screeningDecisions } = get();
-                    const removeSet = new Set(ids);
-                    const remaining = papers.filter((p) => !removeSet.has(p.id));
-                    const newDecisions = { ...screeningDecisions };
-                    for (const id of ids) delete newDecisions[id];
-                    set({
-                        papers: remaining,
-                        screeningDecisions: newDecisions,
-                        totalResults: remaining.length,
-                    }, false, 'removePapers');
-                },
-
-                reset: () => {
-                    set(initialState, false, 'reset');
-                },
-
-                resetScreening: () => {
-                    set({ screeningDecisions: {} }, false, 'resetScreening');
-                },
-
-                screenPaper: (paperId, decision, reason) => {
-                    const { screeningDecisions } = get();
-                    set({
-                        screeningDecisions: {
-                            ...screeningDecisions,
-                            [paperId]: { decision, paperId, reason },
-                        },
-                    }, false, 'screenPaper');
-                },
-
-                searchPapers: async (query) => {
-                    const { selectedSources } = get();
-                    set({
-                        currentPage: 1,
-                        detectedLanguage: null,
-                        hasMore: true,
-                        isSearching: true,
-                        noPapersFound: false,
-                        searchError: null,
-                        searchQuery: query,
-                        translatedQuery: null,
-                    }, false, 'searchPapers/start');
-
-                    try {
-                        // Step 1 — translate VN → EN (Bug A). EN/other passes through unchanged.
-                        const queryInfo = await buildSearchQuery(query, callAI, TRANSLATE_MODEL);
-                        const finalQuery = queryInfo.searchQuery;
-
-                        set({
-                            detectedLanguage: queryInfo.detectedLanguage,
-                            translatedQuery: queryInfo.translated ? queryInfo.searchQuery : null,
-                        }, false, 'searchPapers/translated');
-
-                        (window as any).posthog?.capture('research_query_translated', {
-                            detected_language: queryInfo.detectedLanguage,
-                            duration_ms: queryInfo.durationMs,
-                            fell_back_to_original: queryInfo.fellBackToOriginal,
-                            original_query: queryInfo.originalQuery.slice(0, 200),
-                            surface: 'research_mode',
-                            translated: queryInfo.translated,
-                            translated_query: queryInfo.searchQuery.slice(0, 200),
-                        });
-
-                        // Step 2 — fan out to selected sources using the (possibly translated) query.
-                        const sourceOrder: SearchSource[] = ['PubMed', 'OpenAlex', 'ArXiv', 'ClinicalTrials.gov'];
-                        const fetchers: Record<SearchSource, (_q: string) => Promise<PaperResult[]>> = {
-                            ArXiv: (q) => searchArXiv(q),
-                            'ClinicalTrials.gov': (q) => searchClinicalTrials(q),
-                            OpenAlex: (q) => searchOpenAlex(q),
-                            PubMed: (q) => searchPubMed(q),
-                        };
-                        const usedSources = sourceOrder.filter((s) => selectedSources.includes(s));
-                        const results = await Promise.allSettled(usedSources.map((s) => fetchers[s](finalQuery)));
-
-                        const allPapers: PaperResult[] = [];
-                        const seenKeys = new Set<string>();
-                        const sourceTracker: Record<string, number> = {};
-
-                        for (const [idx, source] of usedSources.entries()) {
-                            const result = results[idx];
-                            if (result?.status === 'fulfilled') {
-                                sourceTracker[source] = result.value.length;
-                                for (const paper of result.value) {
-                                    const key = paper.doi || paper.title;
-                                    if (!seenKeys.has(key)) {
-                                        seenKeys.add(key);
-                                        allPapers.push(paper);
-                                    }
-                                }
-                            } else {
-                                sourceTracker[source] = 0;
-                            }
-                        }
-
-                        allPapers.sort((a, b) => {
-                            if ((b.citations || 0) !== (a.citations || 0)) return (b.citations || 0) - (a.citations || 0);
-                            return b.year - a.year;
-                        });
-
-                        const hasMore = allPapers.length >= 10;
-
-                        (window as any).posthog?.capture('research_papers_found', {
-                            detected_language: queryInfo.detectedLanguage,
-                            original_question: queryInfo.originalQuery.slice(0, 200),
-                            paper_count: allPapers.length,
-                            papers_per_source: sourceTracker,
-                            sources: Array.from(selectedSources),
-                            surface: 'research_mode',
-                            translated_query: queryInfo.searchQuery.slice(0, 200),
-                        });
-
-                        if (allPapers.length === 0) {
-                            set({
-                                hasMore: false,
-                                isSearching: false,
-                                noPapersFound: true,
-                                papers: [],
-                                screeningDecisions: {},
-                                totalResults: 0,
-                            }, false, 'searchPapers/noPapers');
-
-                            (window as any).posthog?.capture('research_no_papers', {
-                                original_question: queryInfo.originalQuery.slice(0, 200),
-                                sources: Array.from(selectedSources),
-                                surface: 'research_mode',
-                                translated_query: queryInfo.searchQuery.slice(0, 200),
-                            });
-                            return;
-                        }
-
-                        set({
-                            hasMore,
-                            isSearching: false,
-                            noPapersFound: false,
-                            papers: allPapers,
-                            screeningDecisions: {},
-                            totalResults: allPapers.length,
-                        }, false, 'searchPapers/done');
-                    } catch (e) {
-                        console.error('[searchPapers] error', e);
-                        set({ isSearching: false, searchError: 'Search failed. Please try again.' }, false, 'searchPapers/error');
-                    }
-                },
-
-                setActivePhase: (phase) => set({ activePhase: phase }, false, 'setActivePhase'),
-                setSearchQuery: (query) => set({ searchQuery: query }, false, 'setSearchQuery'),
-
-                toggleSource: (source) => {
-                    const { selectedSources } = get();
-                    const newSources = selectedSources.includes(source)
-                        ? selectedSources.filter((s) => s !== source)
-                        : [...selectedSources, source];
-                    set({ selectedSources: newSources }, false, 'toggleSource');
-                },
-
-                updateScreeningCriteria: (criteria) => {
-                    set({ screeningCriteria: { ...get().screeningCriteria, ...criteria } }, false, 'updateScreeningCriteria');
-                },
-            }),
+        addPaper: (paper: PaperResult) => {
+          const { papers, screeningDecisions } = get();
+          // Avoid duplicates by id
+          if (papers.some((p) => p.id === paper.id)) return;
+          set(
             {
-                name: 'pho-research-store',
-                partialize: (state) => ({
-                    activePhase: state.activePhase,
-                    papers: state.papers,
-                    pico: state.pico,
-                    screeningCriteria: state.screeningCriteria,
-                    screeningDecisions: state.screeningDecisions,
-                    searchQuery: state.searchQuery,
-                    selectedSources: state.selectedSources,
-                    totalResults: state.totalResults,
-                }),
+              papers: [paper, ...papers],
+              // Auto-include the manually added paper
+              screeningDecisions: {
+                ...screeningDecisions,
+                [paper.id]: {
+                  decision: 'included',
+                  paperId: paper.id,
+                  reason: 'Manually added via DOI resolver',
+                },
+              },
+              totalResults: papers.length + 1,
             },
-        ),
-        { name: 'ResearchStore' },
+            false,
+            'addPaper',
+          );
+        },
+
+        addPapers: (toAdd: PaperResult[]) => {
+          const { papers, screeningDecisions } = get();
+          const existingIds = new Set(papers.map((p) => p.id));
+          const newPapers = toAdd.filter((p) => !existingIds.has(p.id));
+          if (newPapers.length === 0) return;
+          const newDecisions = { ...screeningDecisions };
+          for (const p of newPapers) {
+            newDecisions[p.id] = {
+              decision: 'pending',
+              paperId: p.id,
+              reason: 'Imported via RIS/BibTeX',
+            };
+          }
+          set(
+            {
+              papers: [...newPapers, ...papers],
+              screeningDecisions: newDecisions,
+              totalResults: papers.length + newPapers.length,
+            },
+            false,
+            'addPapers',
+          );
+        },
+
+        autoScreenByCitations: (minCitations) => {
+          const { papers, screeningDecisions } = get();
+          const updated = { ...screeningDecisions };
+          for (const paper of papers) {
+            if ((paper.citations || 0) < minCitations) {
+              updated[paper.id] = {
+                decision: 'excluded',
+                paperId: paper.id,
+                reason: `< ${minCitations} citations`,
+              };
+            }
+          }
+          set(
+            {
+              screeningCriteria: { ...get().screeningCriteria, minCitations },
+              screeningDecisions: updated,
+            },
+            false,
+            'autoScreenByCitations',
+          );
+        },
+
+        autoScreenByYearRange: (yearFrom, yearTo) => {
+          const { papers, screeningDecisions } = get();
+          const updated = { ...screeningDecisions };
+          for (const paper of papers) {
+            if (paper.year < yearFrom || paper.year > yearTo) {
+              updated[paper.id] = {
+                decision: 'excluded',
+                paperId: paper.id,
+                reason: `Outside ${yearFrom}-${yearTo}`,
+              };
+            }
+          }
+          set(
+            {
+              screeningCriteria: { ...get().screeningCriteria, yearFrom, yearTo },
+              screeningDecisions: updated,
+            },
+            false,
+            'autoScreenByYearRange',
+          );
+        },
+
+        excludeAllPapers: () => {
+          const { papers } = get();
+          const decisions: Record<string, ScreeningEntry> = {};
+          for (const paper of papers) {
+            decisions[paper.id] = { decision: 'excluded', paperId: paper.id };
+          }
+          set({ screeningDecisions: decisions }, false, 'excludeAllPapers');
+        },
+
+        extractPICO: async (query) => {
+          const { translatedQuery } = get();
+          // Prefer the English translated query when available — keyword
+          // matching against MeSH-style terminology is far more reliable.
+          const queryForExtraction = translatedQuery || query;
+          const result = await llmExtractPICO(queryForExtraction, callAI, TRANSLATE_MODEL);
+          set({ pico: result.pico }, false, 'extractPICO');
+        },
+
+        getExcludedPapers: () => {
+          const { papers, screeningDecisions } = get();
+          return papers.filter((p) => screeningDecisions[p.id]?.decision === 'excluded');
+        },
+
+        getIncludedPapers: () => {
+          const { papers, screeningDecisions } = get();
+          return papers.filter((p) => screeningDecisions[p.id]?.decision === 'included');
+        },
+
+        getPendingPapers: () => {
+          const { papers, screeningDecisions } = get();
+          return papers.filter(
+            (p) => !screeningDecisions[p.id] || screeningDecisions[p.id]?.decision === 'pending',
+          );
+        },
+
+        getScreeningStats: () => {
+          const { papers, screeningDecisions } = get();
+          let included = 0;
+          let excluded = 0;
+          for (const paper of papers) {
+            const d = screeningDecisions[paper.id]?.decision;
+            if (d === 'included') included++;
+            else if (d === 'excluded') excluded++;
+          }
+          return {
+            excluded,
+            included,
+            pending: papers.length - included - excluded,
+            total: papers.length,
+          };
+        },
+
+        includeAllPapers: () => {
+          const { papers } = get();
+          const decisions: Record<string, ScreeningEntry> = {};
+          for (const paper of papers) {
+            decisions[paper.id] = { decision: 'included', paperId: paper.id };
+          }
+          set({ screeningDecisions: decisions }, false, 'includeAllPapers');
+        },
+
+        loadMoreResults: async () => {
+          const {
+            currentPage,
+            isLoadingMore,
+            searchQuery,
+            selectedSources,
+            papers,
+            translatedQuery,
+          } = get();
+          if (isLoadingMore || !searchQuery) return;
+
+          // Reuse the same English query as the initial search so
+          // pagination doesn't suddenly switch to raw VN and return
+          // unrelated results.
+          const queryToUse = translatedQuery || searchQuery;
+          const nextPage = currentPage + 1;
+          const offset = currentPage * 10;
+          set({ isLoadingMore: true }, false, 'loadMoreResults/start');
+
+          try {
+            const promises: Promise<PaperResult[]>[] = [];
+            if (selectedSources.includes('PubMed'))
+              promises.push(searchPubMed(queryToUse, 10, offset));
+            if (selectedSources.includes('OpenAlex'))
+              promises.push(searchOpenAlex(queryToUse, 10, offset));
+            if (selectedSources.includes('ArXiv'))
+              promises.push(searchArXiv(queryToUse, 10, offset));
+            if (selectedSources.includes('ClinicalTrials.gov'))
+              promises.push(searchClinicalTrials(queryToUse, 10, offset));
+
+            const results = await Promise.allSettled(promises);
+            const newPapers: PaperResult[] = [];
+            const seenKeys = new Set(papers.map((p) => p.doi || p.title));
+
+            for (const result of results) {
+              if (result.status === 'fulfilled') {
+                for (const paper of result.value) {
+                  const key = paper.doi || paper.title;
+                  if (!seenKeys.has(key)) {
+                    seenKeys.add(key);
+                    newPapers.push(paper);
+                  }
+                }
+              }
+            }
+
+            const combined = [...papers, ...newPapers];
+            combined.sort((a, b) => {
+              if ((b.citations || 0) !== (a.citations || 0))
+                return (b.citations || 0) - (a.citations || 0);
+              return b.year - a.year;
+            });
+
+            set(
+              {
+                currentPage: nextPage,
+                hasMore: newPapers.length >= 10,
+                isLoadingMore: false,
+                papers: combined,
+                totalResults: combined.length,
+              },
+              false,
+              'loadMoreResults/done',
+            );
+          } catch {
+            set({ isLoadingMore: false }, false, 'loadMoreResults/error');
+          }
+        },
+
+        removePapers: (ids: string[]) => {
+          const { papers, screeningDecisions } = get();
+          const removeSet = new Set(ids);
+          const remaining = papers.filter((p) => !removeSet.has(p.id));
+          const newDecisions = { ...screeningDecisions };
+          for (const id of ids) delete newDecisions[id];
+          set(
+            {
+              papers: remaining,
+              screeningDecisions: newDecisions,
+              totalResults: remaining.length,
+            },
+            false,
+            'removePapers',
+          );
+        },
+
+        reset: () => {
+          set(initialState, false, 'reset');
+        },
+
+        resetScreening: () => {
+          set({ screeningDecisions: {} }, false, 'resetScreening');
+        },
+
+        screenPaper: (paperId, decision, reason) => {
+          const { screeningDecisions } = get();
+          set(
+            {
+              screeningDecisions: {
+                ...screeningDecisions,
+                [paperId]: { decision, paperId, reason },
+              },
+            },
+            false,
+            'screenPaper',
+          );
+        },
+
+        searchPapers: async (query) => {
+          const { selectedSources } = get();
+          set(
+            {
+              currentPage: 1,
+              detectedLanguage: null,
+              hasMore: true,
+              isSearching: true,
+              noPapersFound: false,
+              searchError: null,
+              searchQuery: query,
+              translatedQuery: null,
+            },
+            false,
+            'searchPapers/start',
+          );
+
+          try {
+            // Step 1 — translate VN → EN (Bug A). EN/other passes through unchanged.
+            const queryInfo = await buildSearchQuery(query, callAI, TRANSLATE_MODEL);
+            const finalQuery = queryInfo.searchQuery;
+
+            set(
+              {
+                detectedLanguage: queryInfo.detectedLanguage,
+                translatedQuery: queryInfo.translated ? queryInfo.searchQuery : null,
+              },
+              false,
+              'searchPapers/translated',
+            );
+
+            (window as any).posthog?.capture('research_query_translated', {
+              detected_language: queryInfo.detectedLanguage,
+              duration_ms: queryInfo.durationMs,
+              fell_back_to_original: queryInfo.fellBackToOriginal,
+              original_query: queryInfo.originalQuery.slice(0, 200),
+              surface: 'research_mode',
+              translated: queryInfo.translated,
+              translated_query: queryInfo.searchQuery.slice(0, 200),
+            });
+
+            // Step 2 — fan out to selected sources using the (possibly translated) query.
+            const sourceOrder: SearchSource[] = [
+              'PubMed',
+              'OpenAlex',
+              'ArXiv',
+              'ClinicalTrials.gov',
+            ];
+            const fetchers: Record<SearchSource, (_q: string) => Promise<PaperResult[]>> = {
+              'ArXiv': (q) => searchArXiv(q),
+              'ClinicalTrials.gov': (q) => searchClinicalTrials(q),
+              'OpenAlex': (q) => searchOpenAlex(q),
+              'PubMed': (q) => searchPubMed(q),
+            };
+            const usedSources = sourceOrder.filter((s) => selectedSources.includes(s));
+            const results = await Promise.allSettled(
+              usedSources.map((s) => fetchers[s](finalQuery)),
+            );
+
+            const allPapers: PaperResult[] = [];
+            const seenKeys = new Set<string>();
+            const sourceTracker: Record<string, number> = {};
+
+            for (const [idx, source] of usedSources.entries()) {
+              const result = results[idx];
+              if (result?.status === 'fulfilled') {
+                sourceTracker[source] = result.value.length;
+                for (const paper of result.value) {
+                  const key = paper.doi || paper.title;
+                  if (!seenKeys.has(key)) {
+                    seenKeys.add(key);
+                    allPapers.push(paper);
+                  }
+                }
+              } else {
+                sourceTracker[source] = 0;
+              }
+            }
+
+            allPapers.sort((a, b) => {
+              if ((b.citations || 0) !== (a.citations || 0))
+                return (b.citations || 0) - (a.citations || 0);
+              return b.year - a.year;
+            });
+
+            const hasMore = allPapers.length >= 10;
+
+            (window as any).posthog?.capture('research_papers_found', {
+              detected_language: queryInfo.detectedLanguage,
+              original_question: queryInfo.originalQuery.slice(0, 200),
+              paper_count: allPapers.length,
+              papers_per_source: sourceTracker,
+              sources: Array.from(selectedSources),
+              surface: 'research_mode',
+              translated_query: queryInfo.searchQuery.slice(0, 200),
+            });
+
+            if (allPapers.length === 0) {
+              set(
+                {
+                  hasMore: false,
+                  isSearching: false,
+                  noPapersFound: true,
+                  papers: [],
+                  screeningDecisions: {},
+                  totalResults: 0,
+                },
+                false,
+                'searchPapers/noPapers',
+              );
+
+              (window as any).posthog?.capture('research_no_papers', {
+                original_question: queryInfo.originalQuery.slice(0, 200),
+                sources: Array.from(selectedSources),
+                surface: 'research_mode',
+                translated_query: queryInfo.searchQuery.slice(0, 200),
+              });
+              return;
+            }
+
+            set(
+              {
+                hasMore,
+                isSearching: false,
+                noPapersFound: false,
+                papers: allPapers,
+                screeningDecisions: {},
+                totalResults: allPapers.length,
+              },
+              false,
+              'searchPapers/done',
+            );
+          } catch (e) {
+            console.error('[searchPapers] error', e);
+            set(
+              { isSearching: false, searchError: 'Search failed. Please try again.' },
+              false,
+              'searchPapers/error',
+            );
+          }
+        },
+
+        setActivePhase: (phase) => set({ activePhase: phase }, false, 'setActivePhase'),
+        setSearchQuery: (query) => set({ searchQuery: query }, false, 'setSearchQuery'),
+
+        toggleSource: (source) => {
+          const { selectedSources } = get();
+          const newSources = selectedSources.includes(source)
+            ? selectedSources.filter((s) => s !== source)
+            : [...selectedSources, source];
+          set({ selectedSources: newSources }, false, 'toggleSource');
+        },
+
+        updateScreeningCriteria: (criteria) => {
+          set(
+            { screeningCriteria: { ...get().screeningCriteria, ...criteria } },
+            false,
+            'updateScreeningCriteria',
+          );
+        },
+      }),
+      {
+        name: 'pho-research-store',
+        partialize: (state) => ({
+          activePhase: state.activePhase,
+          papers: state.papers,
+          pico: state.pico,
+          screeningCriteria: state.screeningCriteria,
+          screeningDecisions: state.screeningDecisions,
+          searchQuery: state.searchQuery,
+          selectedSources: state.selectedSources,
+          totalResults: state.totalResults,
+        }),
+      },
     ),
+    { name: 'ResearchStore' },
+  ),
 );

--- a/src/utils/research/__tests__/buildSearchQuery.test.ts
+++ b/src/utils/research/__tests__/buildSearchQuery.test.ts
@@ -3,101 +3,126 @@ import { describe, expect, it, vi } from 'vitest';
 import { buildSearchQuery, detectLanguage } from '../buildSearchQuery';
 
 describe('detectLanguage', () => {
-    it('returns "en" for plain ASCII English', () => {
-        expect(detectLanguage('hello world')).toBe('en');
-    });
+  it('returns "en" for plain ASCII English', () => {
+    expect(detectLanguage('hello world')).toBe('en');
+  });
 
-    it('returns "vi" for Vietnamese with diacritics', () => {
-        expect(detectLanguage('xin chào bác sĩ')).toBe('vi');
-    });
+  it('returns "vi" for Vietnamese with diacritics', () => {
+    expect(detectLanguage('xin chào bác sĩ')).toBe('vi');
+  });
 
-    it('returns "other" for non-ASCII non-Vietnamese (e.g. Chinese)', () => {
-        expect(detectLanguage('北京大学')).toBe('other');
-    });
+  it('returns "other" for non-ASCII non-Vietnamese (e.g. Chinese)', () => {
+    expect(detectLanguage('北京大学')).toBe('other');
+  });
 
-    it('returns "vi" for mixed EN/VN when any Vietnamese diacritic appears', () => {
-        expect(detectLanguage('GLP-1 và semaglutide')).toBe('vi');
-    });
+  it('returns "vi" for mixed EN/VN when any Vietnamese diacritic appears', () => {
+    expect(detectLanguage('GLP-1 và semaglutide')).toBe('vi');
+  });
 
-    it('returns "en" for empty string (no non-ASCII)', () => {
-        expect(detectLanguage('')).toBe('en');
-    });
+  it('returns "en" for empty string (no non-ASCII)', () => {
+    expect(detectLanguage('')).toBe('en');
+  });
 });
 
 describe('buildSearchQuery', () => {
-    const model = 'test-model';
+  const model = 'test-model';
 
-    it('returns the original query unchanged for English input (no callAI call)', async () => {
-        const callAI = vi.fn().mockResolvedValue('SHOULD_NOT_BE_USED');
-        const result = await buildSearchQuery('metformin diabetes prevention', callAI, model);
+  it('returns the original query unchanged for English input (no callAI call)', async () => {
+    const callAI = vi.fn().mockResolvedValue('SHOULD_NOT_BE_USED');
+    const result = await buildSearchQuery('metformin diabetes prevention', callAI, model);
 
-        expect(result.translated).toBe(false);
-        expect(result.searchQuery).toBe('metformin diabetes prevention');
-        expect(result.detectedLanguage).toBe('en');
-        expect(result.fellBackToOriginal).toBe(false);
-        expect(callAI).not.toHaveBeenCalled();
-    });
+    expect(result.translated).toBe(false);
+    expect(result.searchQuery).toBe('metformin diabetes prevention');
+    expect(result.detectedLanguage).toBe('en');
+    expect(result.fellBackToOriginal).toBe(false);
+    expect(callAI).not.toHaveBeenCalled();
+  });
 
-    it('translates Vietnamese input via callAI', async () => {
-        const callAI = vi
-            .fn()
-            .mockResolvedValue('liraglutide cardiovascular outcomes type 2 diabetes');
-        const result = await buildSearchQuery(
-            'liraglutide kết cục tim mạch ở bệnh nhân đái tháo đường tuýp 2',
-            callAI,
-            model,
-        );
+  it('translates Vietnamese input via callAI', async () => {
+    const callAI = vi.fn().mockResolvedValue('liraglutide cardiovascular outcomes type 2 diabetes');
+    const result = await buildSearchQuery(
+      'liraglutide kết cục tim mạch ở bệnh nhân đái tháo đường tuýp 2',
+      callAI,
+      model,
+    );
 
-        expect(result.translated).toBe(true);
-        expect(result.detectedLanguage).toBe('vi');
-        expect(result.searchQuery).toBe('liraglutide cardiovascular outcomes type 2 diabetes');
-        expect(result.fellBackToOriginal).toBe(false);
-        expect(callAI).toHaveBeenCalledTimes(1);
-    });
+    expect(result.translated).toBe(true);
+    expect(result.detectedLanguage).toBe('vi');
+    expect(result.searchQuery).toBe('liraglutide cardiovascular outcomes type 2 diabetes');
+    expect(result.fellBackToOriginal).toBe(false);
+    expect(callAI).toHaveBeenCalledTimes(1);
+  });
 
-    it('strips quotes, "Query:" prefix, and collapses whitespace from LLM output', async () => {
-        const callAI = vi
-            .fn()
-            .mockResolvedValue('  Query: "tirzepatide   weight loss obesity"  ');
-        const result = await buildSearchQuery(
-            'tirzepatide giảm cân ở bệnh nhân béo phì câu test sạch hóa',
-            callAI,
-            model,
-        );
+  it('strips quotes, "Query:" prefix, and collapses whitespace from LLM output', async () => {
+    const callAI = vi.fn().mockResolvedValue('  Query: "tirzepatide   weight loss obesity"  ');
+    const result = await buildSearchQuery(
+      'tirzepatide giảm cân ở bệnh nhân béo phì câu test sạch hóa',
+      callAI,
+      model,
+    );
 
-        expect(result.searchQuery).toBe('tirzepatide weight loss obesity');
-        expect(result.translated).toBe(true);
-    });
+    expect(result.searchQuery).toBe('tirzepatide weight loss obesity');
+    expect(result.translated).toBe(true);
+  });
 
-    it('falls back to the original Vietnamese query when callAI throws', async () => {
-        const callAI = vi.fn().mockRejectedValue(new Error('boom'));
-        const original = 'sàng lọc ung thư đại tràng nội soi (test fallback throw)';
-        const result = await buildSearchQuery(original, callAI, model);
+  it('falls back to the original Vietnamese query when callAI throws', async () => {
+    const callAI = vi.fn().mockRejectedValue(new Error('boom'));
+    const original = 'sàng lọc ung thư đại tràng nội soi (test fallback throw)';
+    const result = await buildSearchQuery(original, callAI, model);
 
-        expect(result.translated).toBe(false);
-        expect(result.fellBackToOriginal).toBe(true);
-        expect(result.searchQuery).toBe(original);
-        expect(result.detectedLanguage).toBe('vi');
-    });
+    expect(result.translated).toBe(false);
+    expect(result.fellBackToOriginal).toBe(true);
+    expect(result.searchQuery).toBe(original);
+    expect(result.detectedLanguage).toBe('vi');
+  });
 
-    it('falls back when LLM returns an empty / non-letter response', async () => {
-        const callAI = vi.fn().mockResolvedValue('   ');
-        const result = await buildSearchQuery(
-            'điều trị tăng huyết áp ở người cao tuổi (test empty)',
-            callAI,
-            model,
-        );
+  it('falls back when LLM returns an empty / non-letter response', async () => {
+    const callAI = vi.fn().mockResolvedValue('   ');
+    const result = await buildSearchQuery(
+      'điều trị tăng huyết áp ở người cao tuổi (test empty)',
+      callAI,
+      model,
+    );
 
-        expect(result.translated).toBe(false);
-        expect(result.fellBackToOriginal).toBe(true);
-    });
+    expect(result.translated).toBe(false);
+    expect(result.fellBackToOriginal).toBe(true);
+  });
 
-    it('returns input unchanged for empty string', async () => {
-        const callAI = vi.fn();
-        const result = await buildSearchQuery('', callAI, model);
+  it('returns input unchanged for empty string', async () => {
+    const callAI = vi.fn();
+    const result = await buildSearchQuery('', callAI, model);
 
-        expect(result.translated).toBe(false);
-        expect(result.searchQuery).toBe('');
-        expect(callAI).not.toHaveBeenCalled();
-    });
+    expect(result.translated).toBe(false);
+    expect(result.searchQuery).toBe('');
+    expect(callAI).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildSearchQuery cleanup (Phase 1.5.1)', () => {
+  const model = 'mock-model';
+
+  it('strips "stop" glued to last word', async () => {
+    const callAI = vi.fn().mockResolvedValue('GLP-1 mood effectsstop');
+    const result = await buildSearchQuery('khí sắc GLP-1', callAI, model);
+    expect(result.searchQuery).toBe('GLP-1 mood effects');
+    expect(result.translated).toBe(true);
+  });
+
+  it('preserves legitimate "stop" in mid-query (not at end)', async () => {
+    const callAI = vi.fn().mockResolvedValue('non-stop research');
+    const result = await buildSearchQuery('nghiên cứu liên tục', callAI, model);
+    expect(result.searchQuery).toBe('non-stop research');
+  });
+
+  it('strips chat-template <|im_end|> artifact', async () => {
+    const callAI = vi.fn().mockResolvedValue('metformin diabetes<|im_end|>');
+    const result = await buildSearchQuery('metformin tiểu đường', callAI, model);
+    expect(result.searchQuery).toBe('metformin diabetes');
+  });
+
+  it('strips </stop> XML-style closing tag', async () => {
+    const callAI = vi.fn().mockResolvedValue('aspirin prevention</stop>');
+    const result = await buildSearchQuery('aspirin phòng ngừa', callAI, model);
+    expect(result.searchQuery).toBe('aspirin prevention');
+  });
 });

--- a/src/utils/research/buildSearchQuery.ts
+++ b/src/utils/research/buildSearchQuery.ts
@@ -12,8 +12,7 @@
  */
 
 // Vietnamese-specific diacritics + đ/Đ. Presence of any of these = Vietnamese.
-const VIETNAMESE_REGEX =
-  /[À-ÃÈ-ÊÌÍÒ-ÕÙÚÝà-ãè-êìíò-õùúýĂăĐđĨĩŨũƠơƯưẠ-ỹ]/;
+const VIETNAMESE_REGEX = /[À-ÃÈ-ÊÌÍÒ-ÕÙÚÝà-ãè-êìíò-õùúýĂăĐđĨĩŨũƠơƯưẠ-ỹ]/;
 
 // Anything outside printable ASCII (U+0020..U+007E) is non-English-friendly.
 const NON_ASCII_REGEX = /[^\t\n\r -~]/;
@@ -113,8 +112,19 @@ export const buildSearchQuery = async (
     const cleaned = raw
       .replaceAll(/\s+/g, ' ')
       .trim()
+      // Strip leading prefixes the model loves to add ("Query:", "Search query:")
       .replace(/^(query|search query|english query)\s*:\s*/i, '')
+      // Strip surrounding quotes
       .replaceAll(/^["']|["']$/g, '')
+      // Strip trailing chat-template / stop-sequence artifacts. Production
+      // observed e.g. "GLP-1 ... effectsstop" (Gemini occasionally emits a
+      // bare "stop" glued to the last word) plus the usual <|im_end|> /
+      // <|endoftext|> / </stop> tokens. Conservative: the (\w)stop$ rule only
+      // strips when "stop" has a word char immediately before and is at the
+      // very end — so "non-stop" (dash) and "stop bleeding" (mid-query) are
+      // left alone.
+      .replace(/(<\|?im_end\|?>|<\|?endoftext\|?>|<\/?stop>)$/i, '')
+      .replace(/(\w)stop$/i, '$1')
       .trim()
       .slice(0, 240);
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix

#### 🔀 变更说明 | Description of Change

## Why

Phase 1.5 (PR #19) merged but production test on `pho.chat` revealed 4 bugs blocking BS Sơn rollout:

1. **CRITICAL — Research Mode `/api/chat/direct` endpoint doesn't exist.** Every translate / PICO / AI Writing / AI Screening call silently fell back. Predates Phase 1.5 (Writing/Screening were also broken; nobody noticed because of template fallbacks).
2. **HIGH — Zustand persist re-applies legacy 4-source default** (incl. ArXiv noise) for existing users — Phase 1.5's new ArXiv-off default had zero effect on returning users.
3. **MEDIUM — Translation output has trailing "stop" / chat-template artifacts** glued to the last word, e.g. `"...effectsstop"`, `"...<|im_end|>"`, `"...</stop>"`.
4. **MEDIUM — Deep Research gate UI shows "no papers" alongside 10 papers** due to useEffect race: instance #1 runs raw VN, sets noPapersFound=true; instance #2 runs translated, sets papers but never clears the flag.

## What

| Bug | Fix | Files |
|-----|-----|-------|
| #1 | Switch all Research Mode AI calls to `/api/research/ai-summary` (Clerk-auth, full billing/tier check). Body shape `{model, prompt, stream}`, response `{text}`. Explicit 401 / 402 / 403 error mapping. | `src/store/research/index.ts`, `src/features/Portal/Research/Body/{Writing,Screening}/index.tsx` |
| #2 | Persist `version: 2` + `migrate()` — auto-rewrite legacy 4-source default → new 3-source; preserve explicit user customizations. | `src/store/research/index.ts` |
| #3 | Cleanup chain strips `<\|im_end\|>` / `<\|endoftext\|>` / `</stop>` and `(\w)stop$` suffix. Conservative: anchored to end + requires word-char prefix so `"non-stop"` and mid-query `"stop"` survive. 4 new vitest cases. | `src/utils/research/buildSearchQuery.ts` + tests |
| #4 | Defensive `setNoPapersFound(false)` in success path before sourceSummary log. | `src/features/Portal/DeepResearch/Body.tsx` |

#### 📝 补充信息 | Additional Information

## Test plan (manual on Vercel Preview)

| # | Test | Pass criteria |
|---|---|---|
| **R1** | Research Mode VN: `tổng quan tác động GLP1a lên khí sắc semaglutide` | Network: `/api/research/ai-summary` 200, NO `/api/chat/direct` 404. Badge "🌐 Tìm bằng:" hiện. PICO Population/Intervention English có nghĩa. ≥5 papers PubMed/OpenAlex relevant |
| **R2** | Research Mode EN: `Efficacy of SGLT2 inhibitors vs GLP-1 agonists for HFpEF` | PICO Intervention không còn raw query — phải có structured terms ("SGLT2 inhibitors", "GLP-1 agonists", "HFpEF"). ≥8 papers |
| **R3** | New user (incognito) | ArXiv KHÔNG có trong default 3 sources |
| **R4** | Returning user (anh Hien, normal browser) | ArXiv tự động unticked do migrate v2. Manual customizations preserved |
| **R5** | Deep Research VN | Translation output sạch (no "stop" / `<\|im_end\|>` / `</stop>` suffix). Khi tìm được papers, gate "Không tìm thấy" KHÔNG hiện. Article có ≥3 inline citations match papers thật |
| **R6** | Credit deduction | Search 1 query VN → "Phở Credits" giảm ~2 credits (1 translate + 1 PICO) |

## Automated checks (already green locally)

- ✅ `bunx vitest run src/utils/research` — 22/22 pass (15 buildSearchQuery + 7 extractPICO)
- ✅ `bunx eslint --no-fix` on all 5 modified files — 0 errors
- ✅ `NODE_OPTIONS=--max-old-space-size=12288 bunx tsc --noEmit` — exit 0

## Out of scope (Phase 2 / 1.7)

- useEffect deduplication root cause (Bug #4 only papers over the symptom)
- Migrating Writing/Screening to a shared `callAI` helper
- AI call result caching for cost optimization
- UX/discoverability for the "🌐 Tìm bằng" badge

## Rollback

Promote `dpl_5QrSWDc1hCzECK5vrRkh8TdCgxJX` (commit `cd53bb20`). ⚠️ Rollback wipes Phase 1, 1.5, 1.5.1 — last good clinical fix removed too. Strongly prefer fix-forward.

## Cost implication for Hien

Each Research Mode VN search now triggers 2 LLM calls server-side (translate + PICO extract). Free-tier users (`gl_starter`/`vn_free`) may hit credit limits faster. Server-side credit check + tier access already enforced by `/api/research/ai-summary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hotfix to restore Research Mode: routes all AI calls to the correct endpoint, migrates old source defaults for existing users, cleans translation artifacts, and fixes a UI race. This brings back proper translations/PICO, reduces ArXiv noise, and prevents false “no papers” states.

- **Bug Fixes**
  - Switched translate/PICO/Writing/Screening to `/api/research/ai-summary` with Clerk auth and billing checks; updated request/response shape and added explicit 401/402/403 handling.
  - Added Zustand persist `version: 2` with `migrate()` to rewrite the legacy 4-source default to the new 3-source default (keeps user customizations).
  - Cleaned translation output by stripping trailing `<|im_end|>`, `<|endoftext|>`, `</stop>`, and glued `stop` suffixes; added tests.
  - Cleared `noPapersFound` on successful Deep Research results to avoid the “no papers” banner when papers are present.

<sup>Written for commit c8958a6d0c6ca477c067ebdec5200e7095fede98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale state issue in deep research process that could cause duplicate operations.
  * Improved error handling for authentication and credit-related failures.

* **New Features**
  * Added auto-screening capability with visual progress counter in research screening.
  * New "Quick Actions" section for faster research operations.

* **Improvements**
  * Enhanced AI output cleaning for more accurate search query generation.
  * Better citation management in research writing.
  * Optimized API integration for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->