### PR TITLE
📊 fix(research-modes): observability + silent fallback hardening (Phase 1.5.3)

### DIFF
--- a/src/features/Portal/DeepResearch/Body.tsx
+++ b/src/features/Portal/DeepResearch/Body.tsx
@@ -33,6 +33,7 @@ import { Flexbox } from 'react-layout-kit';
 
 import { useChatStore } from '@/store/chat';
 import { buildSearchQuery } from '@/utils/research/buildSearchQuery';
+import { MEDICAL_SAFETY_PREFIX } from '@/utils/research/safetyPrompt';
 
 const { TextArea } = Input;
 
@@ -386,6 +387,7 @@ async function callAI(model: string, prompt: string, label = 'unknown'): Promise
             attempt,
             delay_ms: delayMs,
             label,
+            surface: 'deep_research',
           });
           await new Promise<void>((r) => {
             setTimeout(r, delayMs);
@@ -485,8 +487,21 @@ async function callAIStream(
       }
     }
 
-    console.log('[DeepResearch] callAIStream complete:', { length: fullContent.length });
-    return fullContent;
+    // Phase 1.5.3 (Audit #7) — strip chat-template artifacts that occasionally
+    // leak through streaming, matching the buildSearchQuery cleanup from Phase
+    // 1.5.1. Symptom: ".stop" suffix at the end of Key Takeaways or trailing
+    // tokens like <|im_end|>, <|endoftext|>, </stop>. The (\w)stop$ rule only
+    // strips when "stop" has a word char immediately before and is at the very
+    // end — so "non-stop" / "stop bleeding" mid-content are left alone.
+    const cleaned = fullContent
+      .replace(/(<\|?im_end\|?>|<\|?endoftext\|?>|<\/?stop>)\s*$/i, '')
+      .replace(/(\w)stop\s*$/i, '$1')
+      .trimEnd();
+    console.log('[DeepResearch] callAIStream complete:', {
+      length: cleaned.length,
+      stripped: fullContent.length - cleaned.length,
+    });
+    return cleaned;
   } catch (e: any) {
     // Convert AbortError to friendly message
     if (e.name === 'AbortError') {
@@ -510,8 +525,20 @@ async function searchPubMed(query: string, maxResults = 8): Promise<PubMedPaper[
     if (!res.ok) return [];
     const data = await res.json();
     return data.papers || [];
-  } catch {
+  } catch (error) {
     console.warn('[DeepResearch] PubMed search failed, continuing without literature');
+    // Phase 1.5.3 (Audit #1) — surface API outages without relying on user complaints.
+    try {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      (window as any).posthog?.capture('search_source_failed', {
+        error: errMsg.slice(0, 200),
+        query: query.slice(0, 100),
+        source: 'PubMed',
+        surface: 'deep_research',
+      });
+    } catch {
+      /* posthog not loaded */
+    }
     return [];
   }
 }
@@ -537,8 +564,20 @@ async function searchSemanticScholar(query: string, limit = 10): Promise<PubMedP
       title: p.title || '',
       year: p.year || '',
     }));
-  } catch {
+  } catch (error) {
     console.warn('[DeepResearch] Semantic Scholar search failed');
+    // Phase 1.5.3 (Audit #1) — surface API outages without relying on user complaints.
+    try {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      (window as any).posthog?.capture('search_source_failed', {
+        error: errMsg.slice(0, 200),
+        query: query.slice(0, 100),
+        source: 'SemanticScholar',
+        surface: 'deep_research',
+      });
+    } catch {
+      /* posthog not loaded */
+    }
     return [];
   }
 }
@@ -722,6 +761,7 @@ const DeepResearchBody = memo(() => {
     (window as any).posthog?.capture('research_started', {
       model,
       question: question.slice(0, 200),
+      surface: 'deep_research',
     });
 
     try {
@@ -936,6 +976,7 @@ Provide a thorough analysis from your perspective. Use markdown formatting with 
         ]);
         (window as any).posthog?.capture('research_no_papers_continued', {
           question: question.slice(0, 200),
+          surface: 'deep_research',
         });
         await runAgentsAndOutline([], false);
         return;
@@ -957,6 +998,7 @@ Provide a thorough analysis from your perspective. Use markdown formatting with 
         duration_ms: queryInfo.durationMs,
         fell_back_to_original: queryInfo.fellBackToOriginal,
         original_query: queryInfo.originalQuery.slice(0, 200),
+        surface: 'deep_research',
         translated: queryInfo.translated,
         translated_query: queryInfo.searchQuery.slice(0, 200),
       });
