### PR TITLE
🐛 fix(billing): Phase 2.3 — meter embeddings + PostHog exception capture (PHO-229 + PHO-232)

### DIFF
--- a/src/components/Analytics/LobeAnalyticsProviderWrapper.tsx
+++ b/src/components/Analytics/LobeAnalyticsProviderWrapper.tsx
@@ -20,6 +20,11 @@ export const LobeAnalyticsProviderWrapper = memo<Props>(({ children }) => {
         measurementId: analyticsEnv.GOOGLE_ANALYTICS_MEASUREMENT_ID ?? '',
       }}
       postHogConfig={{
+        // PHO-232: enable browser exception autocapture so $exception events
+        // ship with non-null payloads. Read these via `properties.$exception_list`
+        // (array) — the legacy flat fields ($exception_type/_message/_stack)
+        // were removed in PostHog JS ≥ 1.95.
+        capture_exceptions: true,
         capture_performance: { web_vitals: true },
         debug: analyticsEnv.DEBUG_POSTHOG_ANALYTICS,
         enabled: analyticsEnv.NEXT_PUBLIC_POSTHOG_ENABLED,

--- a/src/server/routers/async/file.ts
+++ b/src/server/routers/async/file.ts
@@ -14,6 +14,7 @@ import { fileEnv } from '@/envs/file';
 import { asyncAuthedProcedure, asyncRouter as router } from '@/libs/trpc/async';
 import { getServerDefaultFilesConfig } from '@/server/globalConfig';
 import { initModelRuntimeWithUserPayload } from '@/server/modules/ModelRuntime';
+import { meterEmbeddingUsage } from '@/server/services/billing/embeddingMetering';
 import { ChunkService } from '@/server/services/chunk';
 import { FileService } from '@/server/services/file';
 import {
@@ -98,10 +99,20 @@ export const fileRouter = router({
 
                 console.log(`run embedding task ${index + 1}`);
 
+                const chunkTexts = chunks.map((c) => c.text);
+
                 const embeddings = await agentRuntime.embeddings({
                   dimensions: 1024,
-                  input: chunks.map((c) => c.text),
+                  input: chunkTexts,
                   model,
+                });
+
+                // PHO-229: meter file-indexing embeddings (the highest-volume path).
+                await meterEmbeddingUsage({
+                  inputs: chunkTexts,
+                  model,
+                  provider,
+                  userId: ctx.userId,
                 });
 
                 const items: NewEmbeddingsItem[] =

--- a/src/server/routers/lambda/chunk.ts
+++ b/src/server/routers/lambda/chunk.ts
@@ -14,6 +14,7 @@ import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { keyVaults, serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { getServerDefaultFilesConfig } from '@/server/globalConfig';
 import { initModelRuntimeWithUserPayload } from '@/server/modules/ModelRuntime';
+import { meterEmbeddingUsage } from '@/server/services/billing/embeddingMetering';
 import { ChunkService } from '@/server/services/chunk';
 import { SemanticSearchSchema } from '@/types/rag';
 
@@ -136,6 +137,14 @@ export const chunkRouter = router({
       });
       console.timeEnd('embedding');
 
+      // PHO-229: meter embedding cost — previously these calls bypassed billing.
+      await meterEmbeddingUsage({
+        inputs: input.query,
+        model,
+        provider,
+        userId: ctx.userId,
+      });
+
       return ctx.chunkModel.semanticSearch({
         embedding: embeddings![0],
         fileIds: input.fileIds,
@@ -169,6 +178,14 @@ export const chunkRouter = router({
             dimensions: 1024,
             input: query,
             model,
+          });
+
+          // PHO-229: meter embedding cost for the chat-RAG path.
+          await meterEmbeddingUsage({
+            inputs: query,
+            model,
+            provider,
+            userId: ctx.userId,
           });
 
           embedding = embeddings![0];

--- a/src/server/services/billing/embeddingMetering.ts
+++ b/src/server/services/billing/embeddingMetering.ts
@@ -1,0 +1,61 @@
+import { processModelUsage } from './credits';
+
+/**
+ * Phở Points cost per 1M input tokens for known embedding models.
+ * Conservative defaults — refine once embedding rows land in `model_pricing`.
+ */
+const EMBEDDING_INPUT_COST_PER_1M: Record<string, number> = {
+  'embedding-001': 3750,
+  'gemini-embedding-001': 3750,
+  'text-embedding-3-large': 3300,
+  'text-embedding-3-small': 500,
+  'text-embedding-ada-002': 500,
+};
+
+const DEFAULT_EMBEDDING_COST_PER_1M = 500;
+
+interface MeterEmbeddingParams {
+  inputs: string | string[];
+  model: string;
+  provider: string;
+  userId?: string;
+}
+
+/**
+ * Record an embedding call against the user's Phở Points balance.
+ *
+ * Embeddings are always Tier 1 (no atomic slot, no daily tier limits).
+ * Token estimate uses chars/4 — coarse but better than zero, which is what
+ * we charged before (PHO-229: embeddings had no metering at all and the
+ * provider cost was eaten by the company).
+ *
+ * Failures are logged and swallowed. Embedding metering must never break
+ * the underlying request — the user already got their search/index result.
+ */
+export async function meterEmbeddingUsage({
+  inputs,
+  model,
+  provider,
+  userId,
+}: MeterEmbeddingParams): Promise<void> {
+  if (!userId) return;
+
+  const texts = Array.isArray(inputs) ? inputs : [inputs];
+  const totalChars = texts.reduce((sum, t) => sum + (t?.length ?? 0), 0);
+  if (totalChars === 0) return;
+
+  const inputTokens = Math.ceil(totalChars / 4);
+  const costPer1M = EMBEDDING_INPUT_COST_PER_1M[model] ?? DEFAULT_EMBEDDING_COST_PER_1M;
+  const cost = Math.ceil((inputTokens * costPer1M) / 1_000_000);
+
+  try {
+    await processModelUsage(userId, cost, 1, false, {
+      inputTokens,
+      model,
+      outputTokens: 0,
+      provider,
+    });
+  } catch (e) {
+    console.warn('[Embedding Metering] failed to record usage:', e);
+  }
+}


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

Phase 2.3 cleanup — bịt embedding metering hole và enable browser exception autocapture.

**PHO-229 — Embedding/RAG metering**
- 3 embedding call sites đều bypass billing: \`semanticSearch\`, \`semanticSearchForChat\` (chat-RAG), and \`embeddingChunks\` (file indexing — biggest cost path).
- Vercel AI Gateway đã charge company → user xài free → company eats $5–10/month.
- New helper \`meterEmbeddingUsage\`:
  - Estimate input tokens via chars/4.
  - Per-model rate table (text-embedding-3-small=500 pts/1M, gemini-embedding-001=3,750 pts/1M, ...).
  - Default fallback to 500 pts/1M for unknown models.
  - Routes through \`processModelUsage\` as Tier 1.
  - Failures logged + swallowed → metering never breaks RAG/upload flows.

**PHO-232 — PostHog browser exception autocapture**
- \`postHogConfig\` không có \`capture_exceptions\` → 29 historical \$exception events đều empty payload.
- Add \`capture_exceptions: true\` to \`postHogConfig\` (TS-typed; @lobehub/analytics forwards it).
- ⚠️ **Important**: PostHog JS ≥ 1.95 lưu exception data trong \`properties.\$exception_list\` (array), KHÔNG phải các flat fields legacy (\`\$exception_type\`/\`_message\`/\`_stack\`). Anh cần update PostHog insights để query \`\$exception_list[0].type\`, \`.value\`, \`.stacktrace\` — query bằng legacy fields sẽ vẫn ra null.

**PHO-235 — Orphan plan IDs**: DEFERRED.
- Without DB access, any mapping I add would be guesswork that risks mapping a paid plan to a free one (worse than current state).
- Existing \`getDailyRequestCap\`/\`getDailyTierLimit\`/\`canUseTier\` already fail-open with strict defaults for unknown plans — behavior is safe today.
- **Anh cần**: chạy \`SELECT current_plan_id, COUNT(*) FROM users GROUP BY 1\` rồi báo lại danh sách orphans → em sẽ extend \`LEGACY_PLAN_MAPPING\` trong PR follow-up.

#### 📝 Additional Information

**Files touched (4):**
- \`src/server/services/billing/embeddingMetering.ts\` — NEW helper.
- \`src/server/routers/lambda/chunk.ts\` — meter \`semanticSearch\` + \`semanticSearchForChat\`.
- \`src/server/routers/async/file.ts\` — meter \`embeddingChunks\` (file indexing).
- \`src/components/Analytics/LobeAnalyticsProviderWrapper.tsx\` — \`capture_exceptions: true\`.

**Verification:**
- \`bun run type-check\` → exit 0 ✓
- \`eslint\` on the 4 files → 0 warnings ✓
- Pre-commit hook (prettier + stylelint + eslint --fix) passed.

**Behavior change for free-tier users:**
- File indexing now counts toward Tier 1 daily quota (5 free/day).
- Heavy uploads sẽ ăn vào Tier 1 chat budget — acceptable trade-off vs. company eating provider cost silently.

**Smoke test sau deploy:**
1. **PHO-229**: Upload a small file → verify a row appears in \`usage_logs\` with \`provider='openai'\` (or 'google'/'vercelaigateway') and \`model\` = embedding model name. Cũng verify \`pho_points_balance\` decreased.
2. **PHO-232**: Trigger a JS error in browser (e.g., \`window.foo.bar\`) → check PostHog \$exception events có \`properties.\$exception_list\` array với \`type\`, \`value\`, \`stacktrace\` non-null.

Linear: PHO-229, PHO-232 shipped; PHO-235 deferred.
Refs: docs/audit/cost-phase-2-implementation-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix billing by metering embedding calls across RAG and file indexing, and enable PostHog browser exception autocapture. Implements PHO-229 and PHO-232.

- **Bug Fixes**
  - Meter embedding usage for `semanticSearch`, `semanticSearchForChat`, and file indexing: estimate tokens via chars/4, use a per-model rate table with a 500 pts/1M default, and record via `processModelUsage` as Tier 1 without blocking on failure. File indexing now counts toward the Tier 1 daily quota.
  - Enable browser exception autocapture in `postHogConfig`. Exception data is now under `properties.$exception_list` (not legacy flat fields).

<sup>Written for commit e45559fb7b015334a1fe67f43f365d32ee5cb2e2. Summary will update on new commits. <a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/30?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

