### PR TITLE
🚑 hotfix(scripts): seed-model-pricing CJS top-level await fix

### DIFF
--- a/scripts/seed-model-pricing.ts
+++ b/scripts/seed-model-pricing.ts
@@ -118,7 +118,17 @@ async function seed() {
   if (failed > 0) throw new Error(`${failed} seed insertions failed`);
 }
 
-await seed().catch((e) => {
-  console.error('\n❌ Seed failed:', e);
-  throw e;
-});
+// Top-level await fails on tsx default CJS output (Node v24.x). Wrap in async IIFE
+// for CJS compat. process.exit is intentional for CLI exit-code propagation.
+// eslint-disable-next-line unicorn/prefer-top-level-await
+(async () => {
+  try {
+    await seed();
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(0);
+  } catch (e) {
+    console.error('\n❌ Seed failed:', e);
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary

Quick hotfix for PR #24 follow-up. The seed script `scripts/seed-model-pricing.ts` shipped with top-level await, which fails on `tsx` default CJS output (Node v24.5.0):

```
ERROR: Top-level await is currently not supported with the "cjs" output format
File: scripts/seed-model-pricing.ts:121
```

## Fix

Wrapped seed invocation in async IIFE — equivalent behavior, CJS-compatible. Added scoped `eslint-disable` for `unicorn/prefer-top-level-await` and `unicorn/no-process-exit` with inline justification (script IS a CLI, exit codes are intentional for propagation).

## Verification

- `bun run type-check` → exit 0
- Runtime dry-run (no `DATABASE_URL`): script parses, imports resolve, reaches seed loop without errors
- Pre-commit hooks (prettier + eslint) pass

## Test plan

- [ ] Merge PR
- [ ] Pull `main` locally
- [ ] Run `pnpm tsx scripts/seed-model-pricing.ts` against prod with `DATABASE_URL` set
- [ ] Verify 9 ✅ rows printed
- [ ] Verify in DB: `SELECT count(*) FROM model_pricing WHERE id LIKE 'seed_phase2_%';` → 9

## Refs

- PHO-223 follow-up
- Post-merge of #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a runtime error from top-level await in the seed script under `tsx` CJS on Node v24.x. The script now runs reliably and returns correct CLI exit codes (follow-up to PHO-223).

- **Bug Fixes**
  - Wrapped the seed call in an async IIFE for CJS compatibility.
  - Added scoped `eslint-disable` for `unicorn/prefer-top-level-await` and `unicorn/no-process-exit` with inline comments.

<sup>Written for commit 930ca369bda6f1d7cd25f58075a237e0fbe4bd03. Summary will update on new commits. <a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/25?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling and process termination for internal seeding script with explicit exit codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->