@@ -990,6 +1032,7 @@ Provide a thorough analysis from your perspective. Use markdown formatting with 
         papers_per_source: { pubmed: pubmedCount, semantic_scholar: s2Count },
         question: question.slice(0, 200),
         sources: Array.from(searchSources),
+        surface: 'deep_research',
         translated_query: queryInfo.searchQuery.slice(0, 200),
       });
 
@@ -1003,6 +1046,7 @@ Provide a thorough analysis from your perspective. Use markdown formatting with 
         (window as any).posthog?.capture('research_no_papers', {
           original_question: queryInfo.originalQuery.slice(0, 200),
           sources: Array.from(searchSources),
+          surface: 'deep_research',
           translated_query: queryInfo.searchQuery.slice(0, 200),
         });
         setStartTime(null);
@@ -1077,6 +1121,7 @@ Provide a thorough analysis from your perspective. Use markdown formatting with 
       agent_count: agents.filter((a) => a.status === 'done').length,
       model,
       outline_sections: outline.length,
+      surface: 'deep_research',
     });
 
     const agentFindings = agents
@@ -1113,25 +1158,12 @@ Provide a thorough analysis from your perspective. Use markdown formatting with 
         ? `\n\nIMPORTANT: Only ${pubmedPapers.length} paper(s) were retrieved. The literature base is very limited. Acknowledge this in the Discussion section as a limitation. Do NOT extrapolate beyond what these papers support. Do NOT fabricate additional citations to fill gaps.`
         : '';
 
-    // Bug G fix — Gemini Flash safety filter aggressively refuses medical
-    // content (mental health, suicidality, mortality), emitting a single
-    // "stop" token (~4 chars) instead of a refusal message. Prepend a
-    // clinical-context framing so the model recognises this as a
-    // legitimate professional medical task rather than patient advice.
-    const SAFETY_PREFIX = `You are assisting a licensed physician in conducting a medical literature review for clinical decision support. The retrieved papers describe documented clinical outcomes from peer-reviewed pharmacovigilance studies and randomized trials.
-
-CRITICAL CONTEXT:
-- This is for healthcare professionals, NOT patient-facing content
-- Discussing documented adverse events (including suicidality, depression, mortality) is essential for evidence-based medicine and patient safety
-- Refusing to summarize peer-reviewed medical literature would harm clinical decision-making
-- Your output is a balanced clinical synthesis, not medical advice or a diagnostic recommendation
-
-Produce a comprehensive, evidence-grounded literature review synthesis.
-
----
-
-`;
-
+    // Phase 1.5.2/1.5.3 — Gemini Flash safety filter aggressively refuses
+    // medical content (mental health, suicidality, mortality), emitting a
+    // single "stop" token (~4 chars) instead of a refusal message. Prepend
+    // shared MEDICAL_SAFETY_PREFIX (clinical-context framing) so the model
+    // recognises this as a legitimate professional medical task rather
+    // than patient advice. See src/utils/research/safetyPrompt.ts.
     const prompt = `You are an expert medical academic writer. Write a comprehensive literature review article based on the following outline and research findings.
 
 Clinical Question: "${question}"
@@ -1170,7 +1202,7 @@ ${limitedLitWarning}
 
 Write the full article now in markdown format.`;
 
-    const fullPrompt = SAFETY_PREFIX + prompt;
+    const fullPrompt = MEDICAL_SAFETY_PREFIX + prompt;
 
     // Bug G fix — multi-model fallback. If the primary model returns a
     // suspiciously short payload (e.g. Gemini Flash safety-filter "stop"
@@ -1210,6 +1242,7 @@ Write the full article now in markdown format.`;
             model: tryModel,
             output_length: trimmed.length,
             output_preview: trimmed.slice(0, 100),
+            surface: 'deep_research',
           });
           throw new Error(
             `Model ${tryModel} trả về quá ngắn (${trimmed.length} ký tự, có thể bị safety filter). Đang thử model khác...`,
@@ -1276,6 +1309,7 @@ Write the full article now in markdown format.`;
         (window as any).posthog?.capture('article_generation_complete', {
           generation_time_seconds: Math.round((Date.now() - articleStartTime) / 1000),
           model,
+          surface: 'deep_research',
           word_count: wordCount,
         });
         setStartTime(null);
