### PR TITLE
✨ feat(observability): planId + tier on $ai_generation events (PHO-246)

### DIFF
--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -764,6 +764,8 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
                   model: actualModelUsed,
                   outputTokens,
                   partial: !completed,
+                  // PHO-246: forward plan from auth check so PostHog can slice cost-per-plan.
+                  planId: userPlanId,
                   provider: actualProviderUsed,
                   responseTimeMs,
                 },
@@ -832,6 +834,8 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
                 inputTokens,
                 model: actualModelUsed,
                 outputTokens,
+                // PHO-246: forward plan from auth check so PostHog can slice cost-per-plan.
+                planId: userPlanId,
                 provider: actualProviderUsed,
                 responseTimeMs,
               },

--- a/src/app/api/artifact-ai/route.ts
+++ b/src/app/api/artifact-ai/route.ts
@@ -214,6 +214,8 @@ export async function POST(req: NextRequest) {
           inputTokens,
           model: modelId,
           outputTokens,
+          // PHO-246: forward plan from auth check so PostHog can slice cost-per-plan.
+          planId: userPlanId,
           provider,
           responseTimeMs,
         });
@@ -241,6 +243,8 @@ export async function POST(req: NextRequest) {
         inputTokens,
         model: modelId,
         outputTokens,
+        // PHO-246: forward plan from auth check so PostHog can slice cost-per-plan.
+        planId: userPlanId,
         provider,
         responseTimeMs,
       });

--- a/src/app/api/research/ai-summary/route.ts
+++ b/src/app/api/research/ai-summary/route.ts
@@ -168,6 +168,8 @@ export async function POST(req: NextRequest) {
                 inputTokens,
                 model: modelId,
                 outputTokens,
+                // PHO-246: forward plan from auth check so PostHog can slice cost-per-plan.
+                planId: userPlanId,
                 provider,
                 responseTimeMs,
               });
@@ -339,6 +341,8 @@ export async function POST(req: NextRequest) {
           inputTokens,
           model: modelId,
           outputTokens,
+          // PHO-246: forward plan from auth check so PostHog can slice cost-per-plan.
+          planId: userPlanId,
           provider,
           responseTimeMs,
         });
@@ -365,6 +369,8 @@ export async function POST(req: NextRequest) {
         inputTokens,
         model: modelId,
         outputTokens,
+        // PHO-246: forward plan from auth check so PostHog can slice cost-per-plan.
+        planId: userPlanId,
         provider,
         responseTimeMs,
       });

--- a/src/libs/posthog-server.ts
+++ b/src/libs/posthog-server.ts
@@ -11,6 +11,7 @@
  * If we ever need durable delivery, swap this module for `posthog-node`
  * with `waitUntil(client.shutdown())` from `@vercel/functions`.
  */
+import { getUserPlanFromDB } from '@/server/services/subscription/getUserPlanFromDB';
 
 const POSTHOG_HOST = process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com';
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
@@ -26,20 +27,53 @@ export interface CaptureAiGenerationParams {
   outputTokens: number;
   /** True when a stream aborted before completion (PHO-230). */
   partial?: boolean;
+  /**
+   * PHO-246: resolved user plan ID. Pass when caller already authorized the
+   * request (chat / artifact / research routes) — saves a DB lookup. If
+   * omitted, the capture function asynchronously falls back to
+   * `getUserPlanFromDB(userId)` and logs a warning so we can migrate the
+   * caller later.
+   */
+  planId?: string;
+  /** PHO-246: source of the plan resolution for drift telemetry. */
+  planSource?: string;
   provider: string;
+  /** PHO-246: model tier (1/2/3) for cost-per-tier breakdowns. */
+  tier?: number;
   userId: string;
 }
 
 /**
- * Fire-and-forget PostHog `$ai_generation` event.
- * Returns immediately; failures are logged and swallowed.
+ * Build the event body and POST it to PostHog. Async so we can optionally
+ * resolve the user's plan via DB lookup when the caller didn't pass one.
  *
- * Caller must NOT await this — billing/inference paths cannot pay the
- * observability tax. The trailing `.catch` exists to keep the unhandled-
- * rejection log clean.
+ * PHO-246: even though this is fire-and-forget, the DB lookup is cheap
+ * (single SELECT, optional Clerk fetch in soft mode) and runs after the
+ * request has returned to the user. The warning log helps us migrate
+ * legacy callers that should be passing `planId` from their authorization
+ * context for free.
  */
