### PR TITLE
⚡ perf(auth): tRPC retry timeout 8s→2s (PHO-259)

### DIFF
--- a/src/libs/trpc/client/edge.ts
+++ b/src/libs/trpc/client/edge.ts
@@ -32,14 +32,27 @@ const retryOnUnauthorizedLink: TRPCLink<EdgeRouter> = () => {
                 return;
               }
 
-              // Poll useUserStore for Clerk auth readiness (extended timeout for slow regions)
+              // Poll useUserStore for Clerk auth readiness. PHO-259: cap at 2s —
+              // silentRefresh typically resolves <1s, so a generous 2s wins back
+              // the unrecoverable user-facing latency the previous 5s wait was
+              // burning on every 401. Past 2s the recovery is treated as failed
+              // and shouldForceReauth() escalates on the next failure. The
+              // `settled` guard stops the recursive poll from running as a
+              // zombie timer after the safety cap fires.
               await new Promise<void>((resolve) => {
+                let settled = false;
+                const finish = () => {
+                  if (settled) return;
+                  settled = true;
+                  resolve();
+                };
                 const check = () => {
-                  if (useUserStore.getState().isLoaded) return resolve();
-                  setTimeout(check, 200);
+                  if (settled) return;
+                  if (useUserStore.getState().isLoaded) return finish();
+                  setTimeout(check, 100);
                 };
                 check();
-                setTimeout(resolve, 5000); // Safety: max 5s wait
+                setTimeout(finish, 2000);
               });
 
               // Singleflight refresh shared with lambda client.
@@ -54,13 +67,16 @@ const retryOnUnauthorizedLink: TRPCLink<EdgeRouter> = () => {
               if (shouldForceReauth()) {
                 forceReauth();
               }
-            } else if (status === 401 && retried && // PHO-252: second 401 after a successful client-side refresh.
+            } else if (
+              status === 401 &&
+              retried && // PHO-252: second 401 after a successful client-side refresh.
               // Server still rejects the fresh JWT (server-side session dead,
               // kid mismatch, etc.). Count it so shouldForceReauth() can
               // escalate instead of silently bubbling.
-              shouldForceReauth()) {
-                forceReauth();
-              }
+              shouldForceReauth()
+            ) {
+              forceReauth();
+            }
             observer.error(err);
           },
           next: (value) => observer.next(value),

--- a/src/libs/trpc/client/lambda.ts
+++ b/src/libs/trpc/client/lambda.ts
@@ -38,15 +38,29 @@ const retryOnUnauthorizedLink: TRPCLink<LambdaRouter> = () => {
                 return;
               }
 
-              // Poll useUserStore for Clerk auth readiness (extended timeout for slow regions)
+              // Poll useUserStore for Clerk auth readiness. PHO-259: cap at 2s —
+              // silentRefresh typically resolves <1s, so a generous 2s wins back
+              // the 6s of unrecoverable user-facing latency the previous 8s wait
+              // was burning on every 401. Past 2s the recovery is treated as
+              // failed; shouldForceReauth() escalates on the next failure rather
+              // than keeping the user stuck. The `settled` guard stops the
+              // recursive poll from running as a zombie timer after the safety
+              // cap fires.
               await new Promise<void>((resolve) => {
+                let settled = false;
+                const finish = () => {
+                  if (settled) return;
+                  settled = true;
+                  resolve();
+                };
                 const check = () => {
+                  if (settled) return;
                   const s = useUserStore.getState();
-                  if (s.isLoaded) return resolve();
-                  setTimeout(check, 200);
+                  if (s.isLoaded) return finish();
+                  setTimeout(check, 100);
                 };
                 check();
-                setTimeout(resolve, 8000); // Max 8s wait (Clerk CDN slow in VN)
+                setTimeout(finish, 2000);
               });
 
               // Singleflight refresh — parallel 401s share one Clerk call.