@@ -1392,6 +1426,7 @@ Generate 3-6 rows for the most important outcomes.`;
       generation_time_seconds: Math.round((Date.now() - articleStartTime) / 1000),
       models_tried: ARTICLE_MODELS_FALLBACK,
       primary_model: model,
+      surface: 'deep_research',
     });
 
     setProgressLines((prev) => [

--- a/src/features/Portal/Research/Body/Screening/index.tsx
+++ b/src/features/Portal/Research/Body/Screening/index.tsx
@@ -1,22 +1,32 @@
 'use client';
 
 import { Button, Tag } from '@lobehub/ui';
-import { Select, Tooltip } from 'antd';
+import { Alert, Select, Tooltip } from 'antd';
 import { createStyles } from 'antd-style';
 import { Bot, CheckCircle, ChevronLeft, Loader2, Sparkles, XCircle } from 'lucide-react';
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
 import { type ScreeningDecision, useResearchStore } from '@/store/research';
+import { MEDICAL_SAFETY_PREFIX } from '@/utils/research/safetyPrompt';
 
 // ── AI Screening helper ────────────────────────────────────────────────────
 type AIVerdict = { decision: 'excluded' | 'included'; paperId: string; reason: string };
+
+// Phase 1.5.3 (Audit #2) — surface fallback to caller so the UI can warn the
+// user that AI screening was unavailable and they're seeing keyword-only
+// decisions. Without this, users don't know quality silently degraded.
+interface AIScreenResult {
+  fallbackReason?: string;
+  usedFallback: boolean;
+  verdicts: AIVerdict[];
+}
 
 const aiScreenBatch = async (
   papers: Array<{ abstract?: string; id: string; title: string }>,
   pico: { comparison: string; intervention: string; outcome: string; population: string } | null,
   query: string,
-): Promise<AIVerdict[]> => {
+): Promise<AIScreenResult> => {
   // Build a concise screener prompt
   const picoTxt = pico
     ? `PICO: P=${pico.population}, I=${pico.intervention}, C=${pico.comparison}, O=${pico.outcome}`
@@ -41,7 +51,10 @@ const aiScreenBatch = async (
     const res = await fetch('/api/research/ai-summary', {
       body: JSON.stringify({
         model: 'gemini-2.5-flash',
-        prompt,
+        // Phase 1.5.3 — apply shared medical safety framing so Gemini Flash
+        // does not refuse with a "stop" token when paper abstracts mention
+        // suicidality / mortality / depression. See safetyPrompt.ts.
+        prompt: MEDICAL_SAFETY_PREFIX + prompt,
         stream: false,
       }),
       credentials: 'include',
@@ -52,10 +65,25 @@ const aiScreenBatch = async (
     const data = await res.json();
     const text: string = data?.text ?? '';
     const parsed = JSON.parse(text.replaceAll(/```[\s\w]*/g, '').trim()) as AIVerdict[];
