### PR TITLE
🚑 fix(research-modes): article model fallback + race dedupe + PICO sequencing + JSX escape (Phase 1.5.2)

### DIFF
--- a/src/features/Portal/DeepResearch/Body.tsx
+++ b/src/features/Portal/DeepResearch/Body.tsx
@@ -2353,12 +2353,12 @@ ER  - `;
                     {agent.status === 'running' && <Loader2 className="animate-spin" size={12} />}
                     {agent.status === 'done' && (
                       <Tag color="success" style={{ fontSize: 10 }}>
-                        \u2713
+                        ✓
                       </Tag>
                     )}
                     {agent.status === 'error' && (
                       <Tag color="error" style={{ fontSize: 10 }}>
-                        \u2717
+                        ✗
                       </Tag>
                     )}
                     {agent.status === 'done' && (

--- a/src/features/Portal/DeepResearch/Body.tsx
+++ b/src/features/Portal/DeepResearch/Body.tsx
@@ -1098,6 +1098,25 @@ Provide a thorough analysis from your perspective. Use markdown formatting with 
         ? `\n\nIMPORTANT: Only ${pubmedPapers.length} paper(s) were retrieved. The literature base is very limited. Acknowledge this in the Discussion section as a limitation. Do NOT extrapolate beyond what these papers support. Do NOT fabricate additional citations to fill gaps.`
         : '';
 
+    // Bug G fix — Gemini Flash safety filter aggressively refuses medical
+    // content (mental health, suicidality, mortality), emitting a single
+    // "stop" token (~4 chars) instead of a refusal message. Prepend a
+    // clinical-context framing so the model recognises this as a
+    // legitimate professional medical task rather than patient advice.
+    const SAFETY_PREFIX = `You are assisting a licensed physician in conducting a medical literature review for clinical decision support. The retrieved papers describe documented clinical outcomes from peer-reviewed pharmacovigilance studies and randomized trials.
+
+CRITICAL CONTEXT:
+- This is for healthcare professionals, NOT patient-facing content
+- Discussing documented adverse events (including suicidality, depression, mortality) is essential for evidence-based medicine and patient safety
+- Refusing to summarize peer-reviewed medical literature would harm clinical decision-making
+- Your output is a balanced clinical synthesis, not medical advice or a diagnostic recommendation
+
+Produce a comprehensive, evidence-grounded literature review synthesis.
+
+---
+
+`;
+
     const prompt = `You are an expert medical academic writer. Write a comprehensive literature review article based on the following outline and research findings.
 
 Clinical Question: "${question}"
@@ -1136,23 +1155,54 @@ ${limitedLitWarning}
 
 Write the full article now in markdown format.`;
 
-    // Retry logic for article generation
-    const maxRetries = 2;
+    const fullPrompt = SAFETY_PREFIX + prompt;
+
+    // Bug G fix — multi-model fallback. If the primary model returns a
+    // suspiciously short payload (e.g. Gemini Flash safety-filter "stop"
+    // token = 4 chars), retry with safety-tolerant alternatives. GPT-4o
+    // is more permissive on documented medical adverse events.
+    const ARTICLE_MODELS_FALLBACK = [
+      model, // primary: user-selected model
+      'gpt-4o', // fallback: better safety tolerance for medical content
+      'gpt-4o-mini', // last resort: cheaper but still works
+    ];
+    // If output < 50 chars, treat as model refusal / safety filter trigger.
+    const SUSPICIOUS_OUTPUT_THRESHOLD = 50;
+
+    const maxRetries = ARTICLE_MODELS_FALLBACK.length;
     let lastError: Error | null = null;
 
     for (let attempt = 0; attempt < maxRetries; attempt++) {
+      const tryModel = ARTICLE_MODELS_FALLBACK[attempt];
       try {
         if (attempt > 0) {
-          setProgressLines((prev) => [...prev, `🔄 Thử lại lần ${attempt + 1}...`]);
+          setProgressLines((prev) => [
+            ...prev,
+            `🔄 Thử lại với model ${tryModel} (model trước có thể bị safety filter)...`,
+          ]);
         }
 
-        // Stream article — keep phase='article' to show progress
-        const result = await callAIStream(model, prompt, (streamedText) => {
+        // Stream article — use tryModel + fullPrompt (with safety prefix)
+        const result = await callAIStream(tryModel, fullPrompt, (streamedText) => {
           setArticle(streamedText);
         });
 
+        // Detect safety-filter refusal pattern (very short output, e.g. "stop")
+        const trimmed = result.trim();
+        if (trimmed.length < SUSPICIOUS_OUTPUT_THRESHOLD) {
+          (window as any).posthog?.capture('article_safety_filter_suspected', {
+            attempt: attempt + 1,
+            model: tryModel,
+            output_length: trimmed.length,
+            output_preview: trimmed.slice(0, 100),
+          });
+          throw new Error(
+            `Model ${tryModel} trả về quá ngắn (${trimmed.length} ký tự, có thể bị safety filter). Đang thử model khác...`,
+          );
+        }
+
         // Validate output — article must have meaningful content
-        const wordCount = result.trim().split(/\s+/).length;
+        const wordCount = trimmed.split(/\s+/).length;
         const MIN_ARTICLE_WORDS = 200;
         if (wordCount < MIN_ARTICLE_WORDS) {
           throw new Error(
@@ -1314,7 +1364,10 @@ Generate 3-6 rows for the most important outcomes.`;
         return; // Success — exit retry loop
       } catch (e: any) {
         lastError = e;
-        console.error(`[DeepResearch] Article attempt ${attempt + 1} failed:`, e.message);
+        console.error(
+          `[DeepResearch] Article attempt ${attempt + 1} (model=${tryModel}) failed:`,
+          e.message,
+        );
       }
     }
 
