### PR TITLE
🚨 hotfix(auth): widen reauth window + proactive Clerk refresh on upload (PHO-251)

### DIFF
--- a/src/libs/trpc/client/authRecovery.ts
+++ b/src/libs/trpc/client/authRecovery.ts
@@ -13,7 +13,14 @@ let recentFailures: number[] = [];
 let lastCaptureAt = 0;
 let reauthScheduled = false;
 
-const FAILURE_WINDOW_MS = 30_000;
+// PHO-251: a single user reported 5 auth_session_expired events over 34 min on
+// /chat (avg ~7 min apart) followed by a TRPCClientError UNAUTHORIZED on file
+// upload. Each failure was outside the previous 30s window, so the threshold
+// never tripped and the user was left silently broken across many sessions.
+// Widened to 15 min so 2 unrecoverable 401s anywhere in that range escalates
+// to a hard re-auth (toast + redirect to /login). Burst storms (8 events in
+// ~15 ms during inbox load) still trip on the 2nd event as before.
+const FAILURE_WINDOW_MS = 15 * 60_000;
 const FAILURE_THRESHOLD = 2;
 const CAPTURE_THROTTLE_MS = 30_000;
 const REAUTH_TOAST_DELAY_MS = 1500;

--- a/src/libs/trpc/client/tools.ts
+++ b/src/libs/trpc/client/tools.ts
@@ -1,12 +1,74 @@
-import { createTRPCClient, httpBatchLink } from '@trpc/client';
+import { TRPCLink, createTRPCClient, httpBatchLink } from '@trpc/client';
+import { observable } from '@trpc/server/observable';
 import superjson from 'superjson';
 
 import { isDesktop } from '@/const/version';
 import type { ToolsRouter } from '@/server/routers/tools';
 import { fetchWithDesktopRemoteRPC } from '@/utils/electron/desktopRemoteRPCFetch';
 
