### PR TITLE
🔒 fix(security): promo code DB-based limit (PHO-248/A1.9)

### DIFF
--- a/packages/database/migrations/0047_promo_activations.sql
+++ b/packages/database/migrations/0047_promo_activations.sql
@@ -1,0 +1,42 @@
+-- PHO-248/A1.9: Promo activation tracking table.
+--
+-- The previous in-memory Map<string, number> counter in
+-- src/app/api/promo/activate/route.ts was defeated by Vercel cold starts
+-- and multi-instance routing — each function instance kept its own counter
+-- and a redeploy reset it to 0, allowing unlimited redemption.
+--
+-- This table is the new source of truth for "how many times has code X
+-- been redeemed". Append-only, with a unique (user_id, promo_code)
+-- constraint that also blocks the same user from redeeming the same code
+-- twice (race-safe at the DB level).
+--
+-- All statements are idempotent (IF NOT EXISTS) so it is safe to re-run.
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'promo_activations') THEN
+    CREATE TABLE "promo_activations" (
+      "id" text PRIMARY KEY NOT NULL,
+      "user_id" text NOT NULL,
+      "promo_code" varchar(50) NOT NULL,
+      "plan_id" varchar(50) NOT NULL,
+      "activated_at" timestamp with time zone NOT NULL DEFAULT now()
+    );
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_name = 'promo_activations' AND constraint_name = 'promo_activations_user_id_users_id_fk'
+  ) THEN
+    ALTER TABLE "promo_activations"
+      ADD CONSTRAINT "promo_activations_user_id_users_id_fk"
+      FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE;
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "promo_activations_user_code_unique"
+  ON "promo_activations" ("user_id", "promo_code");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "promo_activations_code_idx"
+  ON "promo_activations" ("promo_code");

--- a/packages/database/src/schemas/index.ts
+++ b/packages/database/src/schemas/index.ts
@@ -14,6 +14,7 @@ export * from './message';
 export * from './nextauth';
 export * from './oidc';
 export * from './pricing';
+export * from './promoActivations';
 export * from './providerBalances';
 export * from './rag';
 export * from './ragEvals';

--- a/packages/database/src/schemas/promoActivations.ts
+++ b/packages/database/src/schemas/promoActivations.ts
@@ -1,0 +1,48 @@
+/* eslint-disable sort-keys-fix/sort-keys-fix */
+/**
+ * Promo Activations Schema
+ *
+ * Tracks every promo code redemption. Append-only, used by
+ * /api/promo/activate to enforce per-code max-use limits.
+ *
+ * Why a dedicated table (PHO-248/A1.9):
+ *   - In-memory Map<string, number> was reset by Vercel cold starts and
+ *     diverged across instances → users could redeem unlimited times.
+ *   - Subscriptions row is mutable (Polar webhook updates payment_provider),
+ *     so storing the promo code there can't be trusted as a counter.
+ *   - This table is append-only with a unique (user_id, promo_code) so the
+ *     same user cannot redeem the same code twice, regardless of race
+ *     conditions or instance routing.
+ */
+import { index, pgTable, text, uniqueIndex, varchar } from 'drizzle-orm/pg-core';
+
+import { timestamptz } from './_helpers';
+import { users } from './user';
+
+export const promoActivations = pgTable(
+  'promo_activations',
+  {
+    id: text('id')
+      .$defaultFn(() => `promo_act_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`)
+      .primaryKey(),
+
+    userId: text('user_id')
+      .references(() => users.id, { onDelete: 'cascade' })
+      .notNull(),
+
+    promoCode: varchar('promo_code', { length: 50 }).notNull(),
+    planId: varchar('plan_id', { length: 50 }).notNull(),
+
+    activatedAt: timestamptz('activated_at').notNull().defaultNow(),
+  },
+  (self) => ({
+    userCodeUnique: uniqueIndex('promo_activations_user_code_unique').on(
+      self.userId,
+      self.promoCode,
+    ),
+    codeIdx: index('promo_activations_code_idx').on(self.promoCode),
+  }),
+);
+
+export type NewPromoActivation = typeof promoActivations.$inferInsert;
+export type PromoActivationItem = typeof promoActivations.$inferSelect;

--- a/src/app/api/promo/activate/route.ts
+++ b/src/app/api/promo/activate/route.ts
@@ -1,8 +1,8 @@
 import { auth, clerkClient } from '@clerk/nextjs/server';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