@@ -1322,7 +1375,8 @@ Generate 3-6 rows for the most important outcomes.`;
     (window as any).posthog?.capture('article_generation_failed', {
       error: lastError?.message || 'Unknown error',
       generation_time_seconds: Math.round((Date.now() - articleStartTime) / 1000),
-      model,
+      models_tried: ARTICLE_MODELS_FALLBACK,
+      primary_model: model,
     });
 
     setProgressLines((prev) => [

--- a/src/features/Portal/DeepResearch/Body.tsx
+++ b/src/features/Portal/DeepResearch/Body.tsx
@@ -662,6 +662,12 @@ const DeepResearchBody = memo(() => {
   const abortRef = useRef(false);
   const abortControllerRef = useRef<AbortController | null>(null);
   const startResearchRef = useRef<(() => void) | undefined>(undefined);
+  // Bug H fix — guard against the auto-trigger useEffect firing
+  // startResearch multiple times (StrictMode double-invoke, parent
+  // re-render reconciliation, race between phase change and agent state).
+  // Reset to false when phase changes AWAY from 'research' so re-entry
+  // (Reset → new question) still works.
+  const hasAutoStartedRef = useRef(false);
 
   // Consume pendingResearchQuery from portal store (auto-fill from chat suggestion)
   const pendingQuery = useChatStore((s) => s.pendingResearchQuery);
@@ -1031,8 +1037,17 @@ Provide a thorough analysis from your perspective. Use markdown formatting with 
 
   // Auto-trigger research when phase transitions to 'research' but agents haven't started
   useEffect(() => {
-    if (phase === 'research' && agents.every((a) => a.status === 'idle')) {
+    if (
+      phase === 'research' &&
+      agents.every((a) => a.status === 'idle') &&
+      !hasAutoStartedRef.current
+    ) {
+      hasAutoStartedRef.current = true;
       startResearch();
+    }
+    // Reset flag when leaving research phase so re-entry works
+    if (phase !== 'research') {
+      hasAutoStartedRef.current = false;
     }
   }, [phase]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -2223,7 +2238,14 @@ ER  - `;
                   />
                 </Flexbox>
               ))}
-              <Button icon={<Search size={14} />} onClick={() => startResearch()} type="primary">
+              <Button
+                icon={<Search size={14} />}
+                onClick={() => {
+                  hasAutoStartedRef.current = true;
+                  startResearch();
+                }}
+                type="primary"
+              >
                 Tiếp tục nghiên cứu →
               </Button>
             </>
@@ -2270,6 +2292,7 @@ ER  - `;
               onClick={() => {
                 setNoPapersFound(false);
                 setAgents(AGENTS.map((a) => ({ content: '', name: a.name, status: 'idle' })));
+                hasAutoStartedRef.current = true;
                 startResearch();
               }}
               size="small"
@@ -2281,6 +2304,7 @@ ER  - `;
               icon={<Play size={12} />}
               onClick={() => {
                 setAgents(AGENTS.map((a) => ({ content: '', name: a.name, status: 'idle' })));
+                hasAutoStartedRef.current = true;
                 startResearch({ forceContinueWithoutLiterature: true });
               }}
               size="small"