+import { forceReauth, shouldForceReauth, silentRefresh } from './authRecovery';
+
+// Mirrors the lambda + edge clients' retryOnUnauthorizedLink so plugin-router
+// 401s share the same singleflight Clerk refresh and force-reauth escalation.
+// A previous "unify across all clients" commit (6153353958) introduced a
+// shared factory file that no longer exists in the tree, leaving tools.ts as
+// the only client that bubbled up 401s without auto-retry — restoring the
+// guard inline keeps the patch small and avoids reintroducing a missing file.
+const retryOnUnauthorizedLink: TRPCLink<ToolsRouter> = () => {
+  return ({ op, next }) =>
+    observable((observer) => {
+      let retried = false;
+      const attempt = () =>
+        next(op).subscribe({
+          complete: () => observer.complete(),
+          error: async (err) => {
+            const status = (err as any).data?.httpStatus as number | undefined;
+            if (status === 401 && !retried) {
+              retried = true;
+              const { useUserStore } = await import('@/store/user');
+              const state = useUserStore.getState();
+
+              // If Clerk already loaded but user not signed in, don't retry —
+              // genuinely unauthenticated.
+              if (state.isLoaded && !state.isSignedIn) {
+                observer.error(err);
+                return;
+              }
+
+              // Poll useUserStore for Clerk auth readiness (extended for VN CDN).
+              await new Promise<void>((resolve) => {
+                const check = () => {
+                  if (useUserStore.getState().isLoaded) return resolve();
+                  setTimeout(check, 200);
+                };
+                check();
+                setTimeout(resolve, 5000);
+              });
+
+              // Singleflight refresh shared with lambda + edge clients.
+              const refreshed = await silentRefresh();
+              const updated = useUserStore.getState();
+
+              if (refreshed && updated.isSignedIn) {
+                attempt();
+                return;
+              }
+
+              if (shouldForceReauth()) {
+                forceReauth();
+              }
+            }
+            observer.error(err);
+          },
+          next: (value) => observer.next(value),
+        });
+      attempt();
+    });
+};
+
 export const toolsClient = createTRPCClient<ToolsRouter>({
   links: [
+    retryOnUnauthorizedLink,
     httpBatchLink({
       fetch: isDesktop
         ? // eslint-disable-next-line no-undef

--- a/src/store/file/slices/chat/action.ts
+++ b/src/store/file/slices/chat/action.ts
@@ -3,6 +3,7 @@ import { StateCreator } from 'zustand/vanilla';
 
 import { notification } from '@/components/AntdStaticMethods';
 import { FILE_UPLOAD_BLACKLIST } from '@/const/file';
+import { silentRefresh } from '@/libs/trpc/client/authRecovery';
 import { fileService } from '@/services/file';
 import { ServerService } from '@/services/file/server';
 import { ragService } from '@/services/rag';
@@ -117,6 +118,16 @@ export const createFileSlice: StateCreator<
     );
 
     dispatchChatUploadFileList({ files: uploadFiles, type: 'addFiles' });
+
+    // PHO-251: proactively touch the Clerk session before the upload-related
+    // tRPC mutations fire. If the user idled long enough for the __session
+    // cookie to go stale (~5 min), this refreshes it now so the very first
+    // checkFileHash / createS3PreSignedUrl / createFile call lands with a fresh
+    // JWT instead of 401 → retryOnUnauthorizedLink → silent recovery → re-issue.
+    // Singleflight inside authRecovery makes back-to-back uploads share one
+    // Clerk touch (~150ms). The retry link is still the safety net for race
+    // conditions and slow regions; this is a no-op when the session is fresh.
+    await silentRefresh();
 
     // upload files and process it
     const pools = files.map(async (file) => {


### PR DESCRIPTION
## P0 LIVE BUG — file upload silently failing

User `user_3AItxFRvfSfKg1HQPBpgEZT8UE7` reported uploads not working. PostHog evidence: 5x `auth_session_expired` + 1x `TRPCClientError UNAUTHORIZED` in 34 minutes for that user. Pattern recurring 14 days, ~10 users affected.

## Root cause (NOT what the original ticket guessed)

The ticket hypothesized "TRPC client doesn't refresh Clerk JWT". That hypothesis was wrong — `retryOnUnauthorizedLink` + `silentRefresh` + `forceReauth` were already in place from the auth-storm fix (`4d5aaeddac`). The TRUE bug:

1. **`shouldForceReauth` window is 30s, but real failures are ~7 min apart.** The user's 5 events over 34 min never crossed the 2-in-30s threshold, so the force-reauth toast/redirect never fired. Each unrecoverable 401 was throttled to a single PostHog event then swallowed by `uploadChatFiles`'s catch (which deliberately ignores `UNAUTHORIZED` on the assumption retry recovers it). Net: silent failures across many sessions, no UX feedback, no recovery path.

2. **Recoverable JWT-stale 401s still fired one auth_session_expired event per upload before retrying succeeded.** Telemetry noise + a wasted round-trip on the happy path.

3. **`tools.ts` regression.** Commit `6153353958` added a shared `retryUnauthorizedLink.ts` factory that tools.ts imported — that factory file is no longer in the tree, leaving plugin-router 401s un-retry'd ever since.

## Three surgical changes

| File | Change | Why |
|---|---|---|
| `src/libs/trpc/client/authRecovery.ts` | `FAILURE_WINDOW_MS` 30s → 15 min | Slow-recurring 401s now escalate to `forceReauth` (toast + `/login` redirect). Burst storms still trip on the 2nd event as before. |
| `src/store/file/slices/chat/action.ts` | `await silentRefresh()` before parallel upload pool | Idle JWT cookie gets refreshed proactively; first `checkFileHash`/`createS3PreSignedUrl` lands with valid `__session`. Singleflight = no-op when fresh. |
| `src/libs/trpc/client/tools.ts` | Inline `retryOnUnauthorizedLink` mirroring lambda+edge | Restores the missing retry guard for plugin router. |

## Verification done locally

- [x] `bun run type-check` ✅
- [x] `src/store/file/slices/chat/action.test.ts` ✅ (existing coverage still passes)
- [x] lint-staged (prettier + eslint + stylelint) ✅
- [x] Diff inspected: only 3 files, +82 / -2 lines

## Test plan post-merge

1. **Reproduce baseline** (preview deployment): open `/chat`, idle 10+ min, click upload — verify previous behavior (silent fail) on `main` first if needed.
2. **Verify fix**: open `/chat` on this branch's preview, idle 10+ min, click upload → upload should succeed (proactive refresh kicks in).
3. **Verify force-reauth path**: clear `__session` cookie manually in devtools, click upload twice → should see "Phiên đăng nhập đã hết hạn" toast + redirect to `/login?reason=session_expired&callbackUrl=...` after the 2nd attempt.
4. **PostHog check 1h after deploy**:
   ```sql
   SELECT toStartOfMinute(timestamp) AS m, count()
   FROM events
   WHERE event = 'auth_session_expired' AND timestamp >= now() - INTERVAL 1 HOUR
   GROUP BY m ORDER BY m DESC
   ```
   Expect: 0 or near-0 (proactive refresh prevents the recoverable case entirely; unrecoverable cases now redirect to login).
5. **PostHog check 24h after deploy**: trend should drop sharply vs the ~9/day baseline.
6. **Confirm with reporter**: ask `user_3AItxFRvfSfKg1HQPBpgEZT8UE7` to retry upload.

## Risk assessment: LOW

- Widened window only affects unrecoverable 401s. Recoverable retries (the 99% case) still resolve transparently.
- Proactive refresh is singleflight + ~150ms; no-op if session is fresh. Worst case: adds 150ms latency to file upload (negligible vs upload time).
- `tools.ts` retry inline-mirrors edge.ts which has been in production for weeks.

## Linear

- PHO-251 (sub of PHO-238)
- Severity: P0 LIVE BUG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PHO-251: stop silent file upload failures by widening the reauth window and refreshing Clerk before uploads. Restores 401 auto-retry in the tools client so plugin routes recover or redirect cleanly.

- **Bug Fixes**
  - `src/libs/trpc/client/authRecovery.ts`: widen `FAILURE_WINDOW_MS` from 30s to 15 min so slow recurring 401s trigger `forceReauth`.
  - `src/store/file/slices/chat/action.ts`: call `silentRefresh()` before starting the upload pool to avoid stale `__session` cookies; singleflight no-op when fresh.
  - `src/libs/trpc/client/tools.ts`: inline `retryOnUnauthorizedLink` to auto-retry 401s and escalate when needed, matching lambda/edge clients.

<sup>Written for commit 3c29f92bed3e15a4dd018b2573148f5127b0d0b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

