### PR TITLE
🚨 EMERGENCY: daily USD cost cap per plan per tier (PHO-238)

### DIFF
--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -24,6 +24,8 @@ import {
   getUserCreditBalance,
   processModelUsage,
 } from '@/server/services/billing/credits';
+import { checkDailyCostCap } from '@/server/services/billing/dailyCostAggregation';
+import { getSecondsUntilMidnightVN } from '@/server/services/billing/dailyCostCaps';
 import { phoGatewayService } from '@/server/services/phoGateway';
 import { getUserPlanIdFromDB } from '@/server/services/subscription/getUserPlanFromDB';
 import { ChatStreamPayload } from '@/types/openai/chat';
@@ -471,6 +473,32 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
       }
 
       console.log(`[Tier Check] Model: ${data.model}, Tier: ${modelTier}, Plan: ${userPlanId}`);
+
+      // ============  2.0.5. Daily USD Cost Cap (PHO-238 EMERGENCY)  ============ //
+      // Hard ceiling on USD spend per (user, plan, tier, day) so the Phở Points
+      // generosity (e.g. 379K-credit FREE balance ≈ $760 budget) cannot be burned
+      // through expensive Tier 3 models. Pure read — runs BEFORE checkTierAccess
+      // so a blocked request does NOT consume an atomic tier slot. Resets at
+      // midnight Asia/Ho_Chi_Minh.
+      const usdCapCheck = await checkDailyCostCap(jwtPayload.userId, userPlanId, modelTier);
+      if (!usdCapCheck.allowed) {
+        console.warn(
+          `🚫 Daily USD cap blocked: ${usdCapCheck.reasonCode} ` +
+            `($${usdCapCheck.dailyCostUsed.toFixed(2)}/$${usdCapCheck.dailyCostCap.toFixed(2)}, ` +
+            `Plan: ${userPlanId}, Tier: ${modelTier}, User: ${jwtPayload.userId})`,
+        );
+        return createErrorResponse(AgentRuntimeErrorType.InsufficientQuota, {
+          dailyCostCap: usdCapCheck.dailyCostCap,
+          dailyCostUsed: usdCapCheck.dailyCostUsed,
+          error: {
+            message: usdCapCheck.reason || 'Bạn đã đạt giới hạn chi phí hôm nay cho tier này.',
+          },
+          provider: 'pho-chat',
+          reasonCode: usdCapCheck.reasonCode,
+          retryAfter: getSecondsUntilMidnightVN(),
+          upgradeUrl: '/settings/subscription',
+        });
+      }
 
       const tierAccess = await checkTierAccess(jwtPayload.userId, modelTier, userPlanId);
 

--- a/src/app/api/artifact-ai/route.ts
+++ b/src/app/api/artifact-ai/route.ts
@@ -10,6 +10,8 @@ import {
   getUserCreditBalance,
   processModelUsage,
 } from '@/server/services/billing/credits';
+import { checkDailyCostCap } from '@/server/services/billing/dailyCostAggregation';
+import { getSecondsUntilMidnightVN } from '@/server/services/billing/dailyCostCaps';
 import { phoGatewayService } from '@/server/services/phoGateway';
 import { getUserPlanIdFromDB } from '@/server/services/subscription/getUserPlanFromDB';
 
