### PR TITLE
🐛 fix(billing): Phase 2.2 — pre-flight + VN-tz (PHO-225 + PHO-228, PHO-229 deferred)

### DIFF
--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -348,14 +348,23 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
       prefetchedCreditStatus = await getUserCreditBalance(jwtPayload.userId);
       const balance = prefetchedCreditStatus?.balance || 0;
 
-      // Allow small overdraft (e.g. -10k VND) to prevent cutoff mid-sentence
-      // But block if significantly negative
-      if (balance < -10_000) {
+      // PHO-225: block when Phở Points are depleted AND no Tier 1 free quota left.
+      // The previous `balance < -10_000` check could never trigger because
+      // deductPhoCredits floors balance at 0 via GREATEST(0, ...), so any user
+      // who hit 0 kept chatting for free. Tier 1 free quota (5/day) is preserved
+      // — users can still send their daily free messages with 0 balance.
+      // Free users requesting Tier 2/3 are blocked downstream by canUseTier.
+      const FREE_TIER_LIMIT = 5;
+      const dailyTier1Usage = prefetchedCreditStatus?.dailyTier1Usage ?? 0;
+      const hasFreeTier1Quota = dailyTier1Usage < FREE_TIER_LIMIT;
+
+      if (balance <= 0 && !hasFreeTier1Quota) {
         console.warn(
-          `🚫 Blocked request due to negative balance: ${balance} (User: ${jwtPayload.userId})`,
+          `🚫 Blocked: balance ${balance} <= 0 and Tier 1 free quota exhausted ` +
+            `(${dailyTier1Usage}/${FREE_TIER_LIMIT}). User: ${jwtPayload.userId}`,
         );
         return createErrorResponse(AgentRuntimeErrorType.InsufficientQuota, {
-          error: { message: 'Phở Points không đủ. Vui lòng nạp thêm để tiếp tục.' },
+          error: { message: 'Phở Points đã hết. Vui lòng nạp thêm để tiếp tục.' },
           provider: 'pho-chat',
         });
       }

--- a/src/server/services/billing/credits.ts
+++ b/src/server/services/billing/credits.ts
@@ -98,6 +98,17 @@ export interface UsageLogParams {
   sessionId?: string;
 }
 
+/**
+ * Get today's date string in Vietnam timezone (UTC+7) for daily-counter comparison.
+ * Used by both processModelUsage / atomicAcquireTierSlot and the daily-request-cap
+ * check downstream — keeps every "is it the same VN day?" decision aligned.
+ */
+function getVietnamDateString(date: Date = new Date()): string {
+  // UTC+7 (no DST in Vietnam): add 7 hours in milliseconds.
+  const vnTime = new Date(date.getTime() + 7 * 60 * 60 * 1000);
+  return vnTime.toISOString().slice(0, 10);
+}
+
 export async function processModelUsage(
   userId: string,
   cost: number,
@@ -124,12 +135,17 @@ export async function processModelUsage(
     if (userRows.length === 0) return;
     const user = userRows[0];
 
-    // 2. Check for daily reset (reset at midnight)
-    const lastDate = new Date(user.lastUsageDate || 0);
-    const isSameDay =
-      lastDate.getDate() === now.getDate() &&
-      lastDate.getMonth() === now.getMonth() &&
-      lastDate.getFullYear() === now.getFullYear();
+    // 2. Check for daily reset using Vietnam timezone (UTC+7).
+    // PHO-228: previously compared via JS Date.getDate/Month/Year which on
+    // Vercel resolves to UTC. Daily counters were resetting at 00:00 UTC
+    // = 07:00 VN, giving every Vietnam user ~7h of "extra" daily quota each
+    // morning. Now aligned with the rest of the billing path that already
+    // uses getVietnamDateString (see checkDailyRequestCap).
+    const todayVN = getVietnamDateString(now);
+    const lastUsageVN = user.lastUsageDate
+      ? getVietnamDateString(new Date(user.lastUsageDate))
+      : '';
+    const isSameDay = lastUsageVN === todayVN;
 
     // If not same day, reset all tier usage to 0
     let newTier1Usage = isSameDay ? user.dailyTier1Usage || 0 : 0;
@@ -355,21 +371,21 @@ async function atomicAcquireTierSlot(
         UPDATE users
         SET
           daily_tier3_usage = CASE
-            WHEN (last_usage_date IS NULL OR last_usage_date::date < CURRENT_DATE) THEN 1
+            WHEN (last_usage_date IS NULL OR (last_usage_date AT TIME ZONE 'Asia/Ho_Chi_Minh')::date < (NOW() AT TIME ZONE 'Asia/Ho_Chi_Minh')::date) THEN 1
             ELSE daily_tier3_usage + 1
           END,
           daily_tier2_usage = CASE
-            WHEN (last_usage_date IS NULL OR last_usage_date::date < CURRENT_DATE) THEN 0
+            WHEN (last_usage_date IS NULL OR (last_usage_date AT TIME ZONE 'Asia/Ho_Chi_Minh')::date < (NOW() AT TIME ZONE 'Asia/Ho_Chi_Minh')::date) THEN 0
             ELSE daily_tier2_usage
           END,
           daily_tier1_usage = CASE
-            WHEN (last_usage_date IS NULL OR last_usage_date::date < CURRENT_DATE) THEN 0
+            WHEN (last_usage_date IS NULL OR (last_usage_date AT TIME ZONE 'Asia/Ho_Chi_Minh')::date < (NOW() AT TIME ZONE 'Asia/Ho_Chi_Minh')::date) THEN 0
             ELSE daily_tier1_usage
           END,
           last_usage_date = NOW()
         WHERE id = ${userId}
           AND (
-            (last_usage_date IS NULL OR last_usage_date::date < CURRENT_DATE)
+            (last_usage_date IS NULL OR (last_usage_date AT TIME ZONE 'Asia/Ho_Chi_Minh')::date < (NOW() AT TIME ZONE 'Asia/Ho_Chi_Minh')::date)
             OR daily_tier3_usage < ${dailyLimit}
           )
         RETURNING daily_tier3_usage
@@ -387,21 +403,21 @@ async function atomicAcquireTierSlot(
       UPDATE users
       SET
         daily_tier2_usage = CASE
-          WHEN (last_usage_date IS NULL OR last_usage_date::date < CURRENT_DATE) THEN 1
+          WHEN (last_usage_date IS NULL OR (last_usage_date AT TIME ZONE 'Asia/Ho_Chi_Minh')::date < (NOW() AT TIME ZONE 'Asia/Ho_Chi_Minh')::date) THEN 1
           ELSE daily_tier2_usage + 1
         END,
         daily_tier3_usage = CASE
-          WHEN (last_usage_date IS NULL OR last_usage_date::date < CURRENT_DATE) THEN 0
+          WHEN (last_usage_date IS NULL OR (last_usage_date AT TIME ZONE 'Asia/Ho_Chi_Minh')::date < (NOW() AT TIME ZONE 'Asia/Ho_Chi_Minh')::date) THEN 0
           ELSE daily_tier3_usage
         END,
         daily_tier1_usage = CASE
-          WHEN (last_usage_date IS NULL OR last_usage_date::date < CURRENT_DATE) THEN 0
+          WHEN (last_usage_date IS NULL OR (last_usage_date AT TIME ZONE 'Asia/Ho_Chi_Minh')::date < (NOW() AT TIME ZONE 'Asia/Ho_Chi_Minh')::date) THEN 0
           ELSE daily_tier1_usage
         END,
         last_usage_date = NOW()
       WHERE id = ${userId}
         AND (
-          (last_usage_date IS NULL OR last_usage_date::date < CURRENT_DATE)
+          (last_usage_date IS NULL OR (last_usage_date AT TIME ZONE 'Asia/Ho_Chi_Minh')::date < (NOW() AT TIME ZONE 'Asia/Ho_Chi_Minh')::date)
           OR daily_tier2_usage < ${dailyLimit}
         )
       RETURNING daily_tier2_usage
@@ -511,13 +527,6 @@ export async function checkTierAccess(
 // Uses existing tier counters from getUserCreditBalance() (no extra DB query)
 // Resets at 00:00 UTC+7 (Vietnam timezone)
 // ============================================================================
-
-/** Get today's date string in Vietnam timezone (UTC+7) for comparison */
-function getVietnamDateString(date: Date = new Date()): string {
-  // UTC+7: add 7 hours in milliseconds
-  const vnTime = new Date(date.getTime() + 7 * 60 * 60 * 1000);
-  return vnTime.toISOString().slice(0, 10);
-}
 
 /**
  * Check if user has exceeded their daily request cap.


### PR DESCRIPTION
## Summary

Phase 2.2 cost hardening — 2 of 3 planned fixes shipped together. PHO-229 (embedding metering) deferred.

## PHO-225 — Pre-flight balance check now actually blocks

**Bug:** `route.ts:353` had `if (balance < -10_000)` which could never trigger. `deductPhoCredits` floors balance at 0 via `GREATEST(0, ...)`, so any user who hit 0 kept chatting for free.

**Fix:** Block when `balance <= 0 && dailyTier1Usage >= 5`. Free Tier 1 quota (5/day) preserved — free users can still send their daily free messages with 0 balance. Free users hitting Tier 2/3 are already blocked by `canUseTier` downstream, so no UX regression.

## PHO-228 — Daily counter reset uses Vietnam timezone

**Bug:** Two places used UTC for daily reset detection, causing counters to reset at 07:00 Vietnam time (00:00 UTC) instead of midnight VN. Every VN user got ~7h of "extra" free quota every morning.

| Path | Before | After |
|---|---|---|
| `processModelUsage` JS `isSameDay` | `Date.getDate/Month/Year` (UTC on Vercel) | `getVietnamDateString` helper |
| `atomicAcquireTierSlot` SQL (×8 instances) | `last_usage_date::date < CURRENT_DATE` | `(last_usage_date AT TIME ZONE 'Asia/Ho_Chi_Minh')::date < (NOW() AT TIME ZONE 'Asia/Ho_Chi_Minh')::date` |

Schema confirms `last_usage_date` is `timestamptz` → `AT TIME ZONE` pattern works correctly.

`getVietnamDateString` was relocated above `processModelUsage` (same body, ESLint `no-use-before-define`). It's now used by 3 paths: `processModelUsage`, `atomicAcquireTierSlot` (via SQL), and `checkDailyRequestCap` — single source of VN-day truth.

## PHO-229 — DEFERRED

`chunk.ts` has 2 embedding call sites (`semanticSearch` + `semanticSearchForChat`). Adding metering requires token counting per call, embedding pricing rows in `model_pricing` (PHO-223 only seeded chat models), and a different `processModelUsage` shape (no input/output split, no tier slot). Out of scope for this atomic PR — separate follow-up.

## Verification

- [x] `bun run type-check` → exit 0
- [x] Pre-commit (prettier + eslint) pass
- [x] All 8 SQL VN-tz substitutions verified via grep
- [ ] **Hien post-deploy smoke (PHO-225):** chat as `vn_free` user with 0 balance + 5+ Tier 1 reqs already used today → expect 402-ish `InsufficientQuota` rejection
- [ ] **Hien post-deploy smoke (PHO-225):** chat as paid user with 0 balance → expect rejection (currently silently free)
- [ ] **Hien post-deploy smoke (PHO-228):** at ~06:55 VN time, send Tier 3 request that should be at daily limit → counter should NOT reset until 00:00 VN
- [ ] **Hien post-deploy smoke (PHO-228):** observe `usage_logs` daily volume spike — should now appear at 00:00 VN, not 07:00 VN
- [ ] **Hien metric watch:** Vercel AI Gateway $/h trend over 24-48h

## Risk

**Med.** Two billing-critical changes:
1. Pre-flight block (PHO-225) — could over-block if `dailyTier1Usage` is undercounted; verify with a smoke test that consumes 5 free reqs.
2. SQL TZ change (PHO-228) — atomic UPDATE in hot path; tested only via type-check, not local DB. Roll back via revert if VN cutover behavior is wrong on production.

Schema: **NO migrations.**

## Refs

- Linear: PHO-225, PHO-228 (Phase 2.2)
- Audit plan: `docs/audit/cost-phase-2-implementation-plan.md`
- Estimated savings: \$25-40/month (PHO-229 \$5-10 deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens billing in Phase 2.2 by blocking chats when points are depleted (after free Tier 1 quota) and aligning daily resets to Vietnam time. Stops silent free usage and removes the extra morning quota.

- **Bug Fixes**
  - PHO-225: Block when `balance <= 0` and `dailyTier1Usage >= 5`. Keeps 5/day Tier 1 free messages. Tier 2/3 already blocked downstream.
  - PHO-228: Daily counters now reset at VN midnight (UTC+7). JS uses a shared `getVietnamDateString`; SQL compares dates via `AT TIME ZONE 'Asia/Ho_Chi_Minh'`. Prevents ~7h extra free quota. No schema changes.

<sup>Written for commit c0c45003498f3b6711ed6385be693ce3be8630c6. Summary will update on new commits. <a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/28?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

