### PR TITLE
✨ feat(billing): Phase 2.4 final — PostHog cost tracking + article-gen logging + allocation design (PHO-231 + PHO-236 + PHO-237)

### DIFF
--- a/docs/audit/pho-236-article-gen-investigation-2026-04-30.md
+++ b/docs/audit/pho-236-article-gen-investigation-2026-04-30.md
@@ -1,0 +1,159 @@
+# PHO-236 — Article Generation Investigation
+
+**Date:** 2026-04-30
+**Author:** Claude (with Hien)
+**Status:** Code-only investigation — no DB/PostHog query access in this session.
+**Headline number:** 6/19 article generations failed (31.6%) per Hien's earlier audit.
+
+---
+
+## 1. Where the work happens
+
+Article generation is a single async function in
+`src/features/Portal/DeepResearch/Body.tsx` (`handleGenerateArticle`,
+lines \~1108–1440). It runs on the browser, not the server, and is the
+"Phase 4" step of Deep Research. Inputs:
+
+- `question` — the user's clinical question.
+- `outline` — outline produced in Phase 3.
+- `agents` — array of per-agent research findings (Phase 2).
+- `pubmedPapers` — top-k PubMed/Semantic Scholar papers (Phase 2).
+- `model` — user-selected model.
+
+Output: a long markdown article (target 2000–4000 words) streamed via
+`callAIStream` into `setArticle`.
+
+---
+
+## 2. Existing instrumentation (good news)
+
+The function is already heavily instrumented in PostHog:
+
+| Event                             | Where       | What it carries                                               |
+| --------------------------------- | ----------- | ------------------------------------------------------------- |
+| `article_generation_started`      | line \~1120 | `agent_count`, `model`, `outline_sections`, `surface`         |
+| `article_safety_filter_suspected` | line \~1240 | `attempt`, `model`, `output_length`, `output_preview`         |
+| `article_citation_validation`     | line \~1293 | `invalid_count`, `total_citations`, `validation_passed`       |
+| `article_generation_complete`     | line \~1309 | `generation_time_seconds`, `model`, `word_count`              |
+| `article_generation_failed`       | line \~1424 | `error`, `models_tried`, `primary_model` (legacy fields only) |
+
+There is also a multi-model fallback chain
+`[user_model, gpt-4o, gpt-4o-mini]` with two refusal heuristics:
+
+- `SUSPICIOUS_OUTPUT_THRESHOLD = 50` — output ≤ 50 chars ⇒ assume safety
+  filter, retry with the next model.
+- `MIN_ARTICLE_WORDS = 200` — output < 200 words ⇒ assume timeout/short
+  context, retry with the next model.
+
+So the system already retries 3× before declaring failure. A reported
+failure means **all three models failed**.
+
+---
+
+## 3. Why the existing failure event was not enough
+
+Pre-PHO-236, `article_generation_failed` only carried `lastError.message`
+and `models_tried`. We could not see:
+
+- Which attempt actually failed (1, 2, or 3).
+- Whether attempts hit different errors (e.g. attempt 1 = 429 rate limit,
+  attempt 2 = safety filter, attempt 3 = timeout).
+- HTTP status if it was a fetch error.
+- Per-attempt latency.
+- Output length when the refusal heuristic tripped.
+
+Without that, root-cause analysis is guessing.
+
+---
+
+## 4. Plausible failure modes (hypotheses to verify after the next batch)
+
+Ordered by my prior probability:
+
+### H1. Safety filter on **all three** fallback models for a sensitive topic (\~40%)
+
+The fallback list is `[user_model, gpt-4o, gpt-4o-mini]`. All three are
+OpenAI-family for the fallback; if a user picks `gpt-4o` as their primary,
+they effectively get only two distinct vendors and Gemini Flash is never
+tried as a backup. Mental-health, suicidality, oncology adverse events
+already triggered Gemini Flash refusals (`MEDICAL_SAFETY_PREFIX` exists
+because of this); GPT-4o can refuse them too.
+
+**If this is the cause:** add Claude Sonnet to the fallback chain.
+
+### H2. Token-limit overflow from `agentFindings.slice(0, 15_000)` plus context (\~25%)
+
+Prompt assembles `agentFindings` (15K chars), `pubmedPapers` (top 6,
+abstracts capped at 300 chars), the outline, the safety prefix, and \~80
+lines of instructions. With chat history context, this can push past
+gpt-4o-mini's effective window when the user has many active agents,
+producing truncated output that then trips `MIN_ARTICLE_WORDS`.
+
+**If this is the cause:** dynamic agentFindings cap based on model
+context size; or always summarise findings before the article step.
+
+### H3. `callAIStream` timeout on long generations (\~15%)
+
+Article target is 2000–4000 words. At streaming speeds of
+\~30 tokens/sec on Tier 3 models, the response can take 60–120 s. If
+`callAIStream` is on a 60 s Vercel function or a fetch with no
+`AbortSignal.timeout`, the stream gets cut and the model returns < 200
+words. That re-trips the heuristic and burns a retry.
+
+**If this is the cause:** raise function timeout (we already moved to
+300 s default per the platform notes); add explicit `AbortSignal` and
+distinguish "client timeout" from "server refusal" in logging.
+
+### H4. 429 rate limit cascade (\~10%)
+
+The 2 s "cool-down" before article generation (line \~1115) is a hint
+this has happened before. If a user runs many agents in parallel and
+then immediately writes the article, gpt-4o or gpt-4o-mini may 429.
+Current retry chain doesn't know to back off — it just tries the next
+model, which is also OpenAI and may share the same quota.
+
+**If this is the cause:** exponential back-off + jitter on attempt 2.
+
+### H5. Provider-specific bug we don't know yet (\~10%)
+
+The current event lacks `errorName` / `errorStatus` so we can't tell.
+The PHO-236 logging change ships exactly this so we can rule it in or
+out next time.
+
+---
+
+## 5. What this PR ships
+
+**Code change** — `src/features/Portal/DeepResearch/Body.tsx`:
+
+1. New `attemptHistory` array tracking every attempt with `model`,
+   `errorName`, `errorMessage`, `errorStatus`, `outputLength`,
+   `durationMs`.
+2. `article_generation_failed` event now carries `attempt_history` and
+   `error_name` in addition to the legacy fields.
+3. Console.error log shifted from a flat string to a structured object
+   (`{ message, name, status }`) so Vercel function logs are queryable.
+
+**No prompt or fallback-chain changes** — the retry logic is unchanged.
+We need data first.
+
+---
+
+## 6. Decisions Hien needs to make after the next \~20 article runs
+
+1. Pull `article_generation_failed` events for the next 7 days.
+2. Group failures by `attempt_history[*].errorName` and
+   `attempt_history[*].errorStatus`. Whichever cluster is largest is
+   the real bug.
+3. Apply the matching fix from §4 (or report a new pattern).
+
+---
+
+## 7. Reference: existing safety nets we are NOT changing here
+
+- `MEDICAL_SAFETY_PREFIX` (Phase 1.5.2/1.5.3) — already prepended.
+- Citation sanity check after generation (already in place).
+- GRADE table generation as a follow-up (already in place).
+- `localStorage` history of last 20 articles (already in place).
+
+These work as-is; the failure mode lives **before** any of them runs.

