### PR TITLE
🔒 fix(security): timing-safe webhook signature compare (A1.12, PHO-245)

### DIFF
--- a/packages/utils/src/timingSafeCompare.test.ts
+++ b/packages/utils/src/timingSafeCompare.test.ts
@@ -1,0 +1,75 @@
+import { createHmac } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+
+import { timingSafeCompareHex, timingSafeCompareStrings } from './timingSafeCompare';
+
+describe('timingSafeCompareStrings', () => {
+  it('returns true for equal strings', () => {
+    expect(timingSafeCompareStrings('abc', 'abc')).toBe(true);
+    expect(timingSafeCompareStrings('', '')).toBe(true);
+    expect(
+      timingSafeCompareStrings('a long shared secret token', 'a long shared secret token'),
+    ).toBe(true);
+  });
+
+  it('returns false for different strings of same length', () => {
+    expect(timingSafeCompareStrings('abc', 'abd')).toBe(false);
+    expect(timingSafeCompareStrings('SECRET-A', 'SECRET-B')).toBe(false);
+  });
+
+  it('returns false for strings of different length without throwing', () => {
+    expect(timingSafeCompareStrings('abc', 'abcd')).toBe(false);
+    expect(timingSafeCompareStrings('', 'a')).toBe(false);
+    expect(timingSafeCompareStrings('long-secret', '')).toBe(false);
+  });
+
+  it('handles unicode strings byte-correctly', () => {
+    // Two strings that are visually equal must compare equal.
+    expect(timingSafeCompareStrings('ñ', 'ñ')).toBe(true);
+    // Different unicode codepoints with the same UTF-8 byte length must
+    // still be detected as different.
+    expect(timingSafeCompareStrings('ñ', 'á')).toBe(false);
+  });
+});
+
+const computeHmac = (key: string, body: string) =>
+  createHmac('sha256', key).update(body).digest('hex');
+
+describe('timingSafeCompareHex', () => {
+  const secret = 'shared-signing-key';
+  const payload = '{"event":"User.Data.Updated"}';
+
+  it('returns true for matching HMAC-SHA256 hex digests', () => {
+    const a = computeHmac(secret, payload);
+    const b = computeHmac(secret, payload);
+    expect(timingSafeCompareHex(a, b)).toBe(true);
+  });
+
+  it('returns false when the signing key differs', () => {
+    const a = computeHmac(secret, payload);
+    const b = computeHmac('other-key', payload);
+    expect(timingSafeCompareHex(a, b)).toBe(false);
+  });
+
+  it('returns false when the payload differs', () => {
+    const a = computeHmac(secret, payload);
+    const b = computeHmac(secret, payload + 'tampered');
+    expect(timingSafeCompareHex(a, b)).toBe(false);
+  });
+
+  it('returns false for hex strings of different length', () => {
+    expect(timingSafeCompareHex('abcd', 'abcdef')).toBe(false);
+  });
+
+  it('returns false when one input contains non-hex characters', () => {
+    const valid = computeHmac(secret, payload);
+    // Same length, but with non-hex chars — Buffer.from('xx', 'hex')
+    // truncates and the length guard rejects it.
+    const garbage = 'z'.repeat(valid.length);
+    expect(timingSafeCompareHex(valid, garbage)).toBe(false);
+  });
+
+  it('returns false for two empty strings (no signature is invalid)', () => {
+    expect(timingSafeCompareHex('', '')).toBe(false);
+  });
+});

