### PR TITLE
🚨 hotfix(auth): escalate post-retry 401 to forceReauth (PHO-252)

### DIFF
--- a/src/libs/trpc/client/edge.ts
+++ b/src/libs/trpc/client/edge.ts
@@ -54,7 +54,13 @@ const retryOnUnauthorizedLink: TRPCLink<EdgeRouter> = () => {
               if (shouldForceReauth()) {
                 forceReauth();
               }
-            }
+            } else if (status === 401 && retried && // PHO-252: second 401 after a successful client-side refresh.
+              // Server still rejects the fresh JWT (server-side session dead,
+              // kid mismatch, etc.). Count it so shouldForceReauth() can
+              // escalate instead of silently bubbling.
+              shouldForceReauth()) {
+                forceReauth();
+              }
             observer.error(err);
           },
           next: (value) => observer.next(value),

--- a/src/libs/trpc/client/lambda.ts
+++ b/src/libs/trpc/client/lambda.ts
@@ -62,7 +62,17 @@ const retryOnUnauthorizedLink: TRPCLink<LambdaRouter> = () => {
               if (shouldForceReauth()) {
                 forceReauth();
               }
-            }
+            } else if (status === 401 && retried && // PHO-252: second 401 after a successful client-side refresh.
+              // The fresh JWT didn't satisfy the server (Clerk session
+              // server-side dead, instance/kid mismatch, kid rotation lag
+              // between client and edge). Without counting this, the link
+              // bubbled the error to errorHandlingLink which only captures
+              // the PostHog event — forceReauth() never fired, leaving the
+              // user permanently broken across many sessions. Counting it
+              // here lets shouldForceReauth() escalate after the threshold.
+              shouldForceReauth()) {
+                forceReauth();
+              }
             observer.error(err);
           },
           next: (value) => observer.next(value),

--- a/src/libs/trpc/client/tools.ts
+++ b/src/libs/trpc/client/tools.ts
@@ -57,7 +57,12 @@ const retryOnUnauthorizedLink: TRPCLink<ToolsRouter> = () => {
               if (shouldForceReauth()) {
                 forceReauth();
               }
-            }
+            } else if (status === 401 && retried && // PHO-252: second 401 after a successful client-side refresh.
+              // Server still rejects the fresh JWT — count it so
+              // shouldForceReauth() can escalate.
+              shouldForceReauth()) {
+                forceReauth();
+              }
             observer.error(err);
           },
           next: (value) => observer.next(value),


### PR DESCRIPTION
## P0 LIVE BUG #2 — upload still broken after PR #38

User reported file upload still failing AFTER PR #38 (PHO-251) merged + deployed. PR #38 IS live: Vercel native git integration deployed `dpl_AzE7jiUWphpTLoMyrqN3rqXyQ1Zh` at 2026-05-02T09:48:46Z (`state: READY`, `target: production`, `alias: pho.chat`). The failing GitHub Action `Deploy to Vercel (Prod)` is a redundant `vercel deploy` CI step that's been broken for 15 consecutive runs since 2026-04-25 (frozen-lockfile error) — it's not the actual deploy mechanism. Filed as separate cleanup.

## Real root cause (NOT what the ticket suggested)

Vercel runtime logs (production, post-deploy) show 401s persisting on the **entire lambda router**, not just `file.checkFileHash`:

| Time (UTC) | Path | Status |
|---|---|---|
| 09:51:17 | POST /trpc/lambda/file.checkFileHash | 401 |
| 09:52:11 | POST /trpc/lambda/file.removeFile | 401 |
| 09:52:21 | POST /trpc/lambda/file.checkFileHash | 401 |
| 09:52:54 | POST /trpc/lambda/file.checkFileHash | 401 |
| 09:53:36 | POST /trpc/lambda/user.updatePreference | 401 |
| 09:53:52 | POST /trpc/lambda/file.checkFileHash | 401 |
| 09:54:06 | POST /trpc/lambda/file.checkFileHash | 401 |
| 09:54:15 | POST /trpc/lambda/file.checkFileHash | 401 |
| 09:11:55 | GET /trpc/lambda/thread.getThreads | 401 |
| 09:15:12 | POST /trpc/lambda/session.updateSessionConfig | 401 |
| 09:16:01 | GET /trpc/lambda/agent.getKnowledgeBasesAndQAs | 401 |

NOT a `file.*` specific bug. Universal Clerk session expiry → all lambda calls 401.

## The actual hole in `retryOnUnauthorizedLink`

`retryOnUnauthorizedLink` had a missing branch:

