### PR TITLE
💰 feat(billing): token-based point deduction — 1 point = $0.01 USD (PHO-237)

### DIFF
--- a/src/server/services/billing/credits.ts
+++ b/src/server/services/billing/credits.ts
@@ -127,6 +127,31 @@ function getVietnamDateString(date: Date = new Date()): string {
   return vnTime.toISOString().slice(0, 10);
 }
 
+/**
+ * Process AI model usage: deduct Phở Points and log to usage_logs.
+ *
+ * PHO-237 (2026-05-03) — Token-based deduction: 1 Phở Point = $0.01 USD.
+ *
+ * Callers still pass `cost` as the LEGACY points-cost they compute themselves
+ * (e.g. `(in × inPts/1M + out × outPts/1M)` from `model_pricing`). Internally
+ * we convert to real USD via the documented seed ratio (1 pt ≈ $0.00004,
+ * see `scripts/seed-model-pricing-gateway.ts:21`) and derive the actual
+ * deduction from USD:
+ *
+ *     pointsDeducted = Math.ceil(costUSD × 100)   ⇔   Math.ceil(cost / 250)
+ *
+ * Effect (allocation unchanged — "stealth rebalance"):
+ *   $0.01 call →     1 pt  (was ~250)         — light users feel generous
+ *   $0.30 call →    30 pts (was ~7 500)
+ *   $7.50 call →   750 pts (was ~187 500)     — heavy users self-regulate
+ *   $15.00 call → 1 500 pts                   — expensive usage = expensive pts
+ *
+ * Free tier (Tier 1, first 5/day) still pays 0 — no forced minimum.
+ * `usage_logs.cost_usd` continues to record the real USD per call so the
+ * daily USD cap (PHO-238 / PR #46) keeps working unchanged.
+ *
+ * Decision: Hien approved 2026-05-03. Linear: PHO-237.
+ */
 export async function processModelUsage(
   userId: string,
   cost: number,
@@ -137,6 +162,12 @@ export async function processModelUsage(
   try {
     const db = await getServerDB();
     const now = new Date();
+
+    // PHO-237: legacy points-cost → real USD → token-based deduction.
+    // Prefer caller-provided `usageLog.costUSD` (forward-compatible with future
+    // per-model USD pricing); fall back to deriving from `cost` via the seed ratio.
+    const costUSD = usageLog?.costUSD ?? cost / 25_000;
+    const tokenBasedCost = Math.ceil(costUSD * 100);
 
     // 1. Get current user stats including all tier usage
     const userRows = await db
@@ -171,9 +202,9 @@ export async function processModelUsage(
     let newTier3Usage = isSameDay ? user.dailyTier3Usage || 0 : 0;
 
     // 3. Track points actually deducted — used by the unified usage_logs insert below.
-    //    Set per-branch; defaults to `cost` (atomic-slot path) and is overwritten to
-    //    `finalCost` if the free-tier branch waives it.
-    let pointsDeducted = cost;
+    //    PHO-237: defaults to `tokenBasedCost` (atomic-slot path); overwritten
+    //    to `finalCost` (0 when free-tier waives) in the counter-update path.
+    let pointsDeducted = tokenBasedCost;
 
     // 4. Branch: atomic-slot path (Tier 2/3) vs counter-update path (Tier 1 / fallback).
     //    PHO-224: BOTH branches now fall through to the usage_logs insert below.
@@ -182,24 +213,24 @@ export async function processModelUsage(
     if (tierSlotAlreadyAcquired && (tier === 2 || tier === 3)) {
       // Atomic-slot path: tier counters are managed exclusively by atomicAcquireTierSlot()
       // in checkTierAccess(). Only deduct credits here; don't touch counters or lastUsageDate.
-      if (cost > 0) {
+      if (tokenBasedCost > 0) {
         await db
           .update(users)
           .set({
-            lifetimeSpent: sql`${users.lifetimeSpent} + ${cost}`,
-            phoPointsBalance: sql`GREATEST(0, ${users.phoPointsBalance} - ${cost})`,
+            lifetimeSpent: sql`${users.lifetimeSpent} + ${tokenBasedCost}`,
+            phoPointsBalance: sql`GREATEST(0, ${users.phoPointsBalance} - ${tokenBasedCost})`,
           })
           .where(eq(users.id, userId));
         console.log(
-          `[Credits] Deducted ${cost} Credits (Tier ${tier}, atomic slot). User: ${userId}`,
+          `[Credits] Deducted ${tokenBasedCost} pts (Tier ${tier}, atomic slot, $${costUSD.toFixed(4)}). User: ${userId}`,
         );
       }
-      // pointsDeducted already === cost (set above).
+      // pointsDeducted already === tokenBasedCost (set above).
     } else {
       // Counter-update path: Tier 1 (with free-tier waiver) or non-slot fallback.
       // Free Tier: first FREE_TIER_LIMIT Tier 1 requests/day are zero-cost.
       const FREE_TIER_LIMIT = 5;
-      let finalCost = cost;
+      let finalCost = tokenBasedCost;
       let isFree = false;
 
       switch (tier) {
@@ -244,7 +275,7 @@ export async function processModelUsage(
           );
         } else if (finalCost > 0) {
           console.log(
-            `[Credits] Deducted ${finalCost} Credits (Tier ${tier}). T1=${newTier1Usage}, T2=${newTier2Usage}, T3=${newTier3Usage}. User: ${userId}`,
+            `[Credits] Deducted ${finalCost} pts (Tier ${tier}, $${costUSD.toFixed(4)}). T1=${newTier1Usage}, T2=${newTier2Usage}, T3=${newTier3Usage}. User: ${userId}`,
           );
         }
       }
@@ -256,10 +287,22 @@ export async function processModelUsage(
     // increments pho:ratelimit:* keys via checkTierAccess() in the chat route.
     // The duplicate INCR here was causing admin dashboard to show 2x actual usage.
 
+    // PHO-237: monitoring log — searchable as `[billing] Points deducted` in
+    // Vercel logs to verify the new formula is in effect post-deploy.
+    console.log('[billing] Points deducted', {
+      costUSD: costUSD.toFixed(4),
+      formula: '1 point = $0.01 USD (Math.ceil(costUSD × 100))',
+      legacyPointsCost: cost,
+      model: usageLog?.model,
+      pointsDeducted,
+      tier,
+      userId,
+    });
+
     // 5. Log to usage_logs with actual model/tier/tokens (PHO-224: unified for BOTH branches).
     if (usageLog) {
       const VND_RATE = 24_167;
-      const costUSD = usageLog.costUSD ?? pointsDeducted * 0.000_04; // fallback: 1 point ≈ $0.00004
+      // PHO-237: `costUSD` already computed at top; no fallback recomputation here.
 
       try {
         await db.insert(usageLogs).values({


### PR DESCRIPTION
## PHO-237 Phase 2: Proportional deduction

Hien-approved decisions (2026-05-03):
1. 1 Phở Point = $0.01 USD
2. Keep existing allocation unchanged (stealth rebalance)
3. Change deduction formula from flat per-tier → proportional to actual USD cost
4. No user communication needed (T1 benefits, T3 self-regulates)

### What changes
- Deduction formula: `Math.ceil(cost / 250)` (mathematically equivalent to `Math.ceil(costUSD × 100)`)
- 1 Phở Point = \$0.01 USD
- Allocation: **UNCHANGED** (stealth rebalance)
- `usage_logs.cost_usd` fallback fixed: now records real gateway cost even for free tier (was 0 before)

### Implementation: Path A (single-file change)

The original plan assumed cost_usd was real provider cost — investigation showed callers compute cost in POINTS (not USD), and `usage_logs.cost_usd` was being inversely derived from points via fallback `pointsDeducted * 0.000_04`.

Path A leverages the documented seed ratio (1pt ≈ \$0.00004; see `scripts/seed-model-pricing-gateway.ts:21`):

\`\`\`ts
const costUSD = usageLog?.costUSD ?? cost / 25_000;
const tokenBasedCost = Math.ceil(costUSD * 100);
\`\`\`

**Why Path A over the original plan's multi-file approach:**
- 1 file change instead of 6 (no schema migration, no caller updates)
- Mathematically identical to the plan's intent
- Forward-compatible: when callers eventually pass `usageLog.costUSD` directly (e.g. from real gateway response), the new value wins over the derived one
- All 5 callers (chat, artifact-ai, ai-summary, ai-rendering, embeddingMetering) already funnel through `processModelUsage` — single point of conversion

### Behavior change for free tier `cost_usd`
Before: free Tier 1 calls had `cost_usd = 0` in usage_logs (because `pointsDeducted = 0` and fallback derived cost_usd from pointsDeducted)
After: free Tier 1 calls now record real gateway cost in usage_logs (~\$0.001 each)

This **closes a small abuse window** in the daily USD cap (PHO-238): a vn_free user spamming the free 5/day on cheap T1 models was contributing \$0 to the cap budget. Now their real gateway cost counts toward the \$1 T1 cap.

Free tier users still pay 0 points — only the logged USD value changed.

### Out of scope (flagged for follow-up)
- `src/app/api/v1/chat/route.ts` (OpenAI-compatible API for external clients) uses a separate `phoWallet` table and has its own inline `costUSD = cost * 0.000_04` formula. **Not changed in this PR** — different wallet system, different scope. Should be a follow-up ticket if external API users need same rebalance.

### Examples with new formula
\`\`\`
gemini-flash chat (\$0.01):    1 point   (was ~250)
gemini-pro research (\$0.30):  30 points (was ~7,500)
claude-opus analysis (\$7.50): 750 points (was ~187,500)
gpt-5.4 + PDF (\$15.00):       1,500 points (was ~375,000)
\`\`\`

### Test plan post-merge
1. Send chat via gemini-flash → check Vercel logs `[billing] Points deducted` shows ~1 pt
2. Send chat via claude-opus → check `[billing] Points deducted` shows ~500-750 pts
3. Verify usage_logs row: `points_deducted` matches Vercel log; `cost_usd` is real
4. Verify balance decrease: `balance_before - points_deducted = balance_after`
5. T1 user — points drain SLOWER than before (positive UX)
6. T3 user — points drain FASTER than before (correct behavior)
7. Free tier user — first 5 T1 calls still cost 0 points, but show real cost_usd

### Monitoring
- Vercel logs: search \`[billing] Points deducted\` → see formula in action with payload `{ costUSD, pointsDeducted, legacyPointsCost, formula }`
- PostHog: `costPoints` should now correlate with `costUSD` (was uncorrelated before)
- Daily USD cap (PHO-238): no behavior change — already reads `usage_logs.cost_usd`

### Type-check
✓ `bun run type-check` clean
✓ Pre-commit hooks (prettier, stylelint, eslint) all passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Phở Points to be proportional to USD cost (PHO-237): 1 point = $0.01. Allocations stay the same; we now log real USD cost for every call, including free tier.

- **New Features**
  - Deduct points as Math.ceil(costUSD × 100); when only legacy points are provided, derive costUSD via cost / 25_000 (equivalent to Math.ceil(cost / 250)).
  - Applies to all tiers; free tier still 0 points. Added `[billing] Points deducted` log for monitoring.

- **Bug Fixes**
  - Fixed `usage_logs.cost_usd` fallback to record real gateway cost for free-tier calls (was 0), so daily USD caps count correctly (PHO-238).

<sup>Written for commit 31ee37bd78f289694ad143425f5a01bbaddf4fc2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated credit deduction calculations across all account tiers for improved consistency in billing.

* **Chores**
  * Enhanced billing transaction logging to provide additional transparency on cost conversions and point deductions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->