### PR TITLE
🔒 fix(billing): block T3 message count for medical_beta (defense-in-depth)

### DIFF
--- a/src/config/pricing.ts
+++ b/src/config/pricing.ts
@@ -68,7 +68,9 @@ export const VN_PLANS: Record<string, PlanConfig> = {
     advancedAI: true,
     code: 'medical_beta',
     dailyTier2Limit: -1,
-    dailyTier3Limit: 10,
+    // PHO-238: Tier 3 disabled — medical_beta is FREE-tier and was burning $26/hr on flagship models.
+    // Defense-in-depth: blocked here, in PLAN_MODEL_ACCESS.allowedTiers, and in dailyCostCaps.ts.
+    dailyTier3Limit: 0,
     defaultModel: 'llama-3.1-8b-instant',
     defaultProvider: 'groq',
     displayName: 'Phở Medical Beta 🏥',
@@ -79,12 +81,12 @@ export const VN_PLANS: Record<string, PlanConfig> = {
     features: [
       '1M Phở Points/tháng',
       'Unlimited Tier 1 & 2',
-      '10 Tier 3/ngày',
+      'Tier 3 yêu cầu nâng cấp (Pro/Ultimate)',
       'Scientific Skills không giới hạn',
       'PubMed, ArXiv, Drug Interaction, Clinical Calculator',
       'Research Mode + Deep Research',
     ],
-    keyLimits: 'Unlim Tier 1 & 2. 10 Tier 3/day. Medical plugins.',
+    keyLimits: 'Unlim Tier 1 & 2. Tier 3 yêu cầu nâng cấp. Medical plugins.',
     monthlyPoints: 1_000_000,
     // 999k VNĐ/year — paid via Sepay/VietQR, activated by promo code
     price: 999_000,
@@ -596,14 +598,16 @@ export const PLAN_MODEL_ACCESS: Record<string, PlanModelAccess> = {
     models: [...TIER1_MODELS, ...TIER2_MODELS, ...TIER3_MODELS],
   },
 
-  // Medical Beta: Tier 1 + Tier 2 + Tier 3 (limited), Groq primary
-  // 999K VND/year — doctors plan with flagship model access
+  // Medical Beta: Tier 1 + Tier 2 only — Groq primary
+  // PHO-238: Tier 3 disabled. medical_beta is FREE-tier (promo activation) and was
+  // burning $26/hr on Tier 3 flagship models. Defense-in-depth alongside
+  // VN_PLANS.medical_beta.dailyTier3Limit = 0 and dailyCostCaps.ts T3 = $0.
   medical_beta: {
-    allowedTiers: [1, 2, 3],
-    dailyLimits: { tier2: -1, tier3: 10 },
+    allowedTiers: [1, 2],
+    dailyLimits: { tier2: -1 },
     defaultModel: 'llama-3.1-8b-instant',
     defaultProvider: 'groq',
-    models: [...TIER1_MODELS, ...TIER2_MODELS, ...TIER3_MODELS],
+    models: [...TIER1_MODELS, ...TIER2_MODELS],
   },
 
   // VN Basic (Phở Tái): Tier 1 + Tier 2 with 30 messages/day limit

--- a/src/server/services/billing/credits.ts
+++ b/src/server/services/billing/credits.ts
@@ -393,6 +393,20 @@ export interface TierAccessResult {
 }
 
 /**
+ * Build a plan-aware Vietnamese error message when a tier is fully blocked
+ * (either disallowed by `allowedTiers` or has a daily cap of 0).
+ */
+function getTierBlockedReason(planId: string, tier: number): string {
+  if (planId === 'medical_beta' && tier === 3) {
+    return 'Gói Medical Beta (miễn phí) không hỗ trợ model Tier 3. Vui lòng nâng cấp lên gói Pro hoặc Ultimate.';
+  }
+  if (planId === 'vn_free' && tier >= 2) {
+    return `Gói miễn phí không hỗ trợ model Tier ${tier}. Vui lòng nâng cấp để sử dụng.`;
+  }
+  return 'Model này yêu cầu gói cao hơn. Vui lòng nâng cấp để sử dụng.';
+}
+
+/**
  * Atomically acquire a daily tier usage slot using PostgreSQL conditional UPDATE.
  * Prevents race conditions by combining the check and increment in a single query.
  * If the UPDATE matches (returns rows), the slot was acquired.
@@ -494,7 +508,7 @@ export async function checkTierAccess(
   if (!canUseTier(planId, tier)) {
     return {
       allowed: false,
-      reason: 'Model này yêu cầu gói cao hơn. Vui lòng nâng cấp để sử dụng.',
+      reason: getTierBlockedReason(planId, tier),
     };
   }
 
@@ -509,7 +523,7 @@ export async function checkTierAccess(
     return {
       allowed: false,
       dailyLimit: 0,
-      reason: 'Model này không khả dụng cho gói hiện tại của bạn.',
+      reason: getTierBlockedReason(planId, tier),
     };
   }
 

--- a/src/server/services/billing/dailyCostCaps.ts
+++ b/src/server/services/billing/dailyCostCaps.ts
@@ -28,30 +28,23 @@ export interface DailyCostCap {
 const DEFAULT_CAPS: DailyCostCap = { tier1: 1, tier2: 0, tier3: 0 };
 
 const PLAN_CAPS: Record<string, DailyCostCap> = {
-  
   // Lifetime plans
-lifetime_early_bird: { tier1: 10, tier2: 10, tier3: 10 },
+  lifetime_early_bird: { tier1: 10, tier2: 10, tier3: 10 },
 
-  
+  lifetime_last_call: { tier1: 10, tier2: 10, tier3: 10 },
 
-lifetime_last_call: { tier1: 10, tier2: 10, tier3: 10 },
+  lifetime_standard: { tier1: 10, tier2: 10, tier3: 10 },
 
-  
+  // Promo / beta plans
+  // PHO-238: T3 hard-blocked at $0 — medical_beta is FREE-tier and was burning $26/hr.
+  // Defense-in-depth: also blocked via PLAN_MODEL_ACCESS.allowedTiers + dailyTier3Limit=0.
+  medical_beta: { tier1: 5, tier2: 3, tier3: 0 },
 
-lifetime_standard: { tier1: 10, tier2: 10, tier3: 10 },
-  
-  
-// Promo / beta plans
-medical_beta: { tier1: 5, tier2: 3, tier3: 2 },
-  
+  vn_free: { tier1: 1, tier2: 0, tier3: 0 },
 
-vn_free: { tier1: 1, tier2: 0, tier3: 0 },
-
-  
-  
-vn_premium: { tier1: 5, tier2: 5, tier3: 5 },
+  vn_premium: { tier1: 5, tier2: 5, tier3: 5 },
   // Subscription plans
-vn_pro: { tier1: 5, tier2: 5, tier3: 5 },
+  vn_pro: { tier1: 5, tier2: 5, tier3: 5 },
   vn_ultimate: { tier1: 10, tier2: 10, tier3: 10 },
 };
 


### PR DESCRIPTION
## Summary

Backup layer for daily USD cost cap (PR #46). `medical_beta` is a FREE-tier promo plan and was burning **\$26.40/hr** on Tier 3 flagship models. This PR hard-blocks T3 at the **message count** layer so the protection survives even if the USD cost cap env var is misconfigured.

**Linear:** PHO-238

## Defense-in-depth (3 layers)

| Layer | Mechanism | Enforced by |
|-------|-----------|-------------|
| 1. Message count | `dailyTier3Limit = 0` + `allowedTiers = [1, 2]` | **THIS PR** — `src/config/pricing.ts` |
| 2. Daily USD cost | `DAILY_CAP_MEDICAL_BETA_T3 = 0` (env) + code default `\$0` | PR #46 + this PR's `dailyCostCaps.ts` align |
| 3. Phở Points | Balance capped to 10K credits | Emergency SQL backstop (already applied) |

## Changes

- **`src/config/pricing.ts` — `VN_PLANS.medical_beta`**
  `dailyTier3Limit: 10 → 0`; `features` and `keyLimits` text updated to communicate \"Tier 3 yêu cầu nâng cấp\".
- **`src/config/pricing.ts` — `PLAN_MODEL_ACCESS.medical_beta`**
  `allowedTiers: [1, 2, 3] → [1, 2]`; `tier3` removed from `dailyLimits`; `TIER3_MODELS` removed from `models`. Hides T3 entries from the model picker for medical_beta users.
- **`src/server/services/billing/dailyCostCaps.ts`**
  `medical_beta` T3 USD cap `2 → 0`. Aligns code default with the runtime env var so a misconfigured deploy still fails closed.
- **`src/server/services/billing/credits.ts`**
  Extracted `getTierBlockedReason(planId, tier)` helper. `medical_beta` + T3 returns:
  > Gói Medical Beta (miễn phí) không hỗ trợ model Tier 3. Vui lòng nâng cấp lên gói Pro hoặc Ultimate.

## Test plan

- [x] \`bun run type-check\` clean
- [ ] Smoke test on preview: medical_beta user attempts T3 model → expect 403 / Vietnamese block message (not the generic \"Model này không khả dụng\")
- [ ] Verify model picker for medical_beta user no longer lists T3 models
- [ ] Confirm Tier 1 and Tier 2 still work for medical_beta (unlimited T2 unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hard-block Tier 3 usage for `medical_beta` via message count and model access. Prevents runaway spend and still fails closed if the USD cap env is wrong (Linear: PHO-238).

- **Bug Fixes**
  - `src/config/pricing.ts`: set `VN_PLANS.medical_beta.dailyTier3Limit` to `0`; `PLAN_MODEL_ACCESS.medical_beta` now `allowedTiers: [1, 2]` with Tier 3 removed from `dailyLimits` and `models`; copy updated to say Tier 3 requires upgrade.
  - `src/server/services/billing/dailyCostCaps.ts`: `medical_beta` Tier 3 daily USD cap set to `0` to align defaults.
  - `src/server/services/billing/credits.ts`: added `getTierBlockedReason()` with a clear Vietnamese upgrade message for `medical_beta` Tier 3.

<sup>Written for commit e1f21beba507b65e71bdd6ac88f11fcde2054e0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

