### PR TITLE
💰 fix(cost): seed gateway-prefixed model pricing (PHO-256)

### DIFF
--- a/scripts/seed-model-pricing-gateway.sql
+++ b/scripts/seed-model-pricing-gateway.sql
@@ -1,0 +1,35 @@
+-- Seed model_pricing — gateway-prefixed modelIds (PHO-256)
+-- Equivalent of scripts/seed-model-pricing-gateway.ts. Run on Neon Console
+-- when you don't want to run the bunx script against prod DATABASE_URL.
+--
+-- Conversion: USD/1M tokens × 25,000 = points/1M tokens
+-- Rates verified 2026-05-02 from official provider docs.
+--
+-- Verify:   SELECT count(*) FROM model_pricing WHERE id LIKE 'seed_gateway_%';  -- expect 13
+-- Rollback: DELETE FROM model_pricing WHERE id LIKE 'seed_gateway_%';
+
+INSERT INTO model_pricing
+  (id, model_id, input_cost_per_1m, output_cost_per_1m, input_price, output_price, per_msg_fee, tier, is_active)
+VALUES
+  -- Tier 1 — mirrors of PR #24 with provider prefix
+  ('seed_gateway_google_gemini-2.5-flash',                'google/gemini-2.5-flash',                7500,    62500,  0, 0, 0, 1, true),
+  ('seed_gateway_google_gemini-3-flash',                  'google/gemini-3-flash',                  12500,   75000,  0, 0, 0, 1, true),
+  ('seed_gateway_openai_gpt-5.2',                         'openai/gpt-5.2',                         31250,   250000, 0, 0, 0, 1, true),
+  -- Tier 1 — new models not in PR #24
+  ('seed_gateway_openai_gpt-4o-mini',                     'openai/gpt-4o-mini',                     3750,    15000,  0, 0, 0, 1, true),
+  ('seed_gateway_google_gemini-2.0-flash',                'google/gemini-2.0-flash',                2500,    10000,  0, 0, 0, 1, true),
+  ('seed_gateway_google_gemini-3.1-flash-lite-preview',   'google/gemini-3.1-flash-lite-preview',   6250,    37500,  0, 0, 0, 1, true),
+  ('seed_gateway_deepseek_deepseek-chat',                 'deepseek/deepseek-chat',                 3500,    7000,   0, 0, 0, 1, true),
+  -- Tier 2 — mirrors of PR #24
+  ('seed_gateway_google_gemini-2.5-pro',                  'google/gemini-2.5-pro',                  31250,   250000, 0, 0, 0, 2, true),
+  ('seed_gateway_openai_gpt-5.3',                         'openai/gpt-5.3',                         43750,   350000, 0, 0, 0, 2, true),
+  ('seed_gateway_anthropic_claude-sonnet-4.5',            'anthropic/claude-sonnet-4.5',            75000,   375000, 0, 0, 0, 2, true),
+  -- Tier 3 — mirrors of PR #24
+  ('seed_gateway_openai_gpt-5.4',                         'openai/gpt-5.4',                         62500,   375000, 0, 0, 0, 3, true),
+  ('seed_gateway_google_gemini-3.1-pro-preview',          'google/gemini-3.1-pro-preview',          50000,   300000, 0, 0, 0, 3, true),
+  ('seed_gateway_anthropic_claude-opus-4.6',              'anthropic/claude-opus-4.6',              125000,  625000, 0, 0, 0, 3, true)
+ON CONFLICT (id) DO UPDATE SET
+  input_cost_per_1m = EXCLUDED.input_cost_per_1m,
+  output_cost_per_1m = EXCLUDED.output_cost_per_1m,
+  tier = EXCLUDED.tier,
+  is_active = true;