@@ -62,7 +76,9 @@ const retryOnUnauthorizedLink: TRPCLink<LambdaRouter> = () => {
               if (shouldForceReauth()) {
                 forceReauth();
               }
-            } else if (status === 401 && retried && // PHO-252: second 401 after a successful client-side refresh.
+            } else if (
+              status === 401 &&
+              retried && // PHO-252: second 401 after a successful client-side refresh.
               // The fresh JWT didn't satisfy the server (Clerk session
               // server-side dead, instance/kid mismatch, kid rotation lag
               // between client and edge). Without counting this, the link
@@ -70,9 +86,10 @@ const retryOnUnauthorizedLink: TRPCLink<LambdaRouter> = () => {
               // the PostHog event — forceReauth() never fired, leaving the
               // user permanently broken across many sessions. Counting it
               // here lets shouldForceReauth() escalate after the threshold.
-              shouldForceReauth()) {
-                forceReauth();
-              }
+              shouldForceReauth()
+            ) {
+              forceReauth();
+            }
             observer.error(err);
           },
           next: (value) => observer.next(value),

--- a/src/libs/trpc/client/tools.ts
+++ b/src/libs/trpc/client/tools.ts
@@ -35,14 +35,27 @@ const retryOnUnauthorizedLink: TRPCLink<ToolsRouter> = () => {
                 return;
               }
 
-              // Poll useUserStore for Clerk auth readiness (extended for VN CDN).
+              // Poll useUserStore for Clerk auth readiness. PHO-259: cap at 2s —
+              // silentRefresh typically resolves <1s, so a generous 2s wins back
+              // the unrecoverable user-facing latency the previous 5s wait was
+              // burning on every 401. Past 2s the recovery is treated as failed
+              // and shouldForceReauth() escalates on the next failure. The
+              // `settled` guard stops the recursive poll from running as a
+              // zombie timer after the safety cap fires.
               await new Promise<void>((resolve) => {
+                let settled = false;
+                const finish = () => {
+                  if (settled) return;
+                  settled = true;
+                  resolve();
+                };
                 const check = () => {
-                  if (useUserStore.getState().isLoaded) return resolve();
-                  setTimeout(check, 200);
+                  if (settled) return;
+                  if (useUserStore.getState().isLoaded) return finish();
+                  setTimeout(check, 100);
                 };
                 check();
-                setTimeout(resolve, 5000);
+                setTimeout(finish, 2000);
               });
 
               // Singleflight refresh shared with lambda + edge clients.
@@ -57,12 +70,15 @@ const retryOnUnauthorizedLink: TRPCLink<ToolsRouter> = () => {
               if (shouldForceReauth()) {
                 forceReauth();
               }
-            } else if (status === 401 && retried && // PHO-252: second 401 after a successful client-side refresh.
+            } else if (
+              status === 401 &&
+              retried && // PHO-252: second 401 after a successful client-side refresh.
               // Server still rejects the fresh JWT — count it so
               // shouldForceReauth() can escalate.
-              shouldForceReauth()) {
-                forceReauth();
-              }
+              shouldForceReauth()
+            ) {
+              forceReauth();
+            }
             observer.error(err);
           },
           next: (value) => observer.next(value),


### PR DESCRIPTION
## Why

PHO-253 investigation found `retryOnUnauthorizedLink` polls `useUserStore` for up to **8 s** (lambda) or **5 s** (edge/tools) before giving up on a 401. Clerk `silentRefresh()` typically resolves in <1 s — so 6 s (lambda) and 3 s (edge/tools) is unrecoverable user-facing latency burned on every auth retry.

PostHog correlation: on auth-storm days (35–73 `auth_session_expired` events) `/chat` INP p95 spikes to 12.8 s. The 8 s polling cap is a major contributor.

Refs: `docs/perf/PHO-253-investigation-2026-05-02.md` §"tRPC retry pattern (auth recovery)" and §"Top 3 bottlenecks #3".

