### PR TITLE
🚨 HOTFIX(security): /activate-free idempotent (A1.10, PHO-238)

### DIFF
--- a/src/app/api/subscription/activate-free/route.ts
+++ b/src/app/api/subscription/activate-free/route.ts
@@ -1,5 +1,5 @@
 import { auth } from '@clerk/nextjs/server';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { subscriptions, users } from '@/database/schemas';
@@ -46,6 +46,85 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       vn_free: 'vn_free',
     };
     const normalizedPlanId = planCodeMap[planId] || planId;
+
+    // ========================================================================
+    // PHO-238 A1.10: Idempotency guards
+    // ----------------------------------------------------------------------
+    // Pre-fix exposure: this endpoint UPDATE-d phoPointsBalance=50_000
+    // unconditionally on every call. A free user could POST repeatedly to
+    // re-mint their balance back to 50K → unlimited free points.
+    //
+    // Fix layers, in order:
+    //   1. Block if any active subscription row exists (paid or free).
+    //   2. Block if users.pointsResetDate is still in the future
+    //      (current period not yet expired → already activated this cycle).
+    //   3. The existing UPDATE (below) sets pointsResetDate to the start of
+    //      next month — that timestamp is what Layer 2 reads on the next
+    //      call. So Layer 3 is implicit; no extra write needed.
+    // ========================================================================
+
+    // Layer 1: subscription row exists?
+    const [existingSubscription] = await db
+      .select({
+        id: subscriptions.id,
+        planId: subscriptions.planId,
+        status: subscriptions.status,
+      })
+      .from(subscriptions)
+      .where(and(eq(subscriptions.userId, userId), eq(subscriptions.status, 'active')))
+      .limit(1);
+
+    if (existingSubscription) {
+      console.warn('[activate-free] DUPLICATE ACTIVATION ATTEMPT — active subscription exists', {
+        attemptedAt: now.toISOString(),
+        existingPlanId: existingSubscription.planId,
+        userId,
+      });
+      return NextResponse.json(
+        {
+          activated: false,
+          message: 'Bạn đã kích hoạt một gói trước đó. Vào /settings để xem chi tiết.',
+          planId: existingSubscription.planId,
+          success: false,
+        },
+        { status: 409 },
+      );
+    }
+
+    // Layer 2: pointsResetDate still in current period?
+    const [currentUserRow] = await db
+      .select({
+        balance: users.phoPointsBalance,
+        currentPlanId: users.currentPlanId,
+        pointsResetDate: users.pointsResetDate,
+      })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
+
+    if (
+      currentUserRow?.pointsResetDate &&
+      currentUserRow.pointsResetDate.getTime() > now.getTime()
+    ) {
+      console.warn('[activate-free] DUPLICATE ACTIVATION ATTEMPT — period still active', {
+        attemptedAt: now.toISOString(),
+        currentBalance: currentUserRow.balance,
+        currentPlanId: currentUserRow.currentPlanId,
+        pointsResetDate: currentUserRow.pointsResetDate.toISOString(),
+        userId,
+      });
+      return NextResponse.json(
+        {
+          activated: false,
+          currentBalance: currentUserRow.balance,
+          message: `Đã kích hoạt trong kỳ hiện tại. Quota sẽ reset vào ${currentUserRow.pointsResetDate.toISOString().slice(0, 10)}.`,
+          planId: currentUserRow.currentPlanId,
+          pointsResetDate: currentUserRow.pointsResetDate.toISOString(),
+          success: false,
+        },
+        { status: 409 },
+      );
+    }
 
     // 1. Update user's current plan
     await db


### PR DESCRIPTION
## Summary

P0 security hotfix from V1 audit (PR #32, finding A1.10).

**Pre-fix exposure:** `POST /api/subscription/activate-free` UPDATE-d `phoPointsBalance=50_000` unconditionally on every call. Any free user could POST the endpoint repeatedly to reset their balance back to 50K — an unlimited free-token loop. Severity escalated from audit's P1 to P0 because:

- Discoverable by endpoint name (self-descriptive route)
- Exploitable with a single POST, no auth bypass needed
- No detection signal pre-fix (endpoint had no \"already activated\" log line)

## Fix — 2 explicit + 1 implicit defense layers

1. **Layer 1 — subscription record check.** Before the UPDATE, query `subscriptions` for any row with `userId = caller && status = 'active'`. If found, return `409 Conflict` with the existing planId. Catches users who already have either a paid or free subscription.
2. **Layer 2 — pointsResetDate window check.** Query `users.pointsResetDate` and reject if it's still in the future (i.e. the user is in an active free-tier period that hasn't expired). Returns `409 Conflict` with current balance + reset date so the UI can show \"đã kích hoạt — quota sẽ reset vào dd.\"
3. **Layer 3 — implicit.** The existing UPDATE already sets `pointsResetDate` to the first day of next month. That timestamp is exactly what Layer 2 reads on a re-attempt. No extra write needed.

Both rejection paths log `[activate-free] DUPLICATE ACTIVATION ATTEMPT` at `console.warn` with `userId`, `attemptedAt`, current balance, and existing plan — so post-hoc analysis can detect whether anyone exploited the loop before the fix.

## Schema verification

- ✅ `users.pointsResetDate` (`timestamptz`, nullable) — exists in `packages/database/src/schemas/user.ts:34`
- ✅ `users.phoPointsBalance` — exists, default `50_000`
- ✅ `subscriptions.userId` (`text`, FK to `users.id`, NOT unique) — exists. Layer 1 uses `.select().where(...).limit(1)`, so the lack of a UNIQUE constraint doesn't matter for correctness.

## Race condition note

There is a brief window where two parallel POSTs both pass Layer 1 → both UPDATE points to 50_000 → both succeed. Net effect: idempotent (50_000 == 50_000), no extra points. Layer 2 closes this fully on the second attempt once the first's UPDATE has committed. A full transaction wrapper would close the race entirely; not done here to keep the hotfix surface small.

## Test plan

- [ ] **Pre-merge:** type-check passed (`bun run type-check`)
- [ ] **Post-merge, before promoting to prod:**
  - [ ] **Existing free user (no subscription row, no pointsResetDate)** → POST `/api/subscription/activate-free` with `{planId:'vn_free'}` → expect `200`, balance set to 50K, `pointsResetDate` populated.
  - [ ] **Same user, immediate retry** → expect `409` with `DUPLICATE ACTIVATION ATTEMPT — period still active` log.
  - [ ] **User with active paid subscription** → expect `409` with `active subscription exists` log.
  - [ ] **User whose `pointsResetDate` is in the past** (manually backdate in DB) → expect `200` and the period rolls forward.
- [ ] **Exploit detection (immediately after merge):**
  - [ ] Query Vercel/CloudWatch logs for `DUPLICATE ACTIVATION ATTEMPT` over the past 30 days (won't show anything before the fix obviously, but starts the audit trail).
  - [ ] Run on Neon:
    \`\`\`sql
    SELECT email, current_plan_id, pho_points_balance, points_reset_date
    FROM users
    WHERE current_plan_id = 'vn_free' AND pho_points_balance > 100000
    ORDER BY pho_points_balance DESC
    LIMIT 20;
    \`\`\`
    Any free user with > 100K balance is suspicious — pre-fix balance ceiling was 50K + a bit of math; > 100K means either the loop was used or balance was credited some other way.

## Related

- Linear: PHO-238 (V1 Audit Epic)
- Audit report: \`docs/audit/audit-1-auth-2026-04-30.md\` finding A1.10
- Audit PR: #32
- Sibling hotfix (already merged): #33 (A1.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)