### PR TITLE
🐛 fix(billing): close usage_logs hole Tier 2/3 atomic-slot (PHO-224)

### DIFF
--- a/src/server/services/billing/credits.ts
+++ b/src/server/services/billing/credits.ts
@@ -136,9 +136,18 @@ export async function processModelUsage(
     let newTier2Usage = isSameDay ? user.dailyTier2Usage || 0 : 0;
     let newTier3Usage = isSameDay ? user.dailyTier3Usage || 0 : 0;
 
-    // If tier 2/3 slot was already acquired atomically by checkTierAccess,
-    // only handle credit deduction — don't touch tier counters or lastUsageDate
+    // 3. Track points actually deducted — used by the unified usage_logs insert below.
+    //    Set per-branch; defaults to `cost` (atomic-slot path) and is overwritten to
+    //    `finalCost` if the free-tier branch waives it.
+    let pointsDeducted = cost;
+
+    // 4. Branch: atomic-slot path (Tier 2/3) vs counter-update path (Tier 1 / fallback).
+    //    PHO-224: BOTH branches now fall through to the usage_logs insert below.
+    //    The previous early `return;` left every Tier 2/3 paid request invisible
+    //    in usage_logs (points deducted but no log row).
     if (tierSlotAlreadyAcquired && (tier === 2 || tier === 3)) {
+      // Atomic-slot path: tier counters are managed exclusively by atomicAcquireTierSlot()
+      // in checkTierAccess(). Only deduct credits here; don't touch counters or lastUsageDate.
       if (cost > 0) {
         await db
           .update(users)
@@ -151,73 +160,73 @@ export async function processModelUsage(
           `[Credits] Deducted ${cost} Credits (Tier ${tier}, atomic slot). User: ${userId}`,
         );
       }
-      return;
-    }
+      // pointsDeducted already === cost (set above).
+    } else {
+      // Counter-update path: Tier 1 (with free-tier waiver) or non-slot fallback.
+      // Free Tier: first FREE_TIER_LIMIT Tier 1 requests/day are zero-cost.
+      const FREE_TIER_LIMIT = 5;
+      let finalCost = cost;
+      let isFree = false;
 
-    // 3. Free Tier Logic (Tier 1 only)
-    // Free Tier Limit: 5 requests/day for Tier 1 models
-    const FREE_TIER_LIMIT = 5;
-
-    let finalCost = cost;
-    let isFree = false;
-
-    // Increment appropriate tier usage
-    switch (tier) {
-      case 1: {
-        if (newTier1Usage < FREE_TIER_LIMIT) {
-          finalCost = 0; // Free!
-          isFree = true;
+      switch (tier) {
+        case 1: {
+          if (newTier1Usage < FREE_TIER_LIMIT) {
+            finalCost = 0; // Free!
+            isFree = true;
+          }
+          newTier1Usage += 1;
+          break;
         }
-        newTier1Usage += 1;
-        break;
+        case 2:
+        case 3: {
+          // Tier 2/3 counters are ONLY incremented by atomicAcquireTierSlot()
+          // in checkTierAccess(). Do NOT increment here to avoid double-counting.
+          // This was the root cause of the tier limit bypass bug.
+          break;
+        }
+        // No default
       }
-      case 2:
-      case 3: {
-        // Tier 2/3 counters are ONLY incremented by atomicAcquireTierSlot()
-        // in checkTierAccess(). Do NOT increment here to avoid double-counting.
-        // This was the root cause of the tier limit bypass bug.
-        break;
-      }
-      // No default
-    }
 
-    // 4. Update DB — only update tier1 counter + credits.
-    //    Tier 2/3 counters are managed exclusively by atomicAcquireTierSlot().
-    //    On day-reset (isSameDay=false), reset tier 2/3 to 0.
-    const updatePayload: Record<string, any> = {
-      dailyTier1Usage: newTier1Usage,
-      lastUsageDate: now,
-      lifetimeSpent: sql`${users.lifetimeSpent} + ${finalCost}`,
-      phoPointsBalance: sql`GREATEST(0, ${users.phoPointsBalance} - ${finalCost})`,
-    };
-    if (!isSameDay) {
-      // New day: reset tier 2/3 counters (atomicAcquireTierSlot will set to 1 on first use)
-      updatePayload.dailyTier2Usage = 0;
-      updatePayload.dailyTier3Usage = 0;
-    }
-    await db.update(users).set(updatePayload).where(eq(users.id, userId));
-
-    if (process.env.NODE_ENV !== 'production') {
-      if (isFree) {
-        console.log(
-          `[Credits] Free Tier used (${newTier1Usage}/${FREE_TIER_LIMIT}). Cost waived for user ${userId}.`,
-        );
-      } else if (finalCost > 0) {
-        console.log(
-          `[Credits] Deducted ${finalCost} Credits (Tier ${tier}). T1=${newTier1Usage}, T2=${newTier2Usage}, T3=${newTier3Usage}. User: ${userId}`,
-        );
+      // Update DB — only update tier1 counter + credits.
+      // Tier 2/3 counters are managed exclusively by atomicAcquireTierSlot().
+      // On day-reset (isSameDay=false), reset tier 2/3 to 0.
+      const updatePayload: Record<string, any> = {
+        dailyTier1Usage: newTier1Usage,
+        lastUsageDate: now,
+        lifetimeSpent: sql`${users.lifetimeSpent} + ${finalCost}`,
+        phoPointsBalance: sql`GREATEST(0, ${users.phoPointsBalance} - ${finalCost})`,
+      };
+      if (!isSameDay) {
+        // New day: reset tier 2/3 counters (atomicAcquireTierSlot will set to 1 on first use)
+        updatePayload.dailyTier2Usage = 0;
+        updatePayload.dailyTier3Usage = 0;
       }
+      await db.update(users).set(updatePayload).where(eq(users.id, userId));
+
+      if (process.env.NODE_ENV !== 'production') {
+        if (isFree) {
+          console.log(
+            `[Credits] Free Tier used (${newTier1Usage}/${FREE_TIER_LIMIT}). Cost waived for user ${userId}.`,
+          );
+        } else if (finalCost > 0) {
+          console.log(
+            `[Credits] Deducted ${finalCost} Credits (Tier ${tier}). T1=${newTier1Usage}, T2=${newTier2Usage}, T3=${newTier3Usage}. User: ${userId}`,
+          );
+        }
+      }
+
+      pointsDeducted = finalCost;
     }
 
     // NOTE: Redis sync removed — DailyTierRateLimiter.check() already
     // increments pho:ratelimit:* keys via checkTierAccess() in the chat route.
     // The duplicate INCR here was causing admin dashboard to show 2x actual usage.
 
-    // 5. Log to usage_logs with actual model/tier/tokens
+    // 5. Log to usage_logs with actual model/tier/tokens (PHO-224: unified for BOTH branches).
     if (usageLog) {
       try {
         const VND_RATE = 24_167;
-        const costUSD = usageLog.costUSD ?? finalCost * 0.000_04; // fallback: 1 point ≈ $0.00004
+        const costUSD = usageLog.costUSD ?? pointsDeducted * 0.000_04; // fallback: 1 point ≈ $0.00004
         await db.insert(usageLogs).values({
           costUSD,
           costVND: costUSD * VND_RATE,
@@ -225,7 +234,7 @@ export async function processModelUsage(
           model: usageLog.model,
           modelTier: tier,
           outputTokens: usageLog.outputTokens,
-          pointsDeducted: finalCost,
+          pointsDeducted,
           provider: usageLog.provider,
           responseTimeMs: usageLog.responseTimeMs ?? null,
           sessionId: usageLog.sessionId ?? null,


### PR DESCRIPTION
## Summary

Fix for PHO-224. Investigation: #26.

`processModelUsage` was returning early at `credits.ts:154` for the Tier 2/3 atomic-slot path, **before** the `usage_logs` insert at line 217. Every Tier 2/3 paid request had points deducted but no log row written. Bug is universal — affects every Tier 2/3 user since the early-return branch landed (not just vuthanhhuong's 217 misses).

## Before

```
processModelUsage(...)
├── atomic-slot branch (Tier 2/3) → deduct points → return; ❌ usage_logs skipped
└── counter-update branch (Tier 1) → deduct → insert usage_logs ✅
```

## After

```
processModelUsage(...)
├── atomic-slot branch (Tier 2/3) → deduct points → fall through ↓
└── counter-update branch (Tier 1) → deduct → fall through ↓
                                                              ↓
                              ✅ unified usage_logs insert (single source of truth)
```

## Implementation (Option 1c)

- Introduce `pointsDeducted` accumulator at top of fn (defaults to `cost`).
- Wrap the prior fall-through code in `else { ... }`, reassign `pointsDeducted = finalCost` at the end of that branch.
- Remove the early `return;` from the atomic-slot branch.
- Move the `usage_logs` insert outside both branches; reference `pointsDeducted` instead of `finalCost`.

**Diff:** 1 file, +66/-57 (mostly indent shift; net ~10 LoC of new logic). Schema: NO migration.

## Edge cases verified

| Scenario | `pointsDeducted` | usage_logs row? |
|---|---|---|
| Tier 3 atomic slot + cost>0 (post-PHO-223) | `cost` | ✅ inserted |
| Tier 3 atomic slot + cost=0 (pre-seed scenario) | `0` | ✅ inserted |
| Tier 1 free (under 5/day) | `0` | ✅ inserted (existing) |
| Tier 1 paid (over 5/day) | `cost` | ✅ inserted (existing) |
| Tier 2/3 NON-slot fallback | `cost` | ✅ inserted (existing) |
| `usageLog` arg not passed | n/a | skipped (existing) |

## Verification

- [x] `bun run type-check` → exit 0
- [x] Pre-commit hooks (prettier + eslint) pass
- [ ] **Hien post-deploy smoke:** 1 chat request per tier (T1, T2, T3); verify new `usage_logs` rows for each
- [ ] **Hien backfill check:** 24h after deploy, query `usage_logs` for vuthanhhuong + bachcvp1316 — expect rows now appearing
- [ ] **Hien metric watch:** Vercel AI Gateway $/h trend over 24-48h — expect drop as Tier 3 metering normalizes

## Risk

Low-Med. Single billing fn, no schema change, type-check clean. The atomic-slot deduction path is preserved bit-for-bit; only addition is the unified `usage_logs` insert.

## Refs

- Linear: PHO-224 (Phase 2.1 P0-2)
- Investigation report: `docs/audit/pho-224-investigation-2026-04-29.md`
- Sibling PR (investigation): #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PHO-224 by ensuring all Tier 2/3 atomic-slot requests write to `usage_logs`. This closes a bug where points were deducted but no log row was created.

- **Bug Fixes**
  - Removed early return in the Tier 2/3 atomic-slot path; both branches now converge to a single `usage_logs` insert.
  - Added a `pointsDeducted` accumulator to log the exact charged points (handles Tier 1 free requests and paid paths).
  - Preserves counter rules: Tier 2/3 counters remain managed by `atomicAcquireTierSlot`; Tier 1 free limit is unchanged.
  - Code-only change with no schema updates.

<sup>Written for commit 3c70ed400f89cd37ace2cc508cb0779c2d9aae1c. Summary will update on new commits. <a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/27?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of credit deduction calculations by ensuring consistent calculation methods across all request types
  * Enhanced usage logging to capture all model requests for better billing transparency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->