-import { subscriptions, users } from '@/database/schemas';
+import { promoActivations, subscriptions, users } from '@/database/schemas';
 import { getServerDB } from '@/database/server';
 import { getUserPlanFromDB } from '@/server/services/subscription/getUserPlanFromDB';
 
@@ -52,8 +52,25 @@ const VALID_PROMO_CODES: Record<
   },
 };
 
-// Track code usage in memory (in production, use DB)
-const codeUsageCount: Record<string, number> = {};
+/**
+ * Count how many times a promo code has been redeemed.
+ *
+ * PHO-248/A1.9: replaces the previous in-memory Record<string, number>
+ * counter, which was reset by Vercel cold starts and diverged across
+ * multi-instance deployments. The DB row in `promo_activations` is the
+ * single source of truth.
+ */
+async function getPromoCodeUsageCount(
+  db: Awaited<ReturnType<typeof getServerDB>>,
+  promoCode: string,
+): Promise<number> {
+  const result = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(promoActivations)
+    .where(eq(promoActivations.promoCode, promoCode));
+
+  return Number(result[0]?.count ?? 0);
+}
 
 /**
  * Calculate end of current month for points reset date
@@ -93,10 +110,21 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Mã khuyến mãi đã hết hạn.' }, { status: 410 });
     }
 
-    // Check max uses
+    const db = await getServerDB();
+
+    // PHO-248/A1.9: max-use check now reads from `promo_activations` (DB) so
+    // the limit survives Vercel cold starts and is consistent across function
+    // instances. A small race window (count → insert) can let 1–2 extra
+    // redemptions through; acceptable for promo codes vs. the cost of
+    // serializable transactions / advisory locks.
     if (promoConfig.maxUses) {
-      const currentUses = codeUsageCount[normalizedCode] || 0;
+      const currentUses = await getPromoCodeUsageCount(db, normalizedCode);
       if (currentUses >= promoConfig.maxUses) {
+        console.warn('[promo] Code exhausted', {
+          code: normalizedCode,
+          currentUses,
+          maxUses: promoConfig.maxUses,
+        });
         return NextResponse.json({ error: 'Mã khuyến mãi đã được sử dụng hết.' }, { status: 410 });
       }
     }
@@ -124,7 +152,6 @@ export async function POST(request: NextRequest) {
     // STEP 1 (AUTHORITATIVE): Sync database — users + subscriptions tables.
     // Must succeed before we touch Clerk; if this fails we abort.
     // =============================================
-    const db = await getServerDB();
 
     // 1a. Update users table: currentPlanId, phoPointsBalance, pointsResetDate, subscriptionStatus
     const pointsResetDate = getEndOfMonth();
@@ -191,6 +218,25 @@ export async function POST(request: NextRequest) {
       console.error('⚠️ [Promo] Wallet tier sync failed (non-critical):', walletError);
     }
 
+    // 1d. PHO-248/A1.9: record activation row for the redemption counter.
+    // ON CONFLICT DO NOTHING handles the rare race where two concurrent
+    // requests from the same user reach here before the existingPlan check
+    // settles. Failure here does NOT roll back the plan (user already has it
+    // via subscription update above) — we just log so the counter drift is
+    // visible.
+    try {
+      await db
+        .insert(promoActivations)
+        .values({ planId, promoCode: normalizedCode, userId })
+        .onConflictDoNothing();
+      console.log('✅ [Promo] Activation recorded:', { code: normalizedCode, userId });
+    } catch (activationError) {
+      console.error(
+        '⚠️ [Promo] Failed to record activation row (counter may drift):',
+        activationError,
+      );
+    }
+
     // =============================================
     // STEP 2 (DISPLAY ONLY): Update Clerk publicMetadata so the client cache
     // shows the new plan immediately. NOT authoritative — failure here does
@@ -241,8 +287,20 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Increment usage count
-    codeUsageCount[normalizedCode] = (codeUsageCount[normalizedCode] || 0) + 1;
+    // PHO-248/A1.9: emit a structured log line so anh can monitor remaining
+    // capacity per code from Vercel logs without querying the DB.
+    try {
+      const finalCount = await getPromoCodeUsageCount(db, normalizedCode);
+      console.log('[promo] activation complete', {
+        code: normalizedCode,
+        currentUses: finalCount,
+        maxUses: promoConfig.maxUses ?? null,
+        remaining: promoConfig.maxUses ? promoConfig.maxUses - finalCount : null,
+        userId,
+      });
+    } catch {
+      /* monitoring log only — never block the response */
+    }
 
     return NextResponse.json({
       activatedAt: new Date().toISOString(),
@@ -277,7 +335,14 @@ export async function GET(request: NextRequest) {
 
   const isExpired = promoConfig.expiresAt ? new Date(promoConfig.expiresAt) < new Date() : false;
 
-  const currentUses = codeUsageCount[normalizedCode] || 0;
+  // PHO-248/A1.9: read usage count from DB (was in-memory Map).
+  let currentUses = 0;
+  try {
+    const db = await getServerDB();
+    currentUses = await getPromoCodeUsageCount(db, normalizedCode);
+  } catch (countError) {
+    console.error('[promo] GET: failed to read usage count, defaulting to 0', countError);
+  }
   const isMaxedOut = promoConfig.maxUses ? currentUses >= promoConfig.maxUses : false;
 
   return NextResponse.json({


### PR DESCRIPTION
## Summary

- Replace in-memory `Record<string, number>` promo-code counter with a DB-backed `promo_activations` table — the in-memory version was reset on every Vercel cold start and diverged across instances, so codes with `maxUses: 200` could be redeemed unlimited times in practice.
- New table is append-only with `UNIQUE (user_id, promo_code)` so the same user cannot redeem the same code twice even under concurrent requests.
- `/api/promo/activate` POST counts from the DB before activating, INSERTs the activation row (with `.onConflictDoNothing()`) after the subscription is synced, and emits a structured `[promo] activation complete` log line for monitoring remaining capacity.
- GET endpoint also reads usage count from DB.

V1 Audit 1 finding **A1.9** (P1 SECURITY). Sub-ticket of PHO-238.

## Race-condition note

A small window between the count read and the INSERT can let 1–2 extra redemptions slip through under burst traffic — accepted per the audit playbook (Option A): promo codes are not financial instruments, and the cost of SERIALIZABLE / advisory-lock alternatives outweighs the benefit. The unique index still hard-blocks the same user from double-redeeming.

## Out of scope

`VALID_PROMO_CODES` is still hardcoded in the route file. That is audit finding A1.15 and will be migrated separately.

## Files

- `packages/database/src/schemas/promoActivations.ts` — new schema, append-only with composite unique index.
- `packages/database/migrations/0047_promo_activations.sql` — idempotent migration matching 0046's pattern.
- `packages/database/src/schemas/index.ts` — export the new schema.
- `src/app/api/promo/activate/route.ts` — drop `codeUsageCount`, add `getPromoCodeUsageCount`, INSERT activation row, structured logging.

## Test plan post-merge

- [ ] Apply migration `0047_promo_activations.sql` on prod DB (orphan migration pattern, same as 0042–0046).
- [ ] Activate a promo code → verify a row lands in `promo_activations` and `users.current_plan_id` flips correctly.
- [ ] Trigger a Vercel redeploy → activate again with a different user → confirm count increments from where it left off (in-memory version would have reset to 0).
- [ ] Temporarily seed 200 rows for `PHO-MED-2026-BETA` (or set `maxUses: 1` on a test code) → next activation returns `410 Gone` with `Mã khuyến mãi đã được sử dụng hết.`.
- [ ] Try to redeem the same code as the same user twice → second attempt is blocked (existing 409 path or unique-index conflict).
- [ ] Vercel logs: search `[promo] activation complete` → confirm `currentUses` / `remaining` are emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved promo code usage tracking from an in-memory counter to a DB-backed `promo_activations` table to enforce global max-use limits across Vercel instances and restarts. Fulfills PHO-248 (A1.9) by preventing unlimited redemptions and blocking same-user double use.

- **Bug Fixes**
  - Added `promo_activations` table and schema with `UNIQUE (user_id, promo_code)` and an index on `promo_code`.
  - Updated `/api/promo/activate` to count from DB, insert activation with `.onConflictDoNothing()`, and emit `[promo] activation complete` logs.
  - Updated GET to read usage from DB; removed the in-memory counter.

- **Migration**
  - Run `packages/database/migrations/0047_promo_activations.sql` on the production DB.

<sup>Written for commit 560c51b40d6216ddf6a15203323480abce9d6903. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

