### PR TITLE
💰 fix(cost): ai-summary + artifact-ai pricing field mismatch

### DIFF
--- a/src/app/api/artifact-ai/route.ts
+++ b/src/app/api/artifact-ai/route.ts
@@ -201,8 +201,10 @@ export async function POST(req: NextRequest) {
             where: eq(modelPricing.modelId, modelId),
           });
           if (pricing) {
-            inputPrice = pricing.inputPrice ?? inputPrice;
-            outputPrice = pricing.outputPrice ?? outputPrice;
+            // PHO-223 alignment: read points-denominated rates. inputPrice/outputPrice
+            // are legacy VND columns (default 0) — using them yielded cost=0.
+            inputPrice = pricing.inputCostPer1M ?? inputPrice;
+            outputPrice = pricing.outputCostPer1M ?? outputPrice;
           }
         } catch {
           // Use tier fallback

--- a/src/app/api/research/ai-summary/route.ts
+++ b/src/app/api/research/ai-summary/route.ts
@@ -328,8 +328,10 @@ export async function POST(req: NextRequest) {
             where: eq(modelPricing.modelId, modelId),
           });
           if (pricing) {
-            inputPrice = pricing.inputPrice ?? inputPrice;
-            outputPrice = pricing.outputPrice ?? outputPrice;
+            // PHO-223 alignment: read points-denominated rates. inputPrice/outputPrice
+            // are legacy VND columns (default 0) — using them yielded cost=0.
+            inputPrice = pricing.inputCostPer1M ?? inputPrice;
+            outputPrice = pricing.outputCostPer1M ?? outputPrice;
           }
         } catch {
           // Use tier fallback


### PR DESCRIPTION
## Summary

- 2 routes were reading the **legacy VND** column `pricing.inputPrice`/`outputPrice` (default `0`) from the DB lookup branch, while the chat route correctly reads `pricing.inputCostPer1M`/`outputCostPer1M` (points/1M).
- When the DB lookup hits, cost computes as `tokens × 0 = 0` → research summaries and artifact generation are billed at **\$0.00 free**.
- Latent today because PHO-256 prefix-mismatch causes most gateway-routed lookups to MISS; the tier fallback above happens to use points-denominated rates from `MODEL_TIERS`, masking the bug. Once PR #42 seeds prefixed rows the lookup starts hitting, surfacing the \$0 charge.
- Fix mirrors the chat route pattern (`route.ts:745`, `821` — both streaming + non-streaming branches).

## Files

- ` src/app/api/research/ai-summary/route.ts:331-332`
- ` src/app/api/artifact-ai/route.ts:204-205`

## Diff

```ts
// before
inputPrice = pricing.inputPrice ?? inputPrice;
outputPrice = pricing.outputPrice ?? outputPrice;

// after
// PHO-223 alignment: read points-denominated rates. inputPrice/outputPrice
// are legacy VND columns (default 0) — using them yielded cost=0.
inputPrice = pricing.inputCostPer1M ?? inputPrice;
outputPrice = pricing.outputCostPer1M ?? outputPrice;
```

## Audit

`grep -rn 'pricing\.inputPrice\|pricing\.outputPrice' src/` post-fix → no matches. Other matches for `inputPrice`/`outputPrice` in the codebase are unrelated UI sort labels in `discover/(list)/features/SortButton/index.tsx` and `discover/(detail)/.../ProviderList/index.tsx` — those use Lobe model-card data, not the `model_pricing` table.

## Test plan post-merge

- [ ] Trigger a research summary (`/research` flow) on a seeded model
- [ ] `SELECT cost_credits FROM usage_logs WHERE feature='research' ORDER BY id DESC LIMIT 1;` → expect > 0
- [ ] Trigger an artifact generation (`/artifact-ai` flow) on a seeded model
- [ ] `SELECT cost_credits FROM usage_logs WHERE feature='artifact' ORDER BY id DESC LIMIT 1;` → expect > 0
- [ ] Compare with chat-route cost for the same model + token counts → should be in the same order of magnitude (Tier 1 ≈ ones to tens of points; Tier 3 ≈ hundreds)

## Order of merging

Independent of PR #42. Either order is fine, but merging this BEFORE applying the PHO-256 seed is safer — otherwise prefixed rows would briefly cause \$0 charges on research/artifact until this PR ships.

Linear: PHO-238 (V1 Audit Epic)
Refs: #42 (PHO-256, out-of-scope note), PHO-223

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cost calculation for research summaries and artifact generation (PHO-238) by reading the correct points-per-1M rates from `model_pricing`. Routes now use `inputCostPer1M`/`outputCostPer1M`, matching the chat route and preventing $0 charges when DB lookups hit.

<sup>Written for commit 0d04cb71e07a7dea186f7817f147d184505e96a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