-export function captureAiGeneration(params: CaptureAiGenerationParams): void {
-  if (!POSTHOG_KEY || !params.userId) return;
+async function emitAiGeneration(params: CaptureAiGenerationParams): Promise<void> {
+  let { planId, planSource } = params;
+
+  if (!planId) {
+    try {
+      const result = await getUserPlanFromDB(params.userId);
+      planId = result.planId;
+      planSource = result.source;
+      console.warn(
+        `[PostHog Server] $ai_generation: planId not passed by caller for user ${params.userId}; ` +
+          `looked up DB plan=${planId} (source=${planSource}). ` +
+          `Migrate caller to pass planId for performance.`,
+      );
+    } catch (err) {
+      // DB lookup failed — emit the event without plan info rather than drop it.
+      console.warn(
+        '[PostHog Server] getUserPlanFromDB failed in $ai_generation fallback:',
+        (err as Error)?.message,
+      );
+    }
+  }
 
   const body = {
     api_key: POSTHOG_KEY,
@@ -55,15 +89,33 @@ export function captureAiGeneration(params: CaptureAiGenerationParams): void {
       $ai_partial: params.partial ?? false,
       $ai_provider: params.provider,
       ...(params.costUSD !== undefined && { $ai_cost_usd: params.costUSD }),
+      // PHO-246: cost-per-plan / cost-per-tier breakdowns.
+      ...(planId !== undefined && { planId }),
+      ...(planSource !== undefined && { plan_source: planSource }),
+      ...(params.tier !== undefined && { tier: params.tier }),
     },
     timestamp: new Date().toISOString(),
   };
 
-  void fetch(`${POSTHOG_HOST}/capture/`, {
+  await fetch(`${POSTHOG_HOST}/capture/`, {
     body: JSON.stringify(body),
     headers: { 'Content-Type': 'application/json' },
     method: 'POST',
-  }).catch((e) => {
+  });
+}
+
+/**
+ * Fire-and-forget PostHog `$ai_generation` event.
+ * Returns immediately; failures are logged and swallowed.
+ *
+ * Caller must NOT await this — billing/inference paths cannot pay the
+ * observability tax. The trailing `.catch` exists to keep the unhandled-
+ * rejection log clean.
+ */
+export function captureAiGeneration(params: CaptureAiGenerationParams): void {
+  if (!POSTHOG_KEY || !params.userId) return;
+
+  void emitAiGeneration(params).catch((e) => {
     console.warn('[PostHog Server] $ai_generation capture failed:', (e as Error)?.message);
   });
 }

--- a/src/server/services/billing/credits.ts
+++ b/src/server/services/billing/credits.ts
@@ -104,6 +104,13 @@ export interface UsageLogParams {
   // otherwise mid-stream disconnects let users escape billing while the
   // gateway has already charged us.
   partial?: boolean;
+  /**
+   * PHO-246: resolved user plan ID. Caller passes the value already used to
+   * authorize this request so PostHog `$ai_generation` events carry plan +
+   * tier and cost can be sliced per plan / per tier. If omitted, the
+   * capture path falls back to a DB lookup (logs a warning).
+   */
+  planId?: string;
   provider: string;
   responseTimeMs?: number;
   sessionId?: string;
@@ -276,6 +283,8 @@ export async function processModelUsage(
 
       // PHO-231: emit $ai_generation to PostHog so the cost dashboard sees
       // every metered call (chat, embeddings, ...) — not just send_message.
+      // PHO-246: forward `planId` (when caller passed it) and the resolved
+      // `tier` so we can slice cost per plan / per tier in PostHog.
       // Fire-and-forget; observability must never block billing.
       captureAiGeneration({
         costPoints: pointsDeducted,
@@ -286,7 +295,9 @@ export async function processModelUsage(
         model: usageLog.model,
         outputTokens: usageLog.outputTokens,
         partial: usageLog.partial,
+        planId: usageLog.planId,
         provider: usageLog.provider,
+        tier,
         userId,
       });
     }


### PR DESCRIPTION
## Summary

PostHog `$ai_generation` events have been missing `planId` + `tier` properties since PHO-231 — every cost-per-plan / cost-per-tier query returns `NULL`. Real example: user_3AAHAPVP currently burning ~$3/day (~$90/mo) with no way to tell if they're a paying customer or an abuser of free tier.

This PR threads `planId` (and the resolved tier) from each authorized request through to the existing fire-and-forget capture path.

## Changes

- `captureAiGeneration` accepts optional `planId` / `planSource` / `tier` params
- `processModelUsage` forwards `usageLog.planId` plus the local `tier` to capture so the resolved values land on every event automatically
- Migrated 7 explicit call sites that already had `userPlanId` in scope:
  - chat: 2 (`webapi/chat/[provider]/route.ts` streaming + non-streaming)
  - artifact-ai: 2 (streaming + non-streaming)
  - research/ai-summary: 3 (audit stream + main streaming + non-streaming)
  - **zero extra DB hits** — plan was already resolved by the upstream auth/tier check
- Capture path falls back to `getUserPlanFromDB(userId)` when `planId` is missing (today: embedding + ai-rendering routes). Logs a `[PostHog Server]` warning per fallback so we can migrate them later without losing event coverage in the meantime
- Fire-and-forget contract preserved: emit body now built inside an async helper so `getUserPlanFromDB` can safely `await` without blocking billing

## PostHog impact

After deploy, `$ai_generation` events carry:

- `planId` — e.g. `vn_pro_monthly`, `gl_starter`, `vn_free`
- `plan_source` — `db_subscription` | `db_user_default` | `clerk_fallback_soft` | `fallback_free`
- `tier` — `1` | `2` | `3`

Enables HogQL like:

```sql
SELECT properties.planId, properties.tier, sum(toFloat(properties.\$ai_total_cost_usd)) AS cost_usd
FROM events
WHERE event = '\$ai_generation' AND timestamp >= now() - INTERVAL 24 HOUR
GROUP BY planId, tier
ORDER BY cost_usd DESC
```

## Test plan post-merge

- [ ] Trigger AI generation as a paid user (chat / artifact / research)
- [ ] Wait ~1 min for PostHog ingestion
- [ ] Query: `SELECT properties.planId, properties.tier, properties.plan_source FROM events WHERE event = '\$ai_generation' ORDER BY timestamp DESC LIMIT 10`
- [ ] Confirm `planId` + `tier` populated (not null) for the 3 migrated routes
- [ ] Confirm embedding / ai-rendering events also carry `planId` (via fallback) — and that we see the `[PostHog Server] $ai_generation: planId not passed` warning in logs to know they're using the fallback path
- [ ] After 24h, run cost-per-plan query to identify users where cost-per-day vastly exceeds plan ARR — that's the policy queue (ban/upgrade/educate)

## Refs

- Linear: PHO-246
- Builds on: PHO-231 (original `\$ai_generation` capture), PHO-241 (DB-only plan source-of-truth, A1.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `planId` and `tier` to `$ai_generation` events so we can slice AI spend by plan and tier in PostHog. Meets PHO-246 by updating chat, artifact, and research routes to pass plan data, with a safe DB fallback for others.

- **New Features**
  - `captureAiGeneration` accepts optional `planId`, `planSource`, and `tier`; events now include `planId`, `plan_source`, and `tier`.
  - `processModelUsage` forwards plan and resolved tier automatically; no extra DB hits on migrated routes.
  - When `planId` is missing, falls back to `getUserPlanFromDB(userId)` and logs a `[PostHog Server]` warning; fire-and-forget behavior preserved.
  - Updated call sites: chat (2), artifact-ai (2), research/ai-summary (3).

<sup>Written for commit 02a395f69d5d9bb7fd099be42ff90cb1ed142ee7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced billing accuracy by associating AI feature usage with subscription plan information across all API endpoints.

* **Chores**
  * Improved usage analytics to track plan-level metrics for better cost attribution and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->