-    return parsed;
-  } catch {
+    return { usedFallback: false, verdicts: parsed };
+  } catch (err) {
+    const fallbackReason = err instanceof Error ? err.message : String(err);
+
+    // Phase 1.5.3 (Audit #2) — track frequency of AI screening failures.
+    // Without this we can't tell if 1% of users hit it or 50%, which gates
+    // any Phase 2 work on screening quality.
+    try {
+      (window as any).posthog?.capture('screening_fallback_to_keyword', {
+        error: fallbackReason.slice(0, 200),
+        paper_count: papers.length,
+        surface: 'research_mode',
+      });
+    } catch {
+      /* posthog not loaded */
+    }
+
     // Fallback: AI not available — return heuristic decisions based on keywords
-    return papers.map((p) => {
+    const verdicts = papers.map((p) => {
       const titleLower = (p.title + (p.abstract ?? '')).toLowerCase();
       const queryWords = query
         .toLowerCase()
@@ -64,11 +92,12 @@ const aiScreenBatch = async (
       const matches = queryWords.filter((w) => titleLower.includes(w)).length;
       const score = queryWords.length > 0 ? matches / queryWords.length : 0;
       return {
-        decision: score >= 0.3 ? 'included' : 'excluded',
+        decision: (score >= 0.3 ? 'included' : 'excluded') as 'excluded' | 'included',
         paperId: p.id,
         reason: score >= 0.3 ? 'Keyword match ≥30%' : 'Low keyword relevance',
       };
     });
+    return { fallbackReason, usedFallback: true, verdicts };
   }
 };
 
@@ -240,6 +269,11 @@ const ScreeningPhase = memo(() => {
   const [pendingExclude, setPendingExclude] = useState<string | null>(null);
   const [aiLoading, setAiLoading] = useState(false);
   const [aiScreenedCount, setAiScreenedCount] = useState(0);
+  // Phase 1.5.3 (Audit #2) — track when AI screening fell back to keyword
+  // matching so we can show a warning Alert + Retry instead of silently
+  // marking papers via low-quality regex.
+  const [aiUsedFallback, setAiUsedFallback] = useState(false);
+  const [aiFallbackReason, setAiFallbackReason] = useState('');
 
   const EXCLUSION_REASONS = [
     { label: 'Wrong population', value: 'Wrong population' },
@@ -284,10 +318,13 @@ const ScreeningPhase = memo(() => {
     );
     if (pendingPapers.length === 0) return;
     setAiLoading(true);
+    // Clear any prior fallback warning so a successful retry hides the Alert.
+    setAiUsedFallback(false);
+    setAiFallbackReason('');
     try {
-      const verdicts = await aiScreenBatch(pendingPapers, pico, searchQuery);
+      const result = await aiScreenBatch(pendingPapers, pico, searchQuery);
       let count = 0;
-      for (const v of verdicts) {
+      for (const v of result.verdicts) {
         const id = v.paperId ?? (v as { id?: string }).id;
         if (id) {
           screenPaper(id, v.decision, v.reason);
@@ -295,6 +332,10 @@ const ScreeningPhase = memo(() => {
         }
       }
       setAiScreenedCount(count);
+      if (result.usedFallback) {
+        setAiUsedFallback(true);
+        setAiFallbackReason(result.fallbackReason ?? '');
+      }
     } finally {
       setAiLoading(false);
     }
@@ -366,6 +407,33 @@ const ScreeningPhase = memo(() => {
           </span>
         </Flexbox>
       </div>
+
+      {/* Phase 1.5.3 — fallback warning when AI screening was unavailable */}
+      {aiUsedFallback && (
+        <Alert
+          action={
+            <Button onClick={handleAIScreen} size={'small'} type={'primary'}>
+              Thử lại AI
+            </Button>
+          }
+          closable
+          description={
+            <span>
+              Hệ thống đã dùng phương pháp lọc theo từ khóa thay thế. Kết quả có thể kém chính xác
+              hơn AI screening đầy đủ. Hãy nhấn &ldquo;Thử lại&rdquo; để gọi lại AI.
+              {aiFallbackReason && (
+                <span style={{ display: 'block', fontSize: 11, marginTop: 4, opacity: 0.65 }}>
+                  Lỗi: {aiFallbackReason}
+                </span>
+              )}
+            </span>
+          }
+          message="AI screening tạm thời không khả dụng"
+          onClose={() => setAiUsedFallback(false)}
+          showIcon
+          type="warning"
+        />
+      )}
 
       {/* Quick Actions */}
       <Flexbox gap={8} horizontal wrap={'wrap'}>

--- a/src/features/Portal/Research/Body/Writing/index.tsx
+++ b/src/features/Portal/Research/Body/Writing/index.tsx
@@ -1,15 +1,26 @@
 'use client';
 
 import { Button, Tag } from '@lobehub/ui';
-import { Input, Tooltip } from 'antd';
+import { Alert, Input, Modal, Tooltip } from 'antd';
 import { createStyles } from 'antd-style';
 import { Copy, FileText, Loader2, Sparkles } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
 import { useResearchStore } from '@/store/research';
+import { MEDICAL_SAFETY_PREFIX } from '@/utils/research/safetyPrompt';
 
 // ── AI Writing helper ────────────────────────────────────────────────────
+// Phase 1.5.3 (Audit #3) — surface fallback to caller so the UI can warn
+// the user that the section was filled with a placeholder template instead
+// of AI-generated content. Without this the user can ship a draft that
+// still contains literal "[number]" / "[key finding]" tokens.
+interface AIWriteResult {
+  content: string;
+  fallbackReason?: string;
+  usedFallback: boolean;
+}
+
 const aiWriteSection = async (
   sectionKey: string,
   sectionLabel: string,
@@ -19,7 +30,7 @@ const aiWriteSection = async (
     query: string;
     refs: string;
   },
-): Promise<string> => {
+): Promise<AIWriteResult> => {
   const systemInstructions: Record<string, string> = {
     abstract:
       'Write a structured abstract with Background, Objectives, Methods, Results, Conclusions sections. 250 words max.',
@@ -59,7 +70,10 @@ const aiWriteSection = async (
     const res = await fetch('/api/research/ai-summary', {
       body: JSON.stringify({
         model: 'gemini-2.5-flash',
-        prompt,
+        // Phase 1.5.3 — apply shared medical safety framing so Gemini Flash
+        // does not refuse with a "stop" token when generating sections that
+        // mention suicidality / mortality. See safetyPrompt.ts.
+        prompt: MEDICAL_SAFETY_PREFIX + prompt,
         stream: false,
       }),
       credentials: 'include',
@@ -68,8 +82,22 @@ const aiWriteSection = async (
     });
     if (!res.ok) throw new Error(`fail: ${res.status}`);
     const data = await res.json();
-    return data?.text ?? '';
-  } catch {
+    return { content: data?.text ?? '', usedFallback: false };
+  } catch (err) {
+    const fallbackReason = err instanceof Error ? err.message : String(err);
+
+    // Phase 1.5.3 (Audit #3) — track frequency of AI writing failures so we
+    // can size Phase 2 mitigation (better retry, alternate model, etc).
+    try {
+      (window as any).posthog?.capture('writing_fallback_to_template', {
+        error: fallbackReason.slice(0, 200),
+        section_key: sectionKey,
+        surface: 'research_mode',
+      });
+    } catch {
+      /* posthog not loaded */
+    }
+
     // Fallback: template scaffold
     const templates: Record<string, string> = {
       abstract: `## Abstract\n\n**Background:** ${context.query}\n\n**Methods:** Systematic review following PRISMA guidelines.\n\n**Results:** [number] studies included.\n\n**Conclusions:** Further research warranted.`,
@@ -80,9 +108,20 @@ const aiWriteSection = async (
       results: `## Results\n\n### Study Selection\n[n] records identified, [m] included after screening.\n\n### Characteristics of Included Studies\n[Describe study designs, sample sizes, populations].`,
       title: `1. Effectiveness of ${context.pico?.intervention ?? '[intervention]'} in ${context.pico?.population ?? '[population]'}: A Systematic Review\n2. ${context.query}: A Systematic Review and Meta-Analysis\n3. ${context.pico?.intervention ?? '[intervention]'} versus ${context.pico?.comparison ?? '[comparison]'}: Evidence from a Systematic Review`,
     };
-    return templates[sectionKey] ?? `[AI-generated ${sectionLabel} section - edit as needed]`;
+    const content =
+      templates[sectionKey] ?? `[AI-generated ${sectionLabel} section - edit as needed]`;
+    return { content, fallbackReason, usedFallback: true };
   }
 };
+
+// Phase 1.5.3 (Audit #3 bonus) — block accidental publishing of template
+// scaffolds that still contain unfilled placeholders like [number],
+// [key finding]. Conservative regex matches the literal token shapes used
+// in `templates` above. Real prose with bracketed citations like [Smith,
+// 2020] is left alone because the regex only matches these specific keys.
+const PLACEHOLDER_PATTERN =
+  /\[(number|n|m|key finding|gap|recommendation|prior work|search scope, language bias|describe study designs, sample sizes, populations|intervention|population|comparison)]/i;
+const hasUnfilledPlaceholders = (content: string): boolean => PLACEHOLDER_PATTERN.test(content);
 
 const { TextArea } = Input;
 
@@ -282,6 +321,10 @@ const WritingPhase = memo(() => {
   const [expandedSection, setExpandedSection] = useState<string | null>('title');
   // Track which sections are AI-generating
   const [aiGenerating, setAiGenerating] = useState<Record<string, boolean>>({});
+  // Phase 1.5.3 (Audit #3) — sectionKey → fallbackReason for sections that
+  // were filled with the template scaffold instead of AI content. Drives the
+  // per-section warning Alert + Retry button.
+  const [sectionFallback, setSectionFallback] = useState<Record<string, string>>({});
 
   const updateSection = (key: string, content: string) => {
     setSections((prev) => prev.map((s) => (s.key === key ? { ...s, content } : s)));
@@ -291,6 +334,13 @@ const WritingPhase = memo(() => {
   const handleAIWrite = useCallback(
     async (sectionKey: string, sectionLabel: string, existingContent: string) => {
       setAiGenerating((prev) => ({ ...prev, [sectionKey]: true }));
+      // Clear previous fallback for this section so a successful retry hides Alert.
+      setSectionFallback((prev) => {
+        if (!prev[sectionKey]) return prev;
+        const next = { ...prev };
+        delete next[sectionKey];
+        return next;
+      });
       setExpandedSection(sectionKey); // open the section
       const refsText = includedPapers
         .slice(0, 8)
@@ -310,7 +360,13 @@ const WritingPhase = memo(() => {
           query: searchQuery,
           refs: refsText,
         });
-        updateSection(sectionKey, result);
+        updateSection(sectionKey, result.content);
+        if (result.usedFallback) {
+          setSectionFallback((prev) => ({
+            ...prev,
+            [sectionKey]: result.fallbackReason ?? '',
+          }));
+        }
       } finally {
         setAiGenerating((prev) => ({ ...prev, [sectionKey]: false }));
       }
@@ -329,6 +385,19 @@ const WritingPhase = memo(() => {
       .filter((s) => s.content.trim())
       .map((s) => `# ${s.label}\n\n${s.content}`)
       .join('\n\n---\n\n');
+    // Phase 1.5.3 (Audit #3 bonus) — block accidental copy of template
+    // scaffolds with literal "[number]" / "[key finding]" placeholders.
+    if (hasUnfilledPlaceholders(fullText)) {
+      Modal.confirm({
+        cancelText: 'Quay lại chỉnh sửa',
+        content:
+          'Phát hiện các placeholder như [number], [key finding] trong bài viết. Bạn có chắc muốn copy bản này?',
+        okText: 'Vẫn copy',
+        onOk: () => navigator.clipboard.writeText(fullText),
+        title: 'Bài viết còn placeholder chưa điền',
+      });
+      return;
+    }
     navigator.clipboard.writeText(fullText);
   };
 
@@ -353,6 +422,43 @@ const WritingPhase = memo(() => {
         <span className={styles.sectionTitle}>✍️ Manuscript Sections</span>
         {sections.map((section, idx) => (
           <div className={styles.sectionCard} key={section.key}>
+            {/* Phase 1.5.3 — fallback warning when AI writing was unavailable */}
+            {sectionFallback[section.key] !== undefined && (
+              <Alert
+                action={
+                  <Button
+                    onClick={() => handleAIWrite(section.key, section.label, section.content)}
+                    size={'small'}
+                    type={'primary'}
+                  >
+                    Thử lại AI
+                  </Button>
+                }
+                closable
+                description={
+                  <span>
+                    AI writing tạm thời không khả dụng. Phần này hiện chứa template với placeholder
+                    ([number], [key finding], v.v.) cần điền thủ công.
+                    {sectionFallback[section.key] && (
+                      <span style={{ display: 'block', fontSize: 11, marginTop: 4, opacity: 0.65 }}>
+                        Lỗi: {sectionFallback[section.key]}
+                      </span>
+                    )}
+                  </span>
+                }
+                message={`Phần "${section.label}" dùng template thay vì AI`}
+                onClose={() =>
+                  setSectionFallback((prev) => {
+                    const next = { ...prev };
+                    delete next[section.key];
+                    return next;
+                  })
+                }
+                showIcon
+                style={{ marginBottom: 8 }}
+                type="warning"
+              />
+            )}
             <div
               className={styles.sectionHeader}
               onClick={() =>

--- a/src/store/research/index.ts
+++ b/src/store/research/index.ts
@@ -181,6 +181,29 @@ const initialState = {
 
 // ========== API Services ==========
 
+// Phase 1.5.3 (Audit Finding #1) — emit telemetry whenever a search source
+// fails so we can detect API outages (PubMed eutils, OpenAlex, etc) without
+// relying on user complaints. Always paired with `return []` so the search
+// continues with the remaining sources. The try/catch around posthog
+// guarantees a missing analytics global never breaks the search path.
+const captureSearchSourceFailed = (
+  source: SearchSource,
+  error: unknown,
+  context: { query?: string; surface?: string },
+) => {
+  try {
+    const errMsg = error instanceof Error ? error.message : String(error);
+    (window as any).posthog?.capture('search_source_failed', {
+      error: errMsg.slice(0, 200),
+      query: (context.query || '').slice(0, 100),
+      source,
+      surface: context.surface || 'research_mode',
+    });
+  } catch {
+    /* posthog not loaded — skip silently */
+  }
+};
+
 const searchPubMed = async (query: string, maxResults = 10, offset = 0): Promise<PaperResult[]> => {
   try {
     const response = await fetch('/api/plugins/pubmed/search', {
@@ -207,6 +230,7 @@ const searchPubMed = async (query: string, maxResults = 10, offset = 0): Promise
     }));
   } catch (error) {
     console.error('[Research] PubMed search error:', error);
+    captureSearchSourceFailed('PubMed', error, { query, surface: 'research_mode' });
     return [];
   }
 };
@@ -240,6 +264,7 @@ const searchOpenAlex = async (
     }));
   } catch (error) {
     console.error('[Research] OpenAlex search error:', error);
+    captureSearchSourceFailed('OpenAlex', error, { query, surface: 'research_mode' });
     return [];
   }
 };
@@ -270,6 +295,7 @@ const searchArXiv = async (query: string, maxResults = 10, offset = 0): Promise<
     }));
   } catch (error) {
     console.error('[Research] ArXiv search error:', error);
+    captureSearchSourceFailed('ArXiv', error, { query, surface: 'research_mode' });
     return [];
   }
 };
@@ -315,6 +341,7 @@ const searchClinicalTrials = async (
     }));
   } catch (error) {
     console.error('[Research] ClinicalTrials.gov search error:', error);
+    captureSearchSourceFailed('ClinicalTrials.gov', error, { query, surface: 'research_mode' });
     return [];
   }
 };

--- a/src/utils/research/safetyPrompt.ts
+++ b/src/utils/research/safetyPrompt.ts
@@ -1,0 +1,28 @@
+/**
+ * Medical safety framing prompt — prepended to LLM prompts that involve
+ * sensitive medical content (suicidality, depression, mortality, abuse,
+ * drug adverse events). Without this framing, Gemini Flash safety filter
+ * aggressively refuses with a single "stop" token instead of producing
+ * the requested clinical synthesis.
+ *
+ * Audit ADR (Phase 1.5.3): apply this prefix to ALL Gemini Flash calls
+ * touching medical content — not just Deep Research article gen.
+ *
+ * Phase 1.5.2 introduced this prefix only in Deep Research article gen
+ * (Bug G fix). Phase 1.5.3 extracts it as shared constant + applies to
+ * Research Mode Writing and Screening, which also gather PICO + paper
+ * abstracts and face the same safety filter risk.
+ */
+export const MEDICAL_SAFETY_PREFIX = `You are assisting a licensed physician in conducting a medical literature review for clinical decision support. The retrieved papers describe documented clinical outcomes from peer-reviewed pharmacovigilance studies and randomized trials.
+
+CRITICAL CONTEXT:
+- This is for healthcare professionals, NOT patient-facing content
+- Discussing documented adverse events (including suicidality, depression, mortality) is essential for evidence-based medicine and patient safety
+- Refusing to summarize peer-reviewed medical literature would harm clinical decision-making
+- Your output is a balanced clinical synthesis, not medical advice or a diagnostic recommendation
+
+Produce a comprehensive, evidence-grounded analysis.
+
+---
+
+`;


### PR DESCRIPTION
## Why

Phase 1.5.2 (PR #21) shipped successfully and verified pass 6/6 manual tests. But comprehensive audit (`AUDIT-research-modes.md` reference notes in repo) identified 14 silent failure points across Research Mode + Deep Research. Phase 1.5.3 batches the 5 highest-ROI fixes (Tier 1) before any further user testing.

The unifying theme is **observability before optimization** — silent fallbacks (regex screening, template writing, empty-array search) have been hiding bugs from PostHog. Once we have data on real frequency of these fallbacks, Phase 2 priorities become data-driven instead of reactive fix-forward.

## What

1. **Audit #1**: All 4 search sources (PubMed, OpenAlex, ArXiv, ClinicalTrials.gov) emit `search_source_failed` telemetry on catch — Research Mode AND Deep Research surfaces. Helper `captureSearchSourceFailed` in `src/store/research/index.ts`; inline posthog capture in `DeepResearch/Body.tsx` for PubMed + Semantic Scholar.

2. **Audit #4**: All 10 PostHog events in DeepResearch get `surface: 'deep_research'` (research_started, research_query_translated, research_papers_found, research_no_papers, research_no_papers_continued, article_generation_started, article_safety_filter_suspected, article_generation_complete, article_generation_failed, ai_rate_limit_429). After deploy: 0 nulls on `surface` for Deep Research.

3. **Audit #6**: `MEDICAL_SAFETY_PREFIX` extracted to shared `src/utils/research/safetyPrompt.ts`. Applied to Research Mode Writing + Screening (previously only Deep Research article gen had it).

4. **Audit #7**: `callAIStream` output strips `(\w)stop$`, `<|im_end|>`, `<|endoftext|>`, `</stop>` artifacts — same regex Phase 1.5.1 used for `buildSearchQuery`.

5. **Audit #2 + #3**: Screening + Writing fallbacks now:
   - Return `AIScreenResult` / `AIWriteResult` with `usedFallback` + `fallbackReason` flags
   - Emit `screening_fallback_to_keyword` / `writing_fallback_to_template` telemetry on AI failure
   - Show antd Alert + \"Thử lại AI\" button so user can retry
   - `Writing.handleCopyAll` blocks export with `Modal.confirm` when unfilled placeholders ([number], [key finding], etc.) detected

## Architectural ADR added

> Any fallback degrading quality (template, regex, empty array) MUST:
> 1. Emit a PostHog telemetry event with error context
> 2. Surface a UX indicator to the user (warning banner, badge, etc) so they can choose to retry
>
> Apply this rule to Pho.Chat v2 \`research-engine\` package when porting.

## Note on commit granularity

Mega-prompt §8 suggested 5 separate commits per audit task. Implementation reality: \`DeepResearch/Body.tsx\` has interleaved hunks across Tasks 1+2+3+4, and Screening/Writing have interleaved hunks across Tasks 3+5 — splitting cleanly at hunk-level non-interactively was not practical. Single commit \`44601217ae\` covers all 5 audit fixes; commit message + this PR description preserve the audit-level audit trail.

## Test plan

- [ ] Block ai-summary endpoint via DevTools → trigger AI screening in Research Mode → verify warning Alert \"AI screening tạm thời không khả dụng\" appears + Retry button
- [ ] Same for Writing → verify per-section Alert with Retry
- [ ] Try Copy All on Writing draft containing \`[number]\` / \`[key finding]\` → verify Modal.confirm before clipboard write
- [ ] Run R5 query (\`tổng quan tác động GLP1a lên khí sắc semaglutide\`) on Deep Research → verify article output Key Takeaways no longer has \`.stop\` suffix
- [ ] PostHog 6-12h after deploy: verify Deep Research events have \`surface = 'deep_research'\` (no nulls); verify \`search_source_failed\` exists if any source had real outage; verify \`screening_fallback_to_keyword\` / \`writing_fallback_to_template\` rates < 5%
- [ ] Smoke test happy path: Research Mode VN query (no regression on PICO/papers/translation) + Deep Research VN (no regression on safety prefix)

## Out of scope (deferred to Tier 2)

- Audit #5: relevance ranking by query similarity (Phase 2)
- Audit #13: refactor Writing/Screening to shared \`callAI\` helper
- Audit #8: cache LRU/TTL
- Audit #9, #10, #11, #12: low-severity catches and console pollution
- UX/discoverability redesign (Phase 1.7)

## Rollback

Promote \`dpl_4xB56PdDS4kdu5EaXiEP67ackJ3K\` (commit d7fadce7, Phase 1.5.2 — current production).
Or further: \`dpl_FnxAq8HMhjPabGFJvaHWWKVbcBL4\` (commit a7912e7, Phase 1.5.1).

## Verified

- \`tsc --noEmit\` — clean
- \`eslint\` on touched files — clean (1 \`unicorn/better-regex\` finding fixed during build)
- \`vitest run src/utils/research\` — 22/22 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Research Mode and Deep Research by surfacing and tracking silent fallbacks, and by cleaning stray model tokens. Users now get clear warnings with retry when screening/writing degrade, and telemetry captures outages and event surfaces for data-driven follow-up.

- Bug Fixes
  - Emit `search_source_failed` for PubMed, OpenAlex, ArXiv, and ClinicalTrials.gov across both surfaces.
  - Add `surface: 'deep_research'` to all Deep Research PostHog events.
  - Strip trailing artifacts in streamed output: ".stop", `<|im_end|>`, `<|endoftext|>`, `</stop>`.
  - Screening: return `usedFallback`/`fallbackReason`, capture `screening_fallback_to_keyword`, and show a warning with a retry button.
  - Writing: return `usedFallback`/`fallbackReason`, capture `writing_fallback_to_template`, show a warning with a retry button, and block “Copy all” if placeholders remain.

- Refactors
  - Extract `MEDICAL_SAFETY_PREFIX` to `src/utils/research/safetyPrompt.ts` and apply it to Writing and Screening (previously only in Deep Research).

<sup>Written for commit 44601217ae8614f49490bd60be031552df1034d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transparent error alerts with retry actions when AI screening and writing operations fail, replacing silent fallbacks.
  * Added validation to prevent copying incomplete content with unfilled placeholders.

* **Bug Fixes**
  * Improved streaming output cleanup to remove chat artifacts.
  * Enhanced error tracking for external search sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->