--- a/docs/design/pho-237-allocation-redesign-2026-04-30.md
+++ b/docs/design/pho-237-allocation-redesign-2026-04-30.md
@@ -1,0 +1,208 @@
+# PHO-237 — Phở Points Allocation + Burn Rate Redesign
+
+**Date:** 2026-04-30
+**Author:** Claude (with Hien)
+**Status:** Design doc only — no code changes. Decision required from Hien.
+
+---
+
+## 1. Current State
+
+### 1.1 Plans + monthly allocations (from `src/config/pricing.ts`)
+
+| Plan code      | Display                   | Price              | Points / mo        | Tier 2/day      | Tier 3/day | Notes                |
+| -------------- | ------------------------- | ------------------ | ------------------ | --------------- | ---------- | -------------------- |
+| `vn_free`      | Phở Không Người Lái       | 0 đ                | 50,000             | 0 (Tier 1 only) | 0          | No history           |
+| `vn_basic`     | Phở Tái (Starter)         | 69k đ/mo           | 300,000            | 30              | 0          |                      |
+| `vn_premium`   | Phở Bò Viên (Standard)    | 129k đ/mo          | 1,000,000          | ∞               | 20         |                      |
+| `vn_pro`       | Phở Đặc Biệt (Pro)        | 199k đ/mo          | 2,000,000          | ∞               | 50         | + Studio             |
+| `vn_team`      | Lẩu Phở (Team, ≥3 users)  | 299k đ/mo          | 2,000,000 (pooled) | ∞               | per spec   | Pooled               |
+| `vn_ultimate`  | Phở Siêu Đặc Biệt (Ultra) | 499k đ/mo          | 5,000,000          | ∞               | 100        | + Studio + Priority  |
+| `medical_beta` | Phở Medical Beta 🏥       | activated by promo | 1,000,000          | ∞               | 10         | Llama-3.1 default    |
+| `gl_starter`   | Free (USD)                | $0                 | 50,000             | 0               | 0          |                      |
+| `gl_standard`  | Starter (USD)             | $9.99/mo           | 300,000            | 30              | 0          |                      |
+| `gl_premium`   | Premium (USD)             | $19.99/mo          | 2,000,000          | ∞               | 50         |                      |
+| `gl_lifetime`  | Founding Member           | $149.99 once       | 2,000,000          | ∞               | per spec   | Chat only, no Studio |
+
+**Daily request circuit breaker** (`DAILY_REQUEST_CAP` in `pricing.ts`):
+
+| Plan                                     | Cap   | Comment                                         |
+| ---------------------------------------- | ----- | ----------------------------------------------- |
+| `vn_free` / `gl_starter`                 | 20    | strict                                          |
+| `vn_basic` / `gl_standard`               | 100   |                                                 |
+| `vn_premium`                             | 200   | (PHO-234: previously inverted with `vn_pro`)    |
+| `vn_pro`                                 | 500   | (PHO-234)                                       |
+| `vn_team` / `vn_ultimate` / `lifetime_*` | 1,000 |                                                 |
+| `medical_beta`                           | 50    | "burning 71% of total cost" — already throttled |
+
+### 1.2 Per-tier burn rates (from `scripts/seed-model-pricing*` USD/1M tokens)
+
+| Tier | Models (representative)                 | Input USD/1M  | Output USD/1M | Indicative cost / 1k-token chat turn |
+| ---- | --------------------------------------- | ------------- | ------------- | ------------------------------------ |
+| 1    | gemini-2.5-flash, gemini-3-flash        | $0.30 – $0.50 | $2.50 – $3.00 | \~$0.003                             |
+| 2    | gemini-2.5-pro, claude-sonnet-4.5       | $1.25 – $3.00 | $10 – $15     | \~$0.012                             |
+| 3    | gemini-3.1-pro-preview, claude-opus-4.6 | $2.00 – $5.00 | $12 – $25     | \~$0.025                             |
+
+(One Phở Point ≈ $0.00004 USD per the fallback in `credits.ts:245`. So
+2,000,000 points ≈ $80 USD ≈ \~2,000,000 ÷ 25 ≈ 80k Tier-3 turns or
+\~26M Tier-1 turns.)
+
+### 1.3 What Phase 2 already changed
+
+- **PHO-225/228** — pre-flight check + Vietnam-tz daily reset.
+- **PHO-224** — usage_logs hole closed for Tier 2/3 atomic-slot path.
+- **PHO-230** — mid-stream abort billing.
+- **PHO-234** — `vn_premium` / `vn_pro` Tier 3 cap inversion fixed.
+- **PHO-229** — embedding metering (3 sites).
+- **PHO-232** — PostHog browser exception autocapture.
+- **PHO-231** — PostHog server-side `$ai_generation` events.
+
+So as of this PR every billable LLM call (chat + embedding) deducts
+points and emits a PostHog event. The **measurement layer is now
+trustworthy** — we can finally redesign allocation against real numbers.
+
+---
+
+## 2. Problems with the current model
+
+| #   | Problem                                                                                                                                                  | Evidence                                                    |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| P1  | Free plan can hit 50k points fast on a bad day                                                                                                           | One Tier-3-by-mistake = \~25k pts. Two = empty wallet.      |
+| P2  | `vn_basic` blocks Tier 3 entirely but allocates 300k points for Tier 1+2 only — points partly unused                                                     | Most Tier 1+2 traffic costs <100k pts/mo for typical users. |
+| P3  | `vn_premium` (1M pts, 129k đ) and `gl_premium` (2M pts, $19.99) — same approximate USD price, 2× points spread                                           | Cross-currency parity drift.                                |
+| P4  | No soft cap: at 0 points the user is hard-blocked even mid-session                                                                                       | UX cliff. PHO-225 added pre-flight, but 0 still blocks.     |
+| P5  | Daily request cap and monthly point cap are independent — a user on `vn_pro` can drain 2M points in 24h via Tier 3 abuse and still be inside the 500-cap | Abuse path.                                                 |
+| P6  | `medical_beta` allocation (1M pts, 10 T3/day) was the "burning 71% of total cost" plan — current throttle is reactive, not designed                      | Already noted in code.                                      |
+| P7  | `vn_team` "pooled 2M" is confusing — same number as `vn_pro` but split across ≥3 users                                                                   | Per-user that is 666k, weaker than `vn_premium`.            |
+
+---
+
+## 3. Three proposed redesigns
+
+The columns in each option mean:
+
+- **Pts/mo**: monthly point allocation.
+- **T2/T3 day**: hard daily caps for Tier 2 / Tier 3 messages (`-1` = unlimited).
+- **Soft cap %**: how much over the monthly allocation a paid user can
+  spend before being soft-blocked (see §4).
+
+### Option 1 — Conservative (minimum change, fix outliers only)
+
+| Plan           | Pts/mo (was → new) | T2/day | T3/day | Soft cap % |
+| -------------- | ------------------ | ------ | ------ | ---------- |
+| `vn_free`      | 50k → 30k          | 0      | 0      | 0 (hard)   |
+| `vn_basic`     | 300k → 200k        | 30     | 0      | 0 (hard)   |
+| `vn_premium`   | 1.0M → 1.0M        | -1     | 20     | 10         |
+| `vn_pro`       | 2.0M → 2.0M        | -1     | 50     | 15         |
+| `vn_ultimate`  | 5.0M → 5.0M        | -1     | 100    | 20         |
+| `medical_beta` | 1.0M → 600k        | -1     | 10     | 0          |
+
+**Rationale:** Tightens free + medical_beta where the loss is concentrated.
+Keeps paid plans untouched so existing users don't churn.
+
+### Option 2 — Aggressive (cost-optimal)
+
+| Plan           | Pts/mo (was → new) | T2/day | T3/day | Soft cap % |
+| -------------- | ------------------ | ------ | ------ | ---------- |
+| `vn_free`      | 50k → 20k          | 0      | 0      | 0 (hard)   |
+| `vn_basic`     | 300k → 150k        | 20     | 0      | 0 (hard)   |
+| `vn_premium`   | 1.0M → 800k        | 200    | 15     | 10         |
+| `vn_pro`       | 2.0M → 1.5M        | -1     | 40     | 15         |
+| `vn_ultimate`  | 5.0M → 3.5M        | -1     | 80     | 20         |
+| `medical_beta` | 1.0M → 400k        | 100    | 8      | 0          |
+
+**Rationale:** Aligns each plan's points budget with median observed
+burn (assuming user's audit numbers). Maximises gross margin.
+Risk: existing paid users see "less for the same money" → churn.
+
+### Option 3 — Recommended (balanced) ★
+
+| Plan           | Pts/mo (was → new)              | T2/day | T3/day   | Soft cap % |
+| -------------- | ------------------------------- | ------ | -------- | ---------- |
+| `vn_free`      | 50k → 25k                       | 0      | 0        | 0 (hard)   |
+| `vn_basic`     | 300k → 250k                     | 30     | 0        | 0 (hard)   |
+| `vn_premium`   | 1.0M → 1.0M                     | -1     | 20       | 10         |
+| `vn_pro`       | 2.0M → 2.5M ★                   | -1     | 60 ★     | 15         |
+| `vn_ultimate`  | 5.0M → 5.0M                     | -1     | 100      | 25         |
+| `vn_team`      | 2.0M pooled → 3.5M pooled       | -1     | per spec | 15         |
+| `medical_beta` | 1.0M → 500k                     | -1     | 8        | 0          |
+| `gl_*`         | (mirror Vietnam plans by ratio) |        |          |            |
+
+**Rationale:**
+
+- **Plug the leaks**: `vn_free`, `vn_basic`, `medical_beta` are the
+  unprofitable plans → tighten.
+- **Premium stays the same**: it's the volume entry plan, churn-sensitive.
+- **Pro gets a bonus**: 2.0M → 2.5M and 50 → 60 T3/day. This is a
+  positive marketing message ("Pro upgrade — now even better") and
+  recovers some of the perceived value lost when free/basic shrink.
+- **Ultimate keeps its allocation**: it's already over-spec'd, point is
+  signalling not consumption.
+- **Soft caps**: paid plans ramp gracefully; free + medical_beta still
+  hard-cap because they cost us money on every byte.
+
+★ marks the changes from current state.
+
+---
+
+## 4. Soft cap mechanism (applies to all three options)
+
+When a paid user crosses **monthly_points × (100% + soft_cap\_%)**:
+
+1. Continue serving requests for the remainder of the calendar month.
+2. Show a banner: "You're at 110% of your Pro allocation. Upgrade to
+   Ultimate for X more points / mo."
+3. Gate Tier 3 specifically (Tier 1 + 2 still flow). Reasoning: Tier 3
+   is the only thing that can blow a budget; Tier 1 is essentially free.
+4. Email at 100%, 110%, 130%.
+5. Hard block at **monthly_points × 200%** as a circuit breaker — at
+   that point the user is either abusing or has a runaway script.
+
+Free + `medical_beta` keep the current hard-block behaviour; soft cap
+only makes sense when there is revenue offsetting the over-spend.
+
+---
+
+## 5. Decision questions for Hien
+
+1. **Which option (1 / 2 / 3) — and is there a deadline tied to a comms
+   plan (e.g. announce alongside a "we improved Pro" marketing beat)?**
+2. **Soft cap percentages** — are 10 / 15 / 20–25 % the right tiers, or
+   do you want them flatter (all 15 %) for simplicity?
+3. **Grace period** — once a user crosses the soft cap, do we keep
+   serving until end-of-month or until the next billing date?
+4. **Grandfather existing users** — if Option 2 or 3 reduces an existing
+   user's allocation, do we keep their old number for the current
+   billing cycle? Recommended: yes for paid plans, no for free.
+5. **Studio vs. Chat split** — point pool is currently shared. Do we
+   want a separate `monthlyImagePoints` so a user who burns Studio
+   doesn't also lose Chat capacity?
+
+---
+
+## 6. Implementation outline (only after Hien picks an option)
+
+1. Update constants in `src/config/pricing.ts` (`VN_PLANS`, `GLOBAL_PLANS`,
+   `DAILY_REQUEST_CAP`, plus a new `SOFT_CAP_PCT` map).
+2. Update Clerk metadata templates so new signups inherit the new caps.
+3. Add a soft-cap branch to `processModelUsage` /
+   `checkDailyRequestCap`. Hard block stays the existing `GREATEST(0,
+balance - cost)` SQL; soft cap is a new "near-zero" warning state in
+   the API response, surfaced by the chat UI.
+4. Update the user-facing pricing page (`src/features/PricingCards/*`).
+5. Migration script for existing users — re-stamp `monthlyPoints` based
+   on new mapping. Grandfather rule from §5 Q4 applies.
+6. Email sequence templates (100 % / 110 % / 130 %).
+
+Estimated scope: \~6 files, no schema migration needed (allocation is
+read from config, not stored on the user row).
+
+---
+
+## 7. References
+
+- `docs/audit/cost-phase-2-implementation-plan.md`
+- `docs/audit/cost-audit-phase-2-2026-04-28.md`
+- `src/config/pricing.ts`
+- `src/server/services/billing/credits.ts`
+- `scripts/seed-model-pricing*` (per-model USD pricing source of truth)

--- a/src/features/Portal/DeepResearch/Body.tsx
+++ b/src/features/Portal/DeepResearch/Body.tsx
@@ -1218,9 +1218,21 @@ Write the full article now in markdown format.`;
 
     const maxRetries = ARTICLE_MODELS_FALLBACK.length;
     let lastError: Error | null = null;
+    // PHO-236: keep a structured trail of every attempt so the failure event
+    // can show *which* model failed *why*, not just the last error message.
+    const attemptHistory: Array<{
+      attempt: number;
+      durationMs: number;
+      errorMessage: string;
+      errorName: string;
+      errorStatus?: number;
+      model: string;
+      outputLength?: number;
+    }> = [];
 
     for (let attempt = 0; attempt < maxRetries; attempt++) {
       const tryModel = ARTICLE_MODELS_FALLBACK[attempt];
+      const attemptStart = Date.now();
       try {
         if (attempt > 0) {
           setProgressLines((prev) => [
@@ -1413,16 +1425,32 @@ Generate 3-6 rows for the most important outcomes.`;
         return; // Success — exit retry loop
       } catch (e: any) {
         lastError = e;
-        console.error(
-          `[DeepResearch] Article attempt ${attempt + 1} (model=${tryModel}) failed:`,
-          e.message,
-        );
+        // PHO-236: capture richer per-attempt detail. The aggregated
+        // article_generation_failed event below ships this whole array
+        // so we can finally see if the 31% failures cluster on a model,
+        // a status code, or a content-length pattern.
+        attemptHistory.push({
+          attempt: attempt + 1,
+          durationMs: Date.now() - attemptStart,
+          errorMessage: typeof e?.message === 'string' ? e.message.slice(0, 500) : String(e),
+          errorName: e?.name ?? 'Error',
+          errorStatus: typeof e?.status === 'number' ? e.status : undefined,
+          model: tryModel,
+          outputLength: typeof e?.outputLength === 'number' ? e.outputLength : undefined,
+        });
+        console.error(`[DeepResearch] Article attempt ${attempt + 1} (model=${tryModel}) failed:`, {
+          message: e?.message,
+          name: e?.name,
+          status: e?.status,
+        });
       }
     }
 
     // All retries failed
     (window as any).posthog?.capture('article_generation_failed', {
+      attempt_history: attemptHistory,
       error: lastError?.message || 'Unknown error',
+      error_name: lastError?.name ?? 'Error',
       generation_time_seconds: Math.round((Date.now() - articleStartTime) / 1000),
       models_tried: ARTICLE_MODELS_FALLBACK,
       primary_model: model,

--- a/src/libs/posthog-server.ts
+++ b/src/libs/posthog-server.ts
@@ -1,0 +1,69 @@
+/**
+ * Server-side PostHog capture using the public capture endpoint.
+ *
+ * Why fetch instead of `posthog-node`?
+ * - No new runtime dep, no bundle size hit on every Vercel function.
+ * - For our use (fire-and-forget $ai_generation events) we don't need the
+ *   batching, retry, or shutdown logic that `posthog-node` provides.
+ * - Trade-off: a small percentage of events may be lost during serverless
+ *   cold-shutdown. Acceptable for observability — not for billing.
+ *
+ * If we ever need durable delivery, swap this module for `posthog-node`
+ * with `waitUntil(client.shutdown())` from `@vercel/functions`.
+ */
+
+const POSTHOG_HOST = process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com';
+const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+export interface CaptureAiGenerationParams {
+  costPoints: number;
+  costUSD?: number;
+  /** Feature label so we can split spend in PostHog (chat / embedding / artifact / ...) */
+  feature?: string;
+  inputTokens: number;
+  latencyMs?: number;
+  model: string;
+  outputTokens: number;
+  /** True when a stream aborted before completion (PHO-230). */
+  partial?: boolean;
+  provider: string;
+  userId: string;
+}
+
+/**
+ * Fire-and-forget PostHog `$ai_generation` event.
+ * Returns immediately; failures are logged and swallowed.
+ *
+ * Caller must NOT await this — billing/inference paths cannot pay the
+ * observability tax. The trailing `.catch` exists to keep the unhandled-
+ * rejection log clean.
+ */
+export function captureAiGeneration(params: CaptureAiGenerationParams): void {
+  if (!POSTHOG_KEY || !params.userId) return;
+
+  const body = {
+    api_key: POSTHOG_KEY,
+    distinct_id: params.userId,
+    event: '$ai_generation',
+    properties: {
+      $ai_cost_points: params.costPoints,
+      $ai_feature: params.feature ?? 'chat',
+      $ai_input_tokens: params.inputTokens,
+      $ai_latency_ms: params.latencyMs,
+      $ai_model: params.model,
+      $ai_output_tokens: params.outputTokens,
+      $ai_partial: params.partial ?? false,
+      $ai_provider: params.provider,
+      ...(params.costUSD !== undefined && { $ai_cost_usd: params.costUSD }),
+    },
+    timestamp: new Date().toISOString(),
+  };
+
+  void fetch(`${POSTHOG_HOST}/capture/`, {
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+    method: 'POST',
+  }).catch((e) => {
+    console.warn('[PostHog Server] $ai_generation capture failed:', (e as Error)?.message);
+  });
+}

--- a/src/server/services/billing/credits.ts
+++ b/src/server/services/billing/credits.ts
@@ -13,6 +13,7 @@ import {
 import { users } from '@/database/schemas';
 import { usageLogs } from '@/database/schemas/usage';
 import { getServerDB } from '@/database/server';
+import { captureAiGeneration } from '@/libs/posthog-server';
 
 export async function addPhoCredits(userId: string, amount: number) {
   try {
@@ -90,6 +91,11 @@ export async function deductPhoCredits(userId: string, amount: number) {
 
 export interface UsageLogParams {
   costUSD?: number;
+  /**
+   * PHO-231: feature label so PostHog can split spend by surface
+   * (chat / embedding / artifact / summary / ...). Defaults to 'chat'.
+   */
+  feature?: string;
   inputTokens: number;
   model: string;
   outputTokens: number;
@@ -245,9 +251,10 @@ export async function processModelUsage(
 
     // 5. Log to usage_logs with actual model/tier/tokens (PHO-224: unified for BOTH branches).
     if (usageLog) {
+      const VND_RATE = 24_167;
+      const costUSD = usageLog.costUSD ?? pointsDeducted * 0.000_04; // fallback: 1 point ≈ $0.00004
+
       try {
-        const VND_RATE = 24_167;
-        const costUSD = usageLog.costUSD ?? pointsDeducted * 0.000_04; // fallback: 1 point ≈ $0.00004
         await db.insert(usageLogs).values({
           costUSD,
           costVND: costUSD * VND_RATE,
@@ -266,6 +273,22 @@ export async function processModelUsage(
       } catch (logErr) {
         console.warn('⚠️ Failed to insert usage_logs:', logErr);
       }
+
+      // PHO-231: emit $ai_generation to PostHog so the cost dashboard sees
+      // every metered call (chat, embeddings, ...) — not just send_message.
+      // Fire-and-forget; observability must never block billing.
+      captureAiGeneration({
+        costPoints: pointsDeducted,
+        costUSD,
+        feature: usageLog.feature ?? 'chat',
+        inputTokens: usageLog.inputTokens,
+        latencyMs: usageLog.responseTimeMs,
+        model: usageLog.model,
+        outputTokens: usageLog.outputTokens,
+        partial: usageLog.partial,
+        provider: usageLog.provider,
+        userId,
+      });
     }
   } catch (e) {
     console.error('❌ Failed to process model usage:', e);

--- a/src/server/services/billing/embeddingMetering.ts
+++ b/src/server/services/billing/embeddingMetering.ts
@@ -50,6 +50,7 @@ export async function meterEmbeddingUsage({
 
   try {
     await processModelUsage(userId, cost, 1, false, {
+      feature: 'embedding',
       inputTokens,
       model,
       outputTokens: 0,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat (observability + design doc)
- [x] 🐛 fix (article-gen failure logging)
- [x] 📝 docs

#### 🔀 Description of Change

Phase 2.4 final batch — closes PHO-222 cost-audit epic.

**PHO-231 — Server-side PostHog \$ai_generation events**
- Pre-fix: PostHog cost dashboard chỉ tracked \`send_message\`. Embeddings (PHO-229), partial-billed aborts (PHO-230), và mọi non-chat metered call ĐỀU vô hình.
- New \`src/libs/posthog-server.ts\`: fire-and-forget fetch tới PostHog \`/capture/\` endpoint. **Không thêm runtime dep** — lợi: bundle nhẹ, không cần install \`posthog-node\` hay set up Vercel \`waitUntil\`. Trade-off: một số events có thể mất khi serverless cold-shutdown — acceptable cho observability.
- Wire vào \`processModelUsage\` ⇒ MỌI metered call (chat, embedding, future…) tự động emit \`\$ai_generation\` với:
  - \`\$ai_model\`, \`\$ai_provider\`, \`\$ai_feature\` (chat / embedding / …)
  - \`\$ai_input_tokens\`, \`\$ai_output_tokens\`
  - \`\$ai_cost_points\`, \`\$ai_cost_usd\`
  - \`\$ai_latency_ms\`, \`\$ai_partial\` (PHO-230 abort flag)
- New \`UsageLogParams.feature\` field — embedding metering passes \`'embedding'\`; chat defaults to \`'chat'\`.

**PHO-236 — Article generation 31% fail-rate investigation**
- Found that \`handleGenerateArticle\` đã có 5 PostHog events + 3-model fallback + safety/length heuristics. Failure event \`article_generation_failed\` chỉ carry \`lastError.message\` → không root-cause được.
- Add structured \`attemptHistory\` array — mỗi attempt log \`model\`, \`errorName\`, \`errorMessage\`, \`errorStatus\`, \`outputLength\`, \`durationMs\`. Ship trong failure event.
- Console.error chuyển từ flat string → structured object \`{ message, name, status }\` để Vercel logs query được.
- Investigation report tại \`docs/audit/pho-236-article-gen-investigation-2026-04-30.md\` — 5 hypotheses ranked by prior probability:
  - H1 (~40%): Safety filter on all 3 fallback models (chain hiện chỉ có OpenAI-family).
  - H2 (~25%): Token-limit overflow từ \`agentFindings.slice(0, 15_000)\`.
  - H3 (~15%): \`callAIStream\` timeout trên long generations.
  - H4 (~10%): 429 rate-limit cascade.
  - H5 (~10%): Provider-specific bug — chưa thể tell với current logging.
- **No prompt or fallback-chain changes** — cần data từ next 7 days trước khi quyết.

**PHO-237 — Phở Points allocation redesign (DESIGN DOC ONLY)**
- \`docs/design/pho-237-allocation-redesign-2026-04-30.md\`.
- Mapped all current plans + caps + per-tier USD burn rates.
- Documented 7 problems (P1–P7) với current model.
- 3 proposed options:
  - **Option 1** — Conservative: tighten free + medical_beta only, paid plans untouched.
  - **Option 2** — Aggressive: cost-optimal, risks paid-user churn.
  - **Option 3** ★ — Balanced: tighten free/basic/medical, **bonus cho \`vn_pro\` (2M→2.5M, 50→60 T3/day)** để có positive marketing message.
- Soft-cap mechanism: paid users gate Tier 3 ở 100% allocation, hard-block ở 200%. Free + medical_beta giữ hard-cap.
- 5 decision questions cho Hien.

#### 📝 Additional Information

**Files touched (6):**
- NEW \`src/libs/posthog-server.ts\` — server-side PostHog helper.
- NEW \`docs/audit/pho-236-article-gen-investigation-2026-04-30.md\`.
- NEW \`docs/design/pho-237-allocation-redesign-2026-04-30.md\`.
- \`src/server/services/billing/credits.ts\` — emit \`\$ai_generation\` from \`processModelUsage\`; add \`feature\` to \`UsageLogParams\`.
- \`src/server/services/billing/embeddingMetering.ts\` — pass \`feature: 'embedding'\`.
- \`src/features/Portal/DeepResearch/Body.tsx\` — \`attemptHistory\` + structured \`article_generation_failed\` event.

**Verification:**
- \`bun run type-check\` → exit 0 ✓
- \`eslint\` on 4 changed TS files → 0 errors ✓
- Pre-commit hook (prettier + stylelint + eslint --fix + remark on .md) passed.

**Smoke test sau deploy:**
1. **PHO-231**: Send một chat message → check PostHog cho \`\$ai_generation\` event với \`properties.\$ai_feature = 'chat'\`. Upload file (RAG path) → second event với \`\$ai_feature = 'embedding'\`.
2. **PHO-236**: Mở Deep Research, ask câu medical sensitive → trigger fail intentionally → check \`article_generation_failed\` event có \`attempt_history\` array với 3 entries (mỗi entry có errorName / errorStatus / outputLength).
3. **PHO-237**: No code change to verify — Hien review doc, pick Option 1/2/3.

**Anh action items sau merge:**
1. Mark "Ready for review" → Merge PR.
2. Wait 7 days → pull \`article_generation_failed\` events → root-cause → apply matching fix from §4 of investigation report.
3. Review allocation design doc → answer 5 decision questions.
4. **Close PHO-222 epic** 🎉

**Total Phase 2 audit results (sau merge tất cả 4 PRs):**
- 14 issues investigated, 12 ⇒ shipped, 2 ⇒ deferred (PHO-235 needs DB query; PHO-237 awaits decision).
- 4 PRs merged: #28, #29, #30, this one.
- ~\$140–245/month savings.
- Phở Points system + observability: **fully operational and trustworthy**.

Linear: PHO-231, PHO-236, PHO-237 (Phase 2.4 final).
Closes: PHO-222 epic.
Refs: docs/audit/cost-phase-2-implementation-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-side PostHog cost tracking for all metered LLM calls, improves article-generation failure logging for root-cause analysis, and ships an allocation redesign doc. Addresses PHO-231, PHO-236, PHO-237 and closes the PHO-222 cost-audit epic.

- New Features
  - Emit `$ai_generation` server-side for every metered call via a lightweight fetch helper (no `posthog-node` or `@vercel/functions` needed).
  - Hooked into `processModelUsage` with model, provider, tokens, cost (points/USD), latency, and partial-abort flags; adds `feature` label to `UsageLogParams` (chat default, embeddings pass `'embedding'`).
  - Adds PHO-237 design doc proposing three Phở Points allocation options and a paid-plan soft-cap mechanism.

- Bug Fixes
  - Article generation failures now log a structured `attempt_history` (model, error name/message/status, output length, duration) and send it with `article_generation_failed`.
  - Console errors are structured for better log queries. No prompt or fallback-chain changes; this is for diagnosis of the 31% fail rate.

<sup>Written for commit 6b6a418133f502c74c9cbc433c41d80c35061be6. Summary will update on new commits. <a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/31?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Enhanced error diagnostics for article generation with detailed attempt history tracking.
  * Added AI usage metrics monitoring (tokens, latency, cost) for improved system observability.

* **Documentation**
  * Added investigation and design documentation for system improvements and allocation redesign planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->