```ts
if (status === 401 && !retried) {
  retried = true;
  // ... silentRefresh()
  if (refreshed && updated.isSignedIn) {
    attempt();   // retry — if THIS also 401s, falls through below
    return;
  }
  // Refresh failed: count + escalate
  if (shouldForceReauth()) forceReauth();
}
// status === 401 && retried (i.e. retry also 401'd) FELL THROUGH HERE
observer.error(err);
```

When the user's Clerk session is invalidated server-side (revoked, kid rotation lag between Clerk Frontend API and the edge verifier, instance drift, etc.):

1. Initial 401 → retry triggered
2. `silentRefresh()` succeeds **client-side** (Clerk Frontend API returns a new JWT)
3. `attempt()` retries with fresh JWT
4. Server still returns 401 (because root cause is server-side, not client cache)
5. Second 401 falls through `retried=true` straight to `observer.error`
6. errorHandlingLink fires throttled `captureAuthExpired()` PostHog event
7. **`shouldForceReauth()` is NEVER called for this path**
8. `forceReauth()` (toast + redirect to `/login`) never escalates
9. User silently broken indefinitely

PR #38's threshold widening (30s → 15min) didn't help because the counter was never incremented in the first place.

## Fix

In `lambda.ts` / `edge.ts` / `tools.ts`, add an `else if (status === 401 && retried)` branch that calls `shouldForceReauth()`. With `FAILURE_THRESHOLD = 2` + `FAILURE_WINDOW_MS = 15 min` from PR #38, the user's second post-retry 401 within 15 min trips `forceReauth()` → existing toast + redirect to `/login?reason=session_expired&callbackUrl=...`.

Pure additive change inside existing else chain. No behavior change for the happy path or for the refresh-failed path PR #38 already handled.

## Verification done locally

- [x] `bun run type-check` ✅
- [x] `src/store/file/slices/chat/action.test.ts` ✅
- [x] lint-staged (prettier + eslint) ✅
- [x] 24 LOC across 3 files; diff inspected

## Test plan post-merge

1. **Wait for Vercel deploy READY** (check `mcp__plugin_vercel_vercel__list_deployments` for the merge commit's `state: READY`).
2. Reload pho.chat in a tab where you have a stale Clerk session, click upload twice — second attempt should toast "Phiên đăng nhập đã hết hạn" + redirect to `/login`.
3. Vercel runtime logs check 30 min after deploy:
   ```
   query: file.checkFileHash, status: 401, since: 30m, env: production
   ```
   Expect: count drops sharply vs the pre-PR-38 baseline. Stragglers represent the first failure of a stale-session window — second one will redirect.
4. Confirm with affected user (`user_3AAHAPVP3FXij0MX2Qr6cpx2mfp`) that they can upload after re-signing in.

## Risk: LOW

- New branch is reachable only when `status === 401 && retried`, i.e. the fresh JWT failed server-side validation. The only behavior change is calling `shouldForceReauth()` (which has the side effect of incrementing the in-memory counter) and possibly `forceReauth()` (which already fires elsewhere in this codebase for the refresh-failed branch).
- `shouldForceReauth()` requires 2 failures within 15 min — single transient 401s don't trip it.
- `forceReauth()` is idempotent per page load (`reauthScheduled` flag).

## Linear

- PHO-252 (sub of PHO-238)
- Severity: P0 LIVE BUG (follow-up to PHO-251)
- Refs: PR #38

## Follow-ups (separate tickets)

- The 'Deploy to Vercel (Prod)' GitHub Action workflow has been failing 15 consecutive runs (frozen-lockfile). Either delete it (Vercel native integration handles deploys) or fix `bun.lock` and re-enable. Tracking separately.
- Server-side investigation: WHY is Clerk session getting invalidated server-side for active users? kid rotation? instance drift? jwk cache? — needs separate audit ticket.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escalates post-retry 401s to forced reauth so users with invalid server-side Clerk sessions get redirected to log in instead of remaining stuck. Addresses PHO-252 and fixes 401s across lambda calls after a successful silent refresh.

- **Bug Fixes**
  - Added `status === 401 && retried` branch in `retryOnUnauthorizedLink` (`src/libs/trpc/client/edge.ts`, `lambda.ts`, `tools.ts`) to call `shouldForceReauth()` and `forceReauth()`.
  - Uses existing threshold (2 failures within 15 min) to trigger the toast and redirect to `/login?reason=session_expired&callbackUrl=...`.
  - No change to the happy path or the refresh-failed path; only affects second 401s after a refresh.

<sup>Written for commit 4b96337c4cb5a9e7e27e9ef44764a3100f220be9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Enhanced error handling for authentication by implementing improved recovery mechanisms when token refresh attempts fail. The system now properly detects and escalates re-authentication requirements in edge cases instead of silently propagating authentication errors, ensuring users are notified and guided to re-login appropriately when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->