@@ -83,6 +85,28 @@ export async function POST(req: NextRequest) {
   // PHO-241/A1.6: DB is the single source of truth. Never fall back to Clerk metadata.
   const userPlanId = await getUserPlanIdFromDB(userId);
   const modelTier = getModelTier(model);
+
+  // PHO-238 EMERGENCY: hard daily USD cap per (plan, tier). Pre-flight read,
+  // safe to run before checkTierAccess (no tier-slot side effect).
+  const usdCapCheck = await checkDailyCostCap(userId, userPlanId, modelTier);
+  if (!usdCapCheck.allowed) {
+    console.warn(
+      `🚫 [artifact-ai] Daily USD cap blocked: ${usdCapCheck.reasonCode} ` +
+        `($${usdCapCheck.dailyCostUsed.toFixed(2)}/$${usdCapCheck.dailyCostCap.toFixed(2)}, ` +
+        `Plan: ${userPlanId}, Tier: ${modelTier}, User: ${userId})`,
+    );
+    const retryAfter = getSecondsUntilMidnightVN();
+    return NextResponse.json(
+      {
+        dailyCostCap: usdCapCheck.dailyCostCap,
+        dailyCostUsed: usdCapCheck.dailyCostUsed,
+        error: usdCapCheck.reason,
+        reasonCode: usdCapCheck.reasonCode,
+        retryAfter,
+      },
+      { headers: { 'Retry-After': String(retryAfter) }, status: 429 },
+    );
+  }
 
   const tierAccess = await checkTierAccess(userId, modelTier, userPlanId);
   if (!tierAccess.allowed) {

--- a/src/app/api/research/ai-summary/route.ts
+++ b/src/app/api/research/ai-summary/route.ts
@@ -10,6 +10,8 @@ import {
   getUserCreditBalance,
   processModelUsage,
 } from '@/server/services/billing/credits';
+import { checkDailyCostCap } from '@/server/services/billing/dailyCostAggregation';
+import { getSecondsUntilMidnightVN } from '@/server/services/billing/dailyCostCaps';
 import { phoGatewayService } from '@/server/services/phoGateway';
 import { getUserPlanIdFromDB } from '@/server/services/subscription/getUserPlanFromDB';
 
@@ -84,6 +86,28 @@ export async function POST(req: NextRequest) {
   // PHO-241/A1.6: DB is the single source of truth. Never fall back to Clerk metadata.
   const userPlanId = await getUserPlanIdFromDB(userId);
   const modelTier = getModelTier(model);
+
+  // PHO-238 EMERGENCY: hard daily USD cap per (plan, tier). Pre-flight read,
+  // safe to run before checkTierAccess (no tier-slot side effect).
+  const usdCapCheck = await checkDailyCostCap(userId, userPlanId, modelTier);
+  if (!usdCapCheck.allowed) {
+    console.warn(
+      `🚫 [research/ai-summary] Daily USD cap blocked: ${usdCapCheck.reasonCode} ` +
+        `($${usdCapCheck.dailyCostUsed.toFixed(2)}/$${usdCapCheck.dailyCostCap.toFixed(2)}, ` +
+        `Plan: ${userPlanId}, Tier: ${modelTier}, User: ${userId})`,
+    );
+    const retryAfter = getSecondsUntilMidnightVN();
+    return NextResponse.json(
+      {
+        dailyCostCap: usdCapCheck.dailyCostCap,
+        dailyCostUsed: usdCapCheck.dailyCostUsed,
+        error: usdCapCheck.reason,
+        reasonCode: usdCapCheck.reasonCode,
+        retryAfter,
+      },
+      { headers: { 'Retry-After': String(retryAfter) }, status: 429 },
+    );
+  }
 
   const tierAccess = await checkTierAccess(userId, modelTier, userPlanId);
   if (!tierAccess.allowed) {

--- a/src/server/services/billing/dailyCostAggregation.ts
+++ b/src/server/services/billing/dailyCostAggregation.ts
@@ -1,0 +1,125 @@
+/**
+ * Daily USD cost aggregation + cap-check helper.
+ *
+ * Reads `usage_logs.cost_usd` (already populated by `processModelUsage()` on
+ * every metered AI call) and compares against the configured daily cap from
+ * `dailyCostCaps.ts`.
+ *
+ * Used as a pre-flight check before issuing AI calls in:
+ *  - `src/app/(backend)/webapi/chat/[provider]/route.ts`
+ *  - `src/app/api/artifact-ai/route.ts`
+ *  - `src/app/api/research/ai-summary/route.ts`
+ */
+import { and, eq, gte, sql } from 'drizzle-orm';
+
+import { usageLogs } from '@/database/schemas/usage';
+import { getServerDB } from '@/database/server';
+
+import { getDailyCostCap, getStartOfVietnamDayUTC } from './dailyCostCaps';
+
+export interface DailyCostCapCheckResult {
+  allowed: boolean;
+  /** Configured cap in USD for this (plan, tier). 0 = tier blocked. */
+  dailyCostCap: number;
+  /** Total USD already spent today against this tier. */
+  dailyCostUsed: number;
+  /** Vietnamese user-facing message when blocked. */
+  reason?: string;
+  /** Machine-readable code so callers / observability can branch. */
+  reasonCode?: 'TIER_BLOCKED' | 'DAILY_CAP_EXCEEDED';
+}
+
+/**
+ * Sum `cost_usd` from `usage_logs` for the user / tier / current Vietnam day.
+ *
+ * Returns 0 on DB error (fail-OPEN). Rationale: the chat path also has the
+ * Phở Points pre-flight, atomic tier-slot acquire, and post-call billing —
+ * one failed read here only allows ONE extra request through before the
+ * cap recomputes from the new log row, while a fail-CLOSED would brick all
+ * chat on a brief Postgres hiccup.
+ */
+export async function getDailyTierCostUSD(userId: string, tier: number): Promise<number> {
+  try {
+    const db = await getServerDB();
+    const startOfDayUTC = getStartOfVietnamDayUTC();
+
+    const rows = await db
+      .select({ totalCost: sql<number>`COALESCE(SUM(${usageLogs.costUSD}), 0)` })
+      .from(usageLogs)
+      .where(
+        and(
+          eq(usageLogs.userId, userId),
+          eq(usageLogs.modelTier, tier),
+          gte(usageLogs.createdAt, startOfDayUTC),
+        ),
+      );
+
+    // pg `numeric` may come back as string depending on driver; coerce.
+    const raw = rows[0]?.totalCost;
+    const num = typeof raw === 'string' ? Number.parseFloat(raw) : Number(raw ?? 0);
+    return Number.isFinite(num) && num > 0 ? num : 0;
+  } catch (e) {
+    console.warn('[billing] getDailyTierCostUSD failed — failing OPEN', {
+      error: e instanceof Error ? e.message : String(e),
+      tier,
+      userId,
+    });
+    return 0;
+  }
+}
+
+/**
+ * Check whether the user can issue another request against `tier` today.
+ *
+ * Returns:
+ *  - `{ allowed: true,  ... }` when usage is below the cap.
+ *  - `{ allowed: false, reasonCode: 'TIER_BLOCKED', ... }` when cap is 0
+ *    (this plan never gets to use this tier).
+ *  - `{ allowed: false, reasonCode: 'DAILY_CAP_EXCEEDED', ... }` when usage
+ *    has reached/exceeded the cap.
+ *
+ * Side-effect free: pure read, safe to run before `checkTierAccess()`'s
+ * atomic slot increment so we don't burn a tier slot on a blocked request.
+ */
+export async function checkDailyCostCap(
+  userId: string,
+  planId: string,
+  tier: number,
+): Promise<DailyCostCapCheckResult> {
+  const dailyCostCap = getDailyCostCap(planId, tier);
+
+  if (dailyCostCap <= 0) {
+    return {
+      allowed: false,
+      dailyCostCap,
+      dailyCostUsed: 0,
+      reason: `Gói hiện tại của bạn không có quyền dùng model Tier ${tier}. Vui lòng nâng cấp để sử dụng.`,
+      reasonCode: 'TIER_BLOCKED',
+    };
+  }
+
+  const dailyCostUsed = await getDailyTierCostUSD(userId, tier);
+
+  if (dailyCostUsed >= dailyCostCap) {
+    console.warn('[billing] DAILY CAP HIT', {
+      dailyCostCap,
+      dailyCostUsed: dailyCostUsed.toFixed(4),
+      planId,
+      tier,
+      userId,
+    });
+
+    return {
+      allowed: false,
+      dailyCostCap,
+      dailyCostUsed,
+      reason:
+        `⚠️ Bạn đã dùng hết hạn mức Tier ${tier} hôm nay ` +
+        `($${dailyCostUsed.toFixed(2)}/$${dailyCostCap.toFixed(2)}). ` +
+        `Vui lòng dùng model Tier thấp hơn hoặc thử lại sau 0:00 (giờ Việt Nam).`,
+      reasonCode: 'DAILY_CAP_EXCEEDED',
+    };
+  }
+
+  return { allowed: true, dailyCostCap, dailyCostUsed };
+}

--- a/src/server/services/billing/dailyCostCaps.ts
+++ b/src/server/services/billing/dailyCostCaps.ts
@@ -1,0 +1,136 @@
+/**
+ * Daily USD cost caps per plan per tier.
+ *
+ * When the user's total `usage_logs.cost_usd` for a given tier on the current
+ * Vietnam day (Asia/Ho_Chi_Minh) reaches the cap, further requests against
+ * that tier are blocked with HTTP 429 until the next VN midnight rollover.
+ *
+ * EMERGENCY FIX (PHO-238): a medical_beta user burned $26.40 in one hour on
+ * Tier 3 because Phở Points balance is too generous (379K credits ≈ $760
+ * budget for a FREE user) and per-call deduction does not keep pace with the
+ * real per-call USD spend on expensive models. The Phở Points layer stays in
+ * place; this cap is a hard ceiling underneath it.
+ *
+ * Caps are starting values — tune via `DAILY_CAP_{PLAN}_T{TIER}` env vars at
+ * runtime without redeploy. Setting an env var to `0` blocks the tier; any
+ * positive number raises/lowers the limit.
+ */
+
+export interface DailyCostCap {
+  /** USD; 0 means tier is fully blocked for this plan */
+  tier1: number;
+  /** USD; 0 means tier is fully blocked for this plan */
+  tier2: number;
+  /** USD; 0 means tier is fully blocked for this plan */
+  tier3: number;
+}
+
+const DEFAULT_CAPS: DailyCostCap = { tier1: 1, tier2: 0, tier3: 0 };
+
+const PLAN_CAPS: Record<string, DailyCostCap> = {
+  
+  // Lifetime plans
+lifetime_early_bird: { tier1: 10, tier2: 10, tier3: 10 },
+
+  
+
+lifetime_last_call: { tier1: 10, tier2: 10, tier3: 10 },
+
+  
+
+lifetime_standard: { tier1: 10, tier2: 10, tier3: 10 },
+  
+  
+// Promo / beta plans
+medical_beta: { tier1: 5, tier2: 3, tier3: 2 },
+  
+
+vn_free: { tier1: 1, tier2: 0, tier3: 0 },
+
+  
+  
+vn_premium: { tier1: 5, tier2: 5, tier3: 5 },
+  // Subscription plans
+vn_pro: { tier1: 5, tier2: 5, tier3: 5 },
+  vn_ultimate: { tier1: 10, tier2: 10, tier3: 10 },
+};
+
+/**
+ * Resolve the daily USD cap for `(planId, tier)`.
+ *
+ * Lookup order:
+ *   1. Env override `DAILY_CAP_{UPPERCASE_PLAN}_T{TIER}` (e.g. `DAILY_CAP_MEDICAL_BETA_T3=1.00`).
+ *   2. Static `PLAN_CAPS` table.
+ *   3. `DEFAULT_CAPS` (matches vn_free — most restrictive).
+ *
+ * Returns 0 when the tier is fully blocked for this plan. Callers MUST treat
+ * `cap === 0` as "deny" rather than "no cap".
+ */
+export function getDailyCostCap(planId: string, tier: number): number {
+  const envKey = `DAILY_CAP_${planId.toUpperCase()}_T${tier}`;
+  const envVal = process.env[envKey];
+  if (envVal !== undefined && envVal !== '') {
+    const parsed = Number.parseFloat(envVal);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  }
+
+  const caps = PLAN_CAPS[planId] ?? DEFAULT_CAPS;
+  switch (tier) {
+    case 1: {
+      return caps.tier1;
+    }
+    case 2: {
+      return caps.tier2;
+    }
+    case 3: {
+      return caps.tier3;
+    }
+    default: {
+      return 0;
+    }
+  }
+}
+
+/**
+ * Seconds remaining until the next midnight in Asia/Ho_Chi_Minh (UTC+7, no DST).
+ * Used for `Retry-After` headers when a daily cap is hit so clients know when
+ * the cap will reset.
+ */
+export function getSecondsUntilMidnightVN(now: Date = new Date()): number {
+  const VN_OFFSET_MS = 7 * 60 * 60 * 1000;
+  const vnNow = new Date(now.getTime() + VN_OFFSET_MS);
+  const nextMidnightVnAsUtc = Date.UTC(
+    vnNow.getUTCFullYear(),
+    vnNow.getUTCMonth(),
+    vnNow.getUTCDate() + 1,
+    0,
+    0,
+    0,
+    0,
+  );
+  const nextMidnightUtcMs = nextMidnightVnAsUtc - VN_OFFSET_MS;
+  return Math.max(1, Math.ceil((nextMidnightUtcMs - now.getTime()) / 1000));
+}
+
+/**
+ * UTC instant equivalent to "00:00 today in Vietnam (Asia/Ho_Chi_Minh)".
+ * Lower bound for the SUM(cost_usd) aggregation in `dailyCostAggregation.ts`.
+ *
+ * Aligned with `atomicAcquireTierSlot()` (which uses Postgres
+ * `(NOW() AT TIME ZONE 'Asia/Ho_Chi_Minh')::date`) and `getVietnamDateString()`
+ * in `billing/credits.ts`. Vietnam has no DST so a fixed +7h offset is exact.
+ */
+export function getStartOfVietnamDayUTC(now: Date = new Date()): Date {
+  const VN_OFFSET_MS = 7 * 60 * 60 * 1000;
+  const vnNow = new Date(now.getTime() + VN_OFFSET_MS);
+  const startOfVnDayAsUtc = Date.UTC(
+    vnNow.getUTCFullYear(),
+    vnNow.getUTCMonth(),
+    vnNow.getUTCDate(),
+    0,
+    0,
+    0,
+    0,
+  );
+  return new Date(startOfVnDayAsUtc - VN_OFFSET_MS);
+}


### PR DESCRIPTION
## P0 EMERGENCY — \$26/hr AI cost bleeding

A medical_beta user (`danhkhiem1999@gmail.com`, FREE tier) burned **\$26.40 in one hour** on Tier 3 (`gpt-5.4`) — extrapolates to **\$633/day, \$19K/month** from a single user.

**Root cause:** Phở Points balance is too generous (379K credits ≈ \$760 budget for `vn_free`) and per-call deduction does not keep pace with the real per-call USD spend on expensive models. The existing pre-flight check had no hard ceiling on dollar amount — only on credit balance and request count.

Manual SQL emergency mitigation already applied (balance reduced 379K → 10K) but a systemic code fix is required before similar bleeds recur.

## Fix

Hard daily USD cap per `(user, plan, tier)`, checked **before** the atomic tier-slot acquire so blocked requests do not consume a tier slot. Backed by `SUM(usage_logs.cost_usd)` for the current Vietnam day.

**New files**
- `src/server/services/billing/dailyCostCaps.ts` — plan/tier cap matrix + env override + VN-day boundary helpers
- `src/server/services/billing/dailyCostAggregation.ts` — `SUM(cost_usd)` query + `checkDailyCostCap()` wrapper

**Wired into all three metered AI entrypoints**
- `src/app/(backend)/webapi/chat/[provider]/route.ts` → `createErrorResponse(InsufficientQuota)` → 429 (consistent with the existing `checkDailyRequestCap` UX, no client-side surprises)
- `src/app/api/artifact-ai/route.ts` → `NextResponse` 429 + `Retry-After` header
- `src/app/api/research/ai-summary/route.ts` → `NextResponse` 429 + `Retry-After` header

## Cap values (starting — tunable via env vars)

| Plan | Tier 1 | Tier 2 | Tier 3 |
|---|---|---|---|
| \`vn_free\` | \$1 | blocked | blocked |
| \`medical_beta\` | \$5 | \$3 | \$2 |
| \`vn_pro\` | \$5 | \$5 | \$5 |
| \`vn_premium\` | \$5 | \$5 | \$5 |
| \`vn_ultimate\` | \$10 | \$10 | \$10 |
| \`lifetime_*\` | \$10 | \$10 | \$10 |

Tighten at runtime without redeploy:
\`\`\`
DAILY_CAP_MEDICAL_BETA_T3=1.00   # drop medical_beta T3 from \$2 → \$1
DAILY_CAP_VN_FREE_T1=0.50        # tighten free T1 from \$1 → \$0.50
\`\`\`

## Reset boundary

00:00 \`Asia/Ho_Chi_Minh\` (no DST, fixed UTC+7) — aligned with \`atomicAcquireTierSlot()\` and \`getVietnamDateString()\` in \`billing/credits.ts\`.

## User-facing message (Vietnamese)

\`\`\`
⚠️ Bạn đã dùng hết hạn mức Tier 3 hôm nay (\$2.07/\$2.00).
Vui lòng dùng model Tier thấp hơn hoặc thử lại sau 0:00 (giờ Việt Nam).
\`\`\`

When tier cap is 0 (e.g. vn_free + Tier 2):
\`\`\`
Gói hiện tại của bạn không có quyền dùng model Tier 2. Vui lòng nâng cấp để sử dụng.
\`\`\`

## Failure mode — fail OPEN on aggregation read

\`getDailyTierCostUSD\` returns 0 (and a warn log) on DB error. Rationale: chat path also has the Phở Points pre-flight + atomic tier-slot acquire + post-call billing. One failed read here only allows ONE extra request through before the cap recomputes from the new log row, while a fail-CLOSED would brick all chat on a brief Postgres hiccup. The \`atomicAcquireTierSlot\` fail-CLOSED behavior (PHO-227) remains in place underneath.

## Test plan

- [ ] **Vercel logs** — search \`DAILY CAP HIT\` or \`Daily USD cap blocked\` immediately post-deploy
- [ ] **danhkhiem account** — next Tier 3 call should return 429 with the Vietnamese message (already at ~\$26 today, well above the \$2 medical_beta T3 cap)
- [ ] **Tier-fallback** — same user trying a Tier 1 model should succeed (separate cap)
- [ ] **VN midnight reset** — Tier 3 should work again after 00:00 ICT
- [ ] **PostHog 24h** — daily \`cost_usd\` per user should plateau at the cap instead of growing unbounded
- [ ] **Tier-slot conservation** — confirm in logs that a blocked request does NOT increment \`daily_tier3_usage\` (cap check runs before \`checkTierAccess\`)

## Risk

- **Low risk of regression**: pre-flight read only, no schema change, no migration. Existing pre-flight logic (Phở Points balance, daily request cap, atomic tier slot) is untouched.
- **User-facing impact**: paid plans (vn_pro, vn_ultimate, lifetime_*) get \$5–\$10/day per tier, which is far above normal usage patterns — no real users should hit these caps under typical use.
- **vn_free** gets \$1/day on T1 only — typical free user uses ~\$0.05–\$0.20/day so most won't notice.

## Linear

PHO-238 (V1 Audit Epic) — Severity: P0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a hard daily USD spend cap per user per plan per tier to stop runaway costs (PHO-238). The cap is checked before tier-slot acquire on chat, artifact-ai, and research endpoints and returns 429 with a Vietnamese message and Retry-After until VN midnight.

- **New Features**
  - New preflight `checkDailyCostCap` sums `usage_logs.cost_usd` for the current Vietnam day and compares against plan/tier caps.
  - Cap matrix with env overrides: `DAILY_CAP_{PLAN}_T{TIER}` (set to `0` to block a tier).
  - 429 responses include `Retry-After` (seconds until VN midnight) and reason codes; tier slots are not consumed on block.
  - Added `src/server/services/billing/dailyCostCaps.ts` (caps, env, VN-day helpers) and `src/server/services/billing/dailyCostAggregation.ts` (SUM + wrapper).
  - Integrated into `src/app/(backend)/webapi/chat/[provider]/route.ts`, `src/app/api/artifact-ai/route.ts`, and `src/app/api/research/ai-summary/route.ts`.
  - Fail-open on aggregation read to avoid bricking requests during brief DB hiccups; existing billing guards remain.
  - Starting caps: `vn_free` T1=$1 (T2/T3 blocked); `medical_beta` T1=$5 T2=$3 T3=$2; `vn_pro`/`vn_premium` $5 per tier; `vn_ultimate`/`lifetime_*` $10 per tier.

<sup>Written for commit c740245606cbbc60c57b5846166440df672b9388. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-day USD spending cap enforcement across API endpoints. When daily limits are reached, users receive detailed usage information, reason codes, and retry-after guidance tied to local timezone boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->