--- a/src/store/research/index.ts
+++ b/src/store/research/index.ts
@@ -428,10 +428,23 @@ export const useResearchStore = create<ResearchState>()(
         },
 
         extractPICO: async (query) => {
-          const { translatedQuery } = get();
-          // Prefer the English translated query when available — keyword
-          // matching against MeSH-style terminology is far more reliable.
-          const queryForExtraction = translatedQuery || query;
+          // ARCHITECTURAL NOTE for v2 port: any LLM-derived metadata (PICO,
+          // MeSH expansion, specialty hint, embeddings) MUST sequence AFTER
+          // translate, not parallel. Pattern: translate() → derive_metadata()
+          // → search().
+          //
+          // Phase 1.5.2 Bug E: previously read translatedQuery from state,
+          // which was either null (first run, raced with searchPapers) or
+          // STALE from a prior search. Now we call buildSearchQuery directly
+          // — it is cache-friendly so this is a no-op when searchPapers
+          // already translated the same input in the current session.
+          let queryForExtraction = query;
+          try {
+            const queryInfo = await buildSearchQuery(query, callAI, TRANSLATE_MODEL);
+            queryForExtraction = queryInfo.searchQuery;
+          } catch (e) {
+            console.warn('[extractPICO] translate failed, using raw query', e);
+          }
           const result = await llmExtractPICO(queryForExtraction, callAI, TRANSLATE_MODEL);
           set({ pico: result.pico }, false, 'extractPICO');
         },

--- a/src/utils/research/extractPICO.ts
+++ b/src/utils/research/extractPICO.ts
@@ -58,9 +58,14 @@ export const extractPICO = async (
 
   try {
     const raw = await callAI(model, PICO_PROMPT(query), 'extract-pico');
+    // Aggressive cleanup — Gemini sometimes wraps JSON with prose like
+    // "Here is the PICO extraction:" before, or "Note: ..." after, neither
+    // of which the previous code-fence-only strip caught.
     const cleaned = raw
       .replace(/^```(?:json)?\s*/i, '')
       .replace(/```\s*$/i, '')
+      .replace(/^[^{]*?(?={)/s, '')
+      .replace(/}[^}]*$/s, '}')
       .trim();
     const parsed = JSON.parse(cleaned);
 


### PR DESCRIPTION
## Why

Phase 1.5.1 (PR #20) shipped successfully — R3 (incognito new user) verified Bug #2 migrate works. But production R1/R2/R5 testing revealed 4 remaining bugs blocking BS Sơn rollout:

1. **CRITICAL** — Deep Research article gen returns 4 chars `"stop"` — Gemini Flash safety filter triggered on PubMed papers about suicidality / depression / mortality (Bug G).
2. **HIGH** — Deep Research `startResearch` fires 2× (useEffect race) — wastes resources, trips Semantic Scholar 429 rate limit (Bug H).
3. **HIGH** — Research Mode PICO shows stale `translatedQuery` from previous search — race condition between `handleSearch` parallel calls (Bug E).
4. **MEDIUM** — Agent badges show literal `✓` instead of ✓ (JSX text escape bug, Bug I).

## What

- **Bug G — Article gen multi-model fallback + safety prefix** (`src/features/Portal/DeepResearch/Body.tsx`)
  - `SAFETY_PREFIX` prepended to article prompt — frames task as licensed-physician clinical decision support so Gemini stops refusing pharmacovigilance content.
  - `ARTICLE_MODELS_FALLBACK = [primary, gpt-4o, gpt-4o-mini]`. When output `< 50` chars (suspected safety-filter refusal), retry with next model. GPT-4o is more permissive on documented medical adverse events.
  - PostHog telemetry: `article_safety_filter_suspected` per attempt; `article_generation_failed` now reports `models_tried` + `primary_model`.

- **Bug H — useEffect dedupe** (`src/features/Portal/DeepResearch/Body.tsx`)
  - `hasAutoStartedRef = useRef(false)` guards the auto-trigger useEffect.
  - Reset to `false` when phase leaves `'research'`.
  - All 3 manual button handlers (`Tiếp tục nghiên cứu`, `Thử lại`, `Tiếp tục không có y văn`) set the ref to `true` before calling `startResearch` so the useEffect cannot fire on the resulting re-render.
  - Side effect: Bug J (S2 429) auto-resolves.

- **Bug E — extractPICO sequencing** (`src/store/research/index.ts` + `src/utils/research/extractPICO.ts`)
  - `extractPICO` now calls `buildSearchQuery` directly instead of reading `translatedQuery` from store state. Cache-friendly so it's a no-op when `searchPapers` already translated.
  - ADR comment documents pattern for v2 port: *any LLM-derived metadata (PICO, MeSH expansion, specialty hint, embeddings) MUST sequence AFTER translate, not parallel*.
  - `extractPICO.ts` cleanup regex now strips arbitrary prose before/after JSON, not just code fences (Gemini sometimes wraps with prefixes like *"Here is the PICO extraction:"*).

- **Bug I — JSX escape literal** (`src/features/Portal/DeepResearch/Body.tsx`)
  - `✓` / `✗` JSX text content → ✓ / ✗ unicode literals. JSX text is NOT a JS escape context.

## Test plan

Manual verification on production / preview after deploy (per MEGA-PROMPT §6.2):

- [ ] **A1** Research Mode VN: `tổng quan tác động GLP1a lên khí sắc semaglutide` → PICO Intervention is English clinical term, NOT raw VN.
- [ ] **A2** Research Mode EN in same session after A1: `Efficacy of SGLT2 inhibitors vs GLP-1 agonists for HFpEF` → PICO Intervention NOT stale from A1.
- [ ] **B1** Deep Research VN (same query as A1): progress log every step appears 1× only (no duplicates).
- [ ] **B2** Deep Research VN: article gen completes ≥200 words. If Gemini fails, log shows `🔄 Thử lại với model gpt-4o`, fallback succeeds.
- [ ] **B3** Visual: agent badges display ✓ / ✗, NOT `✓` / `✗`.
- [ ] **C1** Network tab: NO 429 from Semantic Scholar during A1+B1.

Automated:

- [x] `bunx vitest run src/utils/research` — 22/22 pass.
- [x] `NODE_OPTIONS="--max-old-space-size=12288" bunx tsc --noEmit` — clean.
- [x] `bunx eslint` on modified files — clean.
- [x] Pre-commit hooks (prettier + stylelint + eslint + tsgo) passed for each commit.

## Architectural note for v2

This PR adds an ADR comment in `extractPICO`:
> Any LLM-derived metadata (PICO, MeSH expansion, specialty hint, embeddings) MUST sequence AFTER translate, not parallel. Pattern: `translate() → derive_metadata() → search()`.

Apply this to the v2 research-engine package when porting.

## Out of scope

- Bug J (S2 429) — auto-resolves with Bug H fix.
- Bug K (`Plugin not found: document-translation`) — unrelated legacy cleanup.
- Bug L (debug `console.log` pollution) — minor sweep, defer.
- UX / discoverability redesign — Phase 1.7.
- Embedding-based ranking — Phase 2.

## PostHog telemetry to verify post-merge (~1h)

- `article_safety_filter_suspected` event fires when Gemini fails on medical query → data point for Phase 2 model strategy (e.g. default GPT-4o for medical queries).
- `article_generation_failed` rate drops vs Phase 1.5.1 baseline.
- NO duplicate `research_query_translated` events per request (Bug H verification).

## Rollback

If anything breaks, promote the last good Phase 1.5.1 deployment:
- `dpl_FnxAq8HMhjPabGFJvaHWWKVbcBL4` (commit `a7912e7`, current production).
- Or further back: `dpl_5QrSWDc1hCzECK5vrRkh8TdCgxJX` (commit `cd53bb20`, last good before all research fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four blocking issues in Deep Research: reliable article generation on sensitive medical topics, no duplicate auto-starts, correct PICO extraction sequencing, and proper badge icons. This reduces 429s, improves article completion, and adds clearer telemetry.

- **Bug Fixes**
  - Article generation: prepend a medical safety prefix and add multi-model fallback (`primary` → `gpt-4o` → `gpt-4o-mini`). Treat outputs <50 chars as safety-filter refusals and retry. Telemetry now logs `article_safety_filter_suspected` and includes `models_tried` and `primary_model` on failures.
  - Auto-start dedupe: guard `startResearch` with `hasAutoStartedRef`; reset when leaving the research phase; set the flag in manual start buttons to prevent double fires.
  - PICO sequencing: call `buildSearchQuery` inside `extractPICO` to avoid stale `translatedQuery`. Harden JSON cleanup to strip prose before/after the JSON block. Adds ADR note: translate → derive metadata → search.
  - UI: replace escaped glyphs with actual ✓/✗ for agent badges.

<sup>Written for commit e69c261fe3b9228443112c670fe637bba56639ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Article generation now falls back to alternative models if the primary model fails, ensuring more reliable content creation
  * Added safety filter that automatically retries with a different model when output appears incomplete

* **Bug Fixes**
  * Fixed unintended duplicate auto-start in research phase initialization
  * Improved PICO extraction robustness for better handling of edge cases and malformed responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->