### PR TITLE
🐛 fix(billing): mid-stream abort + Tier 3 cap inversion (PHO-230 + PHO-234)

### DIFF
--- a/packages/database/src/schemas/usage.ts
+++ b/packages/database/src/schemas/usage.ts
@@ -47,6 +47,9 @@ export const usageLogs = pgTable('usage_logs', {
     errorCode?: string;
     features?: string[];
     ipAddress?: string;
+    // True when the stream aborted before completion (user disconnect, network error).
+    // Tokens reflect what was already consumed from the gateway, not the full response.
+    partial?: boolean;
     userAgent?: string;
   }>(),
 

--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -719,11 +719,17 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
       // STREAMING: Tee the stream to audit usage
       const [stream1, stream2] = bodyStream.tee();
 
-      // Process audit in background (don't await)
+      // Process audit in background (don't await).
+      // PHO-230: billing runs in `finally` so a mid-stream abort (user disconnect,
+      // network drop) still debits the user for tokens already streamed. The
+      // gateway has already charged us for those tokens; the previous silent
+      // catch here let the user escape billing entirely.
       (async () => {
+        let accumulatedText = '';
+        let completed = false;
+
         try {
           const reader = stream2.getReader();
-          let accumulatedText = '';
           const decoder = new TextDecoder();
 
           for (;;) {
@@ -731,46 +737,57 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
             if (done) break;
             accumulatedText += decoder.decode(value, { stream: true });
           }
-
-          const responseTimeMs = Date.now() - requestStartTime;
-
-          // Calculate tokens
-          const outputTokens = countTokens(accumulatedText);
-          const inputTokens =
-            data.messages?.reduce((acc, msg) => acc + countTokens(String(msg.content || '')), 0) ||
-            0;
-
-          // Calculate Cost (per 1M tokens)
-          // Cost = (Input * InputPrice + Output * OutputPrice) / 1,000,000
-          // PHO-223: read points-denominated rates (input_cost_per_1m / output_cost_per_1m).
-          // inputPrice/outputPrice are legacy VND columns (default 0) — using them yielded cost=0.
-          const inputPrice = activePricing.inputCostPer1M ?? 0;
-          const outputPrice = activePricing.outputCostPer1M ?? 0;
-          const cost = Math.ceil(
-            (inputTokens * inputPrice + outputTokens * outputPrice) / 1_000_000,
-          );
-
-          console.log(
-            `📉 Streaming Usage: ${inputTokens} in / ${outputTokens} out. Cost: ${cost} Credits. Time: ${responseTimeMs}ms`,
-          );
-
-          if (jwtPayload.userId) {
-            await processModelUsage(
-              jwtPayload.userId,
-              cost,
-              activePricing.tier || 1,
-              tierSlotAcquired,
-              {
-                inputTokens,
-                model: actualModelUsed,
-                outputTokens,
-                provider: actualProviderUsed,
-                responseTimeMs,
-              },
-            );
-          }
+          completed = true;
         } catch (e) {
-          console.error('Failed to audits stream:', e);
+          console.warn('[Chat API] Stream aborted mid-response, billing partial usage:', {
+            accumulatedChars: accumulatedText.length,
+            error: e instanceof Error ? e.message : String(e),
+          });
+        } finally {
+          try {
+            const responseTimeMs = Date.now() - requestStartTime;
+
+            // Calculate tokens (works for completed and partial streams alike).
+            const outputTokens = countTokens(accumulatedText);
+            const inputTokens =
+              data.messages?.reduce(
+                (acc, msg) => acc + countTokens(String(msg.content || '')),
+                0,
+              ) || 0;
+
+            // Calculate Cost (per 1M tokens).
+            // PHO-223: read points-denominated rates (input_cost_per_1m / output_cost_per_1m).
+            // inputPrice/outputPrice are legacy VND columns (default 0) — using them yielded cost=0.
+            const inputPrice = activePricing.inputCostPer1M ?? 0;
+            const outputPrice = activePricing.outputCostPer1M ?? 0;
+            const cost = Math.ceil(
+              (inputTokens * inputPrice + outputTokens * outputPrice) / 1_000_000,
+            );
+
+            console.log(
+              `📉 Streaming Usage${completed ? '' : ' (PARTIAL — aborted)'}: ${inputTokens} in / ${outputTokens} out. Cost: ${cost} Credits. Time: ${responseTimeMs}ms`,
+            );
+
+            // Skip only on absolute zero (no input parsed, no output streamed).
+            if (jwtPayload.userId && (inputTokens > 0 || outputTokens > 0)) {
+              await processModelUsage(
+                jwtPayload.userId,
+                cost,
+                activePricing.tier || 1,
+                tierSlotAcquired,
+                {
+                  inputTokens,
+                  model: actualModelUsed,
+                  outputTokens,
+                  partial: !completed,
+                  provider: actualProviderUsed,
+                  responseTimeMs,
+                },
+              );
+            }
+          } catch (billingError) {
+            console.error('[Chat API] Billing failed after stream:', billingError);
+          }
         }
       })();
 

--- a/src/config/pricing.ts
+++ b/src/config/pricing.ts
@@ -1125,54 +1125,31 @@ export function getDailyTierLimit(planCode: string, tier: number): number {
 // ============================================================================
 
 export const DAILY_REQUEST_CAP: Record<string, number> = {
-  
-  
-// Pro plans
-gl_premium: 500,
-  
+  // Pro plans
+  gl_premium: 500,
 
+  // Basic plans
+  gl_standard: 100,
 
+  // Free / unknown — strict cap
+  gl_starter: 20,
 
-// Basic plans
-gl_standard: 100,
+  // Ultimate / Lifetime — generous cap
+  lifetime_early_bird: 1000,
 
-  
-  
+  lifetime_last_call: 1000,
 
+  lifetime_standard: 1000,
 
-// Free / unknown — strict cap
-gl_starter: 20,
+  // Medical beta — moderate cap (was burning 71% of total cost)
+  medical_beta: 50,
 
-  
-  
+  vn_basic: 100,
 
-// Ultimate / Lifetime — generous cap
-lifetime_early_bird: 1000,
-  
-
-
-lifetime_last_call: 1000,
-
-  
-  
-
-lifetime_standard: 1000,
-  
-
-// Medical beta — moderate cap (was burning 71% of total cost)
-medical_beta: 50,
-
-  
-  
-
-vn_basic: 100,
-
-  
-  
-vn_free: 20,
+  vn_free: 20,
   // Premium plans
-vn_premium: 500,
-  vn_pro: 200,
+  vn_premium: 200,
+  vn_pro: 500,
   vn_team: 1000,
   vn_ultimate: 1000,
 };

--- a/src/server/services/billing/credits.ts
+++ b/src/server/services/billing/credits.ts
@@ -93,6 +93,11 @@ export interface UsageLogParams {
   inputTokens: number;
   model: string;
   outputTokens: number;
+  // True when the stream aborted before completion. Counts what was already
+  // consumed from the gateway so the user is debited for partial usage too —
+  // otherwise mid-stream disconnects let users escape billing while the
+  // gateway has already charged us.
+  partial?: boolean;
   provider: string;
   responseTimeMs?: number;
   sessionId?: string;
@@ -247,6 +252,7 @@ export async function processModelUsage(
           costUSD,
           costVND: costUSD * VND_RATE,
           inputTokens: usageLog.inputTokens,
+          metadata: usageLog.partial ? { partial: true } : null,
           model: usageLog.model,
           modelTier: tier,
           outputTokens: usageLog.outputTokens,


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

Final Phase 2 billing hardening — bịt 2 bug cuối:

**PHO-230 — Mid-stream abort billing leak**
- Streaming audit IIFE catch silently swallowed errors → user disconnect mid-response skipped `processModelUsage` entirely.
- Vercel AI Gateway already charged us for tokens streamed; user kept all points → free usage.
- Wrap read loop in `try/finally` with hoisted `accumulatedText` + `completed` flag. Billing always runs from `finally`.
- Partial usage rows are tagged `metadata.partial = true` for analytics.
- Skip billing only when both input AND output tokens are 0 (true no-op).

**PHO-234 — Tier 3 daily cap inversion**
- `DAILY_REQUEST_CAP` had `vn_premium=500` and `vn_pro=200` → cheaper plan ran 2.5× more requests/day than the more expensive one.
- Swap to `vn_premium=200`, `vn_pro=500` so caps grow monotonically with plan price.

#### 📝 Additional Information

**Files touched (4):**
- `src/config/pricing.ts` — cap swap (2 lines).
- `packages/database/src/schemas/usage.ts` — add `partial?: boolean` to `usage_logs.metadata` jsonb type.
- `src/server/services/billing/credits.ts` — `partial?` on `UsageLogParams`; `metadata: { partial: true }` written when set.
- `src/app/(backend)/webapi/chat/[provider]/route.ts` — try/finally streaming audit, partial billing path.

**Verification before merge:**
- `bun run type-check` → exit 0 ✓
- `eslint` on the 4 changed files → 0 warnings ✓
- Pre-commit hook (prettier + stylelint + eslint --fix) passed.

**Smoke test (manual after deploy):**
1. Start a chat with a Tier 2/3 model (so usage_logs row is observable).
2. Close the browser tab mid-response.
3. Query `usage_logs` for the user → row exists with `metadata = {"partial": true}` and `pointsDeducted > 0`.

**Combined savings:** \$5–15/month.

Linear: PHO-230, PHO-234 (Phase 2 final)
Refs: docs/audit/cost-phase-2-implementation-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a billing leak when chat streams abort mid-response and corrects inverted daily request caps for VN Premium/Pro. Addresses Linear PHO-230 and PHO-234 to prevent free token leakage and align caps with plan pricing.

- **Bug Fixes**
  - Billing on streaming: wrap the read loop in try/finally so billing always runs; charge for partial streams; mark `metadata.partial = true`; skip only when both input and output tokens are 0.
  - Daily caps: swap VN Tier 3 caps to `vn_premium = 200` and `vn_pro = 500` so limits increase with plan price.

<sup>Written for commit 8b526b756eeaa96f60d391c4a71faaa3253e7cc6. Summary will update on new commits. <a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/29?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing accuracy for streaming responses that terminate early or are interrupted mid-response.
  * Token charges now correctly apply to incomplete streaming responses.

* **Chores**
  * Internal restructuring of configuration mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->