--- a/scripts/seed-model-pricing-gateway.ts
+++ b/scripts/seed-model-pricing-gateway.ts
@@ -1,0 +1,162 @@
+/**
+ * Seed model_pricing — gateway-prefixed modelIds (PHO-256)
+ *
+ * Companion to seed-model-pricing.ts (PR #24). PR #24 seeded 9 rows with
+ * UN-prefixed modelIds (e.g. 'gpt-5.4'). However, src/app/(backend)/webapi/
+ * chat/[provider]/route.ts:669 calls getModelPricing(actualModelUsed) where
+ * actualModelUsed is the gateway-routed form returned by phoGatewayService
+ * (e.g. 'openai/gpt-5.4'). The lookup at route.ts:78 is exact-match
+ * (eq(modelPricing.modelId, modelId)) — so the prefix mismatch causes every
+ * Vercel-AI-Gateway-routed call to log "No DB pricing for model X, using
+ * Tier N fallback" and bill at the tier fallback rate instead of the exact
+ * per-model rate.
+ *
+ * Vercel logs (2026-05-02): warning observed for openai/gpt-5.4 ($6.91/week).
+ * PostHog 7-day data shows 12 active models with the same shape.
+ *
+ * This script seeds gateway-prefixed mirror entries so the lookup hits.
+ * Existing PR #24 rows are left untouched (they may still serve direct-
+ * provider routes that pass un-prefixed IDs).
+ *
+ * Conversion: USD/1M tokens × 25,000 = points/1M tokens (1 pt ≈ $0.00004)
+ * Reference: src/server/services/billing/credits.ts:220
+ *
+ * Rates VERIFIED 2026-05-02 from official provider docs:
+ *   - OpenAI:    https://openai.com/api/pricing
+ *   - Anthropic: https://docs.anthropic.com/en/docs/about-claude/pricing
+ *   - Google:    https://ai.google.dev/gemini-api/docs/pricing
+ *   - DeepSeek:  https://api-docs.deepseek.com/quick_start/pricing
+ *
+ * Run:      bunx tsx scripts/seed-model-pricing-gateway.ts
+ * Verify:   SELECT count(*) FROM model_pricing WHERE id LIKE 'seed_gateway_%';  -- expect 13
+ * Rollback: DELETE FROM model_pricing WHERE id LIKE 'seed_gateway_%';
+ */
+import dotenv from 'dotenv';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+
+import { modelPricing } from '../packages/database/src/schemas/pricing';
+
+dotenv.config();
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+  throw new Error('DATABASE_URL is not defined');
+}
+
+const pool = new Pool({ connectionString });
+const db = drizzle(pool);
+
+const USD_TO_POINTS = 25_000;
+
+interface PricingSeed {
+  inputUsdPer1M: number;
+  modelId: string;
+  outputUsdPer1M: number;
+  tier: number;
+}
+
+// All entries use the gateway-prefixed modelId form that route.ts:669 passes
+// to getModelPricing(). Tier classifications mirror PR #24 (seed-model-pricing.ts).
+const SEEDS: PricingSeed[] = [
+  // ============================================================================
+  // Tier 1 — Free / Cheap tier
+  // ============================================================================
+  // Mirrors of PR #24 entries (same tier + same rate, prefixed modelId)
+  { inputUsdPer1M: 0.3, modelId: 'google/gemini-2.5-flash', outputUsdPer1M: 2.5, tier: 1 },
+  { inputUsdPer1M: 0.5, modelId: 'google/gemini-3-flash', outputUsdPer1M: 3, tier: 1 },
+  { inputUsdPer1M: 1.25, modelId: 'openai/gpt-5.2', outputUsdPer1M: 10, tier: 1 },
+
+  // New models observed in PostHog 7-day data, not in PR #24
+  { inputUsdPer1M: 0.15, modelId: 'openai/gpt-4o-mini', outputUsdPer1M: 0.6, tier: 1 },
+  { inputUsdPer1M: 0.1, modelId: 'google/gemini-2.0-flash', outputUsdPer1M: 0.4, tier: 1 },
+  {
+    inputUsdPer1M: 0.25,
+    modelId: 'google/gemini-3.1-flash-lite-preview',
+    outputUsdPer1M: 1.5,
+    tier: 1,
+  },
+  { inputUsdPer1M: 0.14, modelId: 'deepseek/deepseek-chat', outputUsdPer1M: 0.28, tier: 1 },
+
+  // ============================================================================
+  // Tier 2 — Standard / Mid tier
+  // ============================================================================
+  { inputUsdPer1M: 1.25, modelId: 'google/gemini-2.5-pro', outputUsdPer1M: 10, tier: 2 },
+  { inputUsdPer1M: 1.75, modelId: 'openai/gpt-5.3', outputUsdPer1M: 14, tier: 2 },
+  { inputUsdPer1M: 3, modelId: 'anthropic/claude-sonnet-4.5', outputUsdPer1M: 15, tier: 2 },
+
+  // ============================================================================
+  // Tier 3 — Premium / Expensive tier
+  // ============================================================================
+  { inputUsdPer1M: 2.5, modelId: 'openai/gpt-5.4', outputUsdPer1M: 15, tier: 3 },
+  { inputUsdPer1M: 2, modelId: 'google/gemini-3.1-pro-preview', outputUsdPer1M: 12, tier: 3 },
+  { inputUsdPer1M: 5, modelId: 'anthropic/claude-opus-4.6', outputUsdPer1M: 25, tier: 3 },
+];
+
+async function seed() {
+  console.log(`\n🌱 Seeding model_pricing (gateway-prefixed) — ${SEEDS.length} rows\n`);
+
+  let inserted = 0;
+  let failed = 0;
+
+  for (const s of SEEDS) {
+    // Replace '/' so the PK stays well-formed and easy to query/rollback.
+    const id = `seed_gateway_${s.modelId.replace('/', '_')}`;
+    const inputPts = Math.round(s.inputUsdPer1M * USD_TO_POINTS);
+    const outputPts = Math.round(s.outputUsdPer1M * USD_TO_POINTS);
+
+    try {
+      await db
+        .insert(modelPricing)
+        .values({
+          id,
+          inputCostPer1M: inputPts,
+          inputPrice: 0,
+          isActive: true,
+          modelId: s.modelId,
+          outputCostPer1M: outputPts,
+          outputPrice: 0,
+          perMsgFee: 0,
+          tier: s.tier,
+        })
+        .onConflictDoUpdate({
+          set: {
+            inputCostPer1M: inputPts,
+            isActive: true,
+            outputCostPer1M: outputPts,
+            tier: s.tier,
+          },
+          target: modelPricing.id,
+        });
+
+      console.log(
+        `✅ ${s.modelId.padEnd(40)} Tier ${s.tier} | ` +
+          `in: ${inputPts.toLocaleString().padStart(9)} pts | ` +
+          `out: ${outputPts.toLocaleString().padStart(9)} pts`,
+      );
+      inserted++;
+    } catch (e: any) {
+      console.error(`❌ ${s.modelId} FAILED: ${e?.message}`);
+      failed++;
+    }
+  }
+
+  console.log(`\n📊 Summary: ${inserted} inserted/updated, ${failed} failed\n`);
+  await pool.end();
+  if (failed > 0) throw new Error(`${failed} seed insertions failed`);
+}
+
+// Top-level await fails on tsx default CJS output (Node v24.x). Wrap in async IIFE
+// for CJS compat. process.exit is intentional for CLI exit-code propagation.
+// eslint-disable-next-line unicorn/prefer-top-level-await
+(async () => {
+  try {
+    await seed();
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(0);
+  } catch (e) {
+    console.error('\n❌ Seed failed:', e);
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary

- Vercel logs (2026-05-02): `⚠️ No DB pricing for model openai/gpt-5.4, using Tier 3 fallback` — gpt-5.4 traffic ($6.91/week per PostHog) bills at flat tier rate instead of exact per-model rate.
- **Real root cause:** key-format mismatch, NOT missing rows. PR #24 seeded 9 rows with un-prefixed modelIds (`gpt-5.4`, `claude-opus-4.6`, …) but `route.ts:669` calls `getModelPricing(actualModelUsed)` with the gateway form (`openai/gpt-5.4`, `anthropic/claude-opus-4.6`, …). The lookup at `route.ts:78` is exact-match, so every Vercel-AI-Gateway call misses.
- Fix: companion seed adding 13 prefixed rows (9 mirrors of PR #24 + 4 active models from PostHog 7-day data missing entirely). PR #24 rows are kept untouched for direct-provider routes.

## Rows added

| Tier | modelId | input USD/1M | output USD/1M | Source |
|------|---------|---:|---:|---|
| 1 | `google/gemini-2.5-flash` | 0.30 | 2.50 | mirror PR #24 |
| 1 | `google/gemini-3-flash` | 0.50 | 3.00 | mirror PR #24 |
| 1 | `openai/gpt-5.2` | 1.25 | 10.00 | mirror PR #24 |
| 1 | `openai/gpt-4o-mini` | 0.15 | 0.60 | new — openai.com/api/pricing |
| 1 | `google/gemini-2.0-flash` | 0.10 | 0.40 | new — ai.google.dev (deprecating Jun 2026) |
| 1 | `google/gemini-3.1-flash-lite-preview` | 0.25 | 1.50 | new — ai.google.dev |
| 1 | `deepseek/deepseek-chat` | 0.14 | 0.28 | new — api-docs.deepseek.com |
| 2 | `google/gemini-2.5-pro` | 1.25 | 10.00 | mirror PR #24 |
| 2 | `openai/gpt-5.3` | 1.75 | 14.00 | mirror PR #24 |
| 2 | `anthropic/claude-sonnet-4.5` | 3.00 | 15.00 | mirror PR #24 |
| 3 | `openai/gpt-5.4` | 2.50 | 15.00 | mirror PR #24 |
| 3 | `google/gemini-3.1-pro-preview` | 2.00 | 12.00 | mirror PR #24 |
| 3 | `anthropic/claude-opus-4.6` | 5.00 | 25.00 | mirror PR #24 |

Conversion: USD/1M × 25,000 = points/1M (matches `credits.ts:220`).
ID format: `seed_gateway_<provider>_<model>` (slash → underscore for cleanliness).
Rates verified 2026-05-02 from official provider docs.

## How to apply (NOT auto-run)

Two options — script does NOT run automatically on prod:

**Option A** — run script locally with prod DATABASE_URL:
```bash
bunx tsx scripts/seed-model-pricing-gateway.ts
```

**Option B** — paste SQL into Neon Console:
```bash
cat scripts/seed-model-pricing-gateway.sql
```

## Test plan post-merge

- [ ] Vercel logs (24h after deploy): search `No DB pricing` → expect 0 warnings for the 13 listed models
- [ ] Verify rows on Neon: `SELECT count(*) FROM model_pricing WHERE id LIKE 'seed_gateway_%';` → expect 13
- [ ] PostHog: cost_usd accuracy for `openai/gpt-5.4` calls reflects $2.50/$15.00 instead of T3 fallback
- [ ] Spot-check one row: `SELECT model_id, tier, input_cost_per_1m, output_cost_per_1m FROM model_pricing WHERE model_id = 'openai/gpt-5.4';`
- [ ] Rollback if needed: `DELETE FROM model_pricing WHERE id LIKE 'seed_gateway_%';`

## Out of scope (separate bugs)

- `src/app/api/research/ai-summary/route.ts:331` and `src/app/api/artifact-ai/route.ts:204` read `pricing.inputPrice`/`pricing.outputPrice` (legacy VND fields = 0 in PR #24 + this seed). They should read `inputCostPer1M`/`outputCostPer1M` like `chat/[provider]/route.ts:680` does — otherwise a successful DB hit returns 0 cost. Same issue exists in PR #24; not introduced here. Worth a follow-up ticket.
- The chat lookup at `route.ts:78` could also be hardened with a "strip prefix and retry" fallback so it tolerates either format. Cleaner long-term than maintaining mirrored rows. Out of scope for the immediate fix.

Linear: PHO-256 (sub of PHO-238)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds gateway-prefixed model pricing so lookups hit and stop falling back to tier rates. Fixes cost accuracy for models like openai/gpt-5.4 and aligns with Linear PHO-256.

- **Bug Fixes**
  - Root cause: DB had unprefixed model IDs, but lookups used gateway-prefixed IDs (e.g., openai/...).
  - Added 13 gateway-prefixed rows (9 mirrors from PR #24 + 4 active models).
  - Kept existing rows for direct-provider routes.
  - Pricing uses USD/1M × 25,000 points; upserts set correct tier and activate rows.

- **Migration**
  - Run the seed against the target DB: `bunx tsx scripts/seed-model-pricing-gateway.ts`.
  - Or execute SQL in Neon: `scripts/seed-model-pricing-gateway.sql`.

<sup>Written for commit 732ca094083051ff2124af9191511a535bac4d07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