--- a/packages/utils/src/timingSafeCompare.ts
+++ b/packages/utils/src/timingSafeCompare.ts
@@ -1,0 +1,56 @@
+import { timingSafeEqual } from 'node:crypto';
+
+/**
+ * Constant-time string comparison helpers — server-only.
+ *
+ * Why this exists (PHO-245 / A1.12):
+ *   JavaScript `===` short-circuits on the first differing byte. The time
+ *   a comparison takes therefore leaks how many leading bytes match,
+ *   which lets an attacker brute-force a webhook signature byte-by-byte
+ *   given enough requests. `crypto.timingSafeEqual` always walks every
+ *   byte, so a wrong byte at position 0 takes the same time as one at
+ *   position 31.
+ *
+ *   Length is NOT secret — comparing strings of different lengths is
+ *   pointless and `timingSafeEqual` throws on mismatched buffer lengths,
+ *   so we short-circuit on length explicitly. Both helpers fail closed
+ *   (return false) on any conversion error.
+ */
+
+/**
+ * Compare two arbitrary strings (shared secret tokens, base64, etc.) in
+ * constant time. Use when you don't know — or don't care about — the
+ * encoding of the input.
+ */
+export const timingSafeCompareStrings = (a: string, b: string): boolean => {
+  if (a.length !== b.length) return false;
+
+  try {
+    return timingSafeEqual(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8'));
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Compare two hex-encoded signatures (e.g. `hmac.digest('hex')`) in
+ * constant time. Decoding to raw bytes first means the comparison length
+ * is the actual signature length (32 bytes for SHA-256), which is the
+ * most efficient form.
+ *
+ * Falls back to false if either input is not valid hex.
+ */
+export const timingSafeCompareHex = (a: string, b: string): boolean => {
+  if (a.length !== b.length) return false;
+
+  try {
+    const bufA = Buffer.from(a, 'hex');
+    const bufB = Buffer.from(b, 'hex');
+    // Buffer.from('xx', 'hex') silently truncates on invalid input — guard
+    // against that so a malformed signature can't accidentally match.
+    if (bufA.length === 0 || bufA.length !== bufB.length) return false;
+    return timingSafeEqual(bufA, bufB);
+  } catch {
+    return false;
+  }
+};

--- a/src/app/(backend)/api/webhooks/casdoor/validateRequest.ts
+++ b/src/app/(backend)/api/webhooks/casdoor/validateRequest.ts
@@ -1,6 +1,7 @@
 import { headers } from 'next/headers';
 
 import { authEnv } from '@/envs/auth';
+import { timingSafeCompareStrings } from '@/utils/timingSafeCompare';
 
 export type CasdoorUserEntity = {
   avatar?: string;
@@ -21,7 +22,11 @@ export const validateRequest = async (request: Request, secret?: string) => {
   const headerPayload = await headers();
   const casdoorSecret = headerPayload.get('casdoor-secret')!;
   try {
-    if (casdoorSecret === secret) {
+    // PHO-245 / A1.12: constant-time compare prevents timing attack on the
+    // shared secret. `timingSafeCompareStrings` returns false for missing or
+    // mismatched-length inputs, which also covers the previous `secret`
+    // undefined-fallback case.
+    if (secret && timingSafeCompareStrings(casdoorSecret, secret)) {
       return JSON.parse(payloadString, (k, v) =>
         k === 'object' && typeof v === 'string' ? JSON.parse(v) : v,
       ) as CasdoorWebhookPayload;

--- a/src/app/(backend)/api/webhooks/logto/validateRequest.ts
+++ b/src/app/(backend)/api/webhooks/logto/validateRequest.ts
@@ -2,6 +2,7 @@ import { headers } from 'next/headers';
 import { createHmac } from 'node:crypto';
 
 import { authEnv } from '@/envs/auth';
+import { timingSafeCompareHex } from '@/utils/timingSafeCompare';
 
 export type LogtToUserEntity = {
   applicationId?: string;
@@ -32,7 +33,9 @@ export const validateRequest = async (request: Request, signingKey: string) => {
     const hmac = createHmac('sha256', signingKey);
     hmac.update(payloadString);
     const signature = hmac.digest('hex');
-    if (signature === logtoHeaderSignature) {
+    // PHO-245 / A1.12: constant-time compare on the HMAC-SHA256 hex digest
+    // prevents byte-by-byte timing attacks on the signature.
+    if (logtoHeaderSignature && timingSafeCompareHex(signature, logtoHeaderSignature)) {
       return JSON.parse(payloadString) as LogtoWebhookPayload;
     } else {
       console.warn(

--- a/src/app/api/payment/sepay/webhook/route.ts
+++ b/src/app/api/payment/sepay/webhook/route.ts
@@ -9,6 +9,7 @@ import { SepayWebhookData, sepayGateway } from '@/libs/sepay';
 import { sendTikTokServerEvent } from '@/libs/tiktok-events-api';
 import { logWebhookEvent } from '@/libs/webhookLogger';
 import { getPaymentByOrderId } from '@/server/services/billing/sepay';
+import { timingSafeCompareStrings } from '@/utils/timingSafeCompare';
 
 /**
  * GET endpoint to test webhook accessibility
@@ -506,7 +507,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       );
     }
 
-    if (!providedSecret || providedSecret !== webhookSecret) {
+    // PHO-245 / A1.12: constant-time compare on the shared SePay secret.
+    // `timingSafeCompareStrings` returns false on missing/different-length
+    // inputs, so it also subsumes the previous `!providedSecret` guard.
+    if (!providedSecret || !timingSafeCompareStrings(providedSecret, webhookSecret)) {
       console.error('❌ Unauthorized webhook request - invalid or missing secret token');
       console.error('❌ Provided secret:', providedSecret ? '[REDACTED]' : 'NONE');
       console.error(


### PR DESCRIPTION
Quick-win security fix from Audit 1 (A1.12).

## Problem

3 webhook handlers compared signatures with JavaScript `===`:

| File | Line | Format |
|------|------|--------|
| `src/app/(backend)/api/webhooks/casdoor/validateRequest.ts` | 24 | shared token |
| `src/app/(backend)/api/webhooks/logto/validateRequest.ts`   | 35 | HMAC-SHA256 hex |
| `src/app/api/payment/sepay/webhook/route.ts`                | 509 | shared token |

`===` short-circuits on the first differing byte. The time the comparison takes therefore leaks how many leading bytes match, letting an attacker brute-force the secret byte-by-byte across many requests.

## Fix

New helper `packages/utils/src/timingSafeCompare.ts` wraps `node:crypto.timingSafeEqual` with two variants:

- `timingSafeCompareStrings` — arbitrary string tokens (utf-8 buffer)
- `timingSafeCompareHex` — hex-encoded HMAC digests (decode to raw bytes first, then compare)

Both helpers fail closed:

- short-circuit on length mismatch (length itself is not secret, and `timingSafeEqual` throws on mismatched buffer length)
- reject malformed hex (non-hex chars cause `Buffer.from('xx', 'hex')` to silently truncate — guard catches that)
- return `false` on any conversion error

All 3 sites migrated. Caller-side null/empty guards retained so `timingSafeCompareStrings(undefined, secret)` cannot reach the helper.

Helper placed in `packages/utils/` because the project's vitest alias resolves `@/utils/*` → `packages/utils/src/*` first (per \`vitest.config.mts:18\` and \`tsconfig.json\` \"paths\"). Building it under \`src/utils/\` would type-check but fail to resolve in vitest.

## Tests

10 new unit tests in \`packages/utils/src/timingSafeCompare.test.ts\` cover:

- Equal strings (true)
- Different strings of same length (false)
- Length mismatch — empty / shorter / longer
- Unicode strings with same byte length but different codepoints
- Real HMAC-SHA256 round-trip with matching key + payload (true)
- Wrong signing key (false)
- Tampered payload (false)
- Hex strings of different length
- Non-hex characters in input
- Both empty strings (rejected because no signature is invalid)

\`\`\`
✓ src/timingSafeCompare.test.ts (10 tests) 3ms
Test Files  1 passed (1)
     Tests  10 passed (10)
\`\`\`

The pre-existing integration test files (\`webhooks/casdoor/__tests__/route.test.ts\`, \`webhooks/logto/__tests__/route.test.ts\`) are \`describe.skip\` local-dev only — no behavior change there.

## Test plan post-merge

- [ ] Trigger one real SePay webhook (or Sepay sandbox) and confirm payment still validates (returns 200, subscription activates)
- [ ] Hit \`/api/payment/sepay/webhook\` with a deliberately wrong secret → 401 with \"Unauthorized - invalid webhook secret\" (same as today)
- [ ] If using Casdoor / Logto SSO in any env, run a real signup/profile-update event through the webhook and confirm 200

No behavior change for valid signatures; invalid signatures still rejected. Latency delta is sub-microsecond.

## Refs

- Linear: PHO-245 (sub of PHO-238 Audit 1)
- Severity: P1 SECURITY
- Audit doc: \`docs/audit/audit-1-auth-2026-04-30.md\` (A1.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened webhook signature checks with timing-safe comparisons to prevent timing attacks. Replaces `===` compares in Casdoor, Logto, and SePay handlers. Linear: PHO-245 (Audit A1.12).

- **Bug Fixes**
  - Added `packages/utils/src/timingSafeCompare.ts` with `timingSafeCompareStrings` and `timingSafeCompareHex`, using `node:crypto.timingSafeEqual` and failing closed on length mismatch or invalid hex.
  - Updated Casdoor (shared token), Logto (HMAC-SHA256 hex), and SePay (shared token) to use the new helpers.
  - Added unit tests for string and HMAC cases; valid signatures still pass, invalid ones still fail.

<sup>Written for commit 76d9b7917bd8c6d055d93fe138a5133c141d4ba0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