## Changes

All three tRPC client links: `lambda.ts`, `edge.ts`, `tools.ts`.

- **Safety timeout**: lambda 8 s → **2 s**, edge 5 s → **2 s**, tools 5 s → **2 s**
- **Poll interval**: 200 ms → **100 ms** (catch fresh hydration twice as fast)
- **`settled` flag**: stops the recursive `setTimeout(check, …)` from running as a zombie timer after the safety cap fires (pre-existing benign leak, fixed in passing)

## Escalation path verified intact

After the polling Promise resolves (whether by `isLoaded` or 2 s cap):
1. `silentRefresh()` runs (singleflight, shared across the 3 clients)
2. If refreshed + signed-in → retry the original request
3. Otherwise → `shouldForceReauth()` → `forceReauth()` per PHO-251 / PHO-252

A 2 s cap doesn't change which code paths run, only how fast we give up. Faster fail → faster `forceReauth` → faster recovery.

## Impact estimate

- −3–6 s worst-case per single retry cycle
- −20–30 s cumulative on auth-storm days when multiple parallel queries all 401
- Faster `forceReauth` redirect for genuinely-dead sessions (good UX — user sees "session expired" toast in 2 s instead of 8 s)

## Risk assessment: very low

- No API surface change. No new types. No new code paths.
- Only constants change (8 000/5 000 → 2 000, 200 → 100) plus a `settled` guard.
- Local `npx tsc --noEmit` clean (exit 0). Diff is purely behavioural.
- The 8 s timeout was added historically for "Clerk CDN slow in VN" + SSO-callback race. Both concerns still mitigated:
  - SSO race: `state.isSignedIn` short-circuit at line 36 still runs before polling (genuinely unauthenticated → no retry).
  - Slow Clerk: 2 s is still 2× the typical resolve time. The few users on >2 s networks now hit `forceReauth` once (a redirect they would have hit eventually anyway).

## Test plan post-merge

1. **Manual smoke**: open `/chat`, wait 10+ min for JWT to expire, click any action (send message, upload file). Should resolve in <2 s — either a successful retry or a redirect to `/login` with the session-expired toast. Pre-fix: 8 s hang.
2. **PostHog 24 h after deploy** — expect INP improvement on auth-storm days:
   ```
   SELECT toDate(timestamp) AS day,
          round(avg(toFloat(properties.\$web_vitals_INP_value)), 0) AS inp_avg,
          round(quantile(0.95)(toFloat(properties.\$web_vitals_INP_value)), 0) AS inp_p95,
          countIf(event = 'auth_session_expired') AS auth_events
   FROM events
   WHERE properties.\$pathname = '/chat'
     AND timestamp >= now() - INTERVAL 7 DAY
   GROUP BY day ORDER BY day DESC
   ```
   Watch for INP avg trending below ~300 ms baseline on days when `auth_events > 20`.
3. **Sentry / PostHog `auth_session_expired` rate** — should not spike upward; if it does, the 2 s cap is too aggressive and we should bump to 3 s.

## Files modified

- `src/libs/trpc/client/lambda.ts`
- `src/libs/trpc/client/edge.ts`
- `src/libs/trpc/client/tools.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shorten unauthorized retry safety timeout in `tRPC` client links to 2s and tighten polling to cut wasted wait time on 401s and speed up auth recovery. Addresses PHO-259 and should reduce `/chat` INP spikes on auth-storm days.

- **Performance**
  - Safety cap: `lambda` 8s→2s; `edge` 5s→2s; `tools` 5s→2s.
  - Poll every 100ms (was 200ms) for `useUserStore.isLoaded`; add `settled` guard to stop orphaned timers.
  - Flow unchanged: `silentRefresh()` then retry; if still 401, `shouldForceReauth()`/`forceReauth()` runs sooner.

<sup>Written for commit be48e78d1f4f7cdfbe6d4b119d98166f29bb16ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

