### PR TITLE
🎨 fix(ux): handle 429 daily cap + tier block gracefully (PHO-238)

### DIFF
--- a/packages/utils/src/fetch/parseError.ts
+++ b/packages/utils/src/fetch/parseError.ts
@@ -33,7 +33,16 @@ export const getMessageError = async (response: Response) => {
     const data = (await response.json()) as ErrorResponse;
     // PHO-238: prefer specific backend message (daily-cap detail, tier-block reason, ...)
     // over the generic translated key for the error type.
-    const specific = extractSpecificMessage(data.body);
+    //
+    // EXCEPTION: for Pho billing-limit codes (`DAILY_CAP_EXCEEDED` / `TIER_BLOCKED`)
+    // the backend message embeds raw dollar amounts ("đã dùng $26.50/$26.00 ..."),
+    // which Hien deliberately does not want surfaced in the user-facing alert
+    // (keep the messaging aspirational rather than transactional). We fall back to
+    // the generic translated key for these codes; the rich body is still passed
+    // through `body` so `<BillingLimit>` can render its own copy + alternatives.
+    const reasonCode = (data.body as { reasonCode?: string } | undefined)?.reasonCode;
+    const isBillingLimit = reasonCode === 'DAILY_CAP_EXCEEDED' || reasonCode === 'TIER_BLOCKED';
+    const specific = isBillingLimit ? undefined : extractSpecificMessage(data.body);
     chatMessageError = {
       body: data.body,
       message: specific ?? t(`response.${data.errorType}` as any, { ns: 'error' }),

--- a/packages/utils/src/fetch/parseError.ts
+++ b/packages/utils/src/fetch/parseError.ts
@@ -1,15 +1,42 @@
 import { ChatMessageError, ErrorResponse, ErrorType } from '@lobechat/types';
 import { t } from 'i18next';
 
+/**
+ * Pull a backend-provided user-facing message out of the error body, if any.
+ *
+ * Backends like the Pho daily-cap (PHO-238) or tier-block (PHO-241) paths embed
+ * a localized message inside the body so the alert can show the specific reason
+ * (e.g. "Bạn đã dùng hết hạn mức Tier 3 hôm nay ($26.50/$26.00)...") instead of
+ * the generic translated key for the error type. We accept a few shapes that
+ * have appeared in callers:
+ *
+ *   { body: { error: { message: "..." } } }   ← `createErrorResponse(...)` shape
+ *   { body: { message: "..." } }              ← legacy / direct shape
+ *   { body: { error: "..." } }                ← raw routes (artifact-ai, research)
+ *
+ * Falls back to undefined when nothing usable is present.
+ */
+const extractSpecificMessage = (body: any): string | undefined => {
+  if (!body || typeof body !== 'object') return undefined;
+  const candidates = [body.error?.message, body.message, body.error];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim().length > 0) return candidate;
+  }
+  return undefined;
+};
+
 export const getMessageError = async (response: Response) => {
   let chatMessageError: ChatMessageError;
 
   // try to get the biz error
   try {
     const data = (await response.json()) as ErrorResponse;
+    // PHO-238: prefer specific backend message (daily-cap detail, tier-block reason, ...)
+    // over the generic translated key for the error type.
+    const specific = extractSpecificMessage(data.body);
     chatMessageError = {
       body: data.body,
-      message: t(`response.${data.errorType}` as any, { ns: 'error' }),
+      message: specific ?? t(`response.${data.errorType}` as any, { ns: 'error' }),
       type: data.errorType,
     };
   } catch {

--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -496,6 +496,9 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
           provider: 'pho-chat',
           reasonCode: usdCapCheck.reasonCode,
           retryAfter: getSecondsUntilMidnightVN(),
+          // PHO-238 frontend: tier of the blocked request — drives `<BillingLimit>`'s
+          // tier-specific alternatives list (e.g. T3 block → suggest Sonnet 4.6 / Gemini Pro).
+          tier: modelTier,
           upgradeUrl: '/settings/subscription',
         });
       }

--- a/src/features/Conversation/Error/BillingLimit.tsx
+++ b/src/features/Conversation/Error/BillingLimit.tsx
@@ -1,88 +1,231 @@
 import { Button } from '@lobehub/ui';
-import { AlertTriangle, Sparkles } from 'lucide-react';
-import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+import { createStyles } from 'antd-style';
+import { ChevronRight, ShoppingCart, Sparkles } from 'lucide-react';
+import { memo, useCallback } from 'react';
+import { Center, Flexbox } from 'react-layout-kit';
 
+import { useAgentStore } from '@/store/agent';
 import { useChatStore } from '@/store/chat';
 import { ChatMessage } from '@/types/message';
 
-import { ErrorActionContainer, FormAction } from './style';
+import { ErrorActionContainer } from './style';
 
 /**
  * BillingLimit — rendered for `InsufficientQuota` errors that carry a Pho-specific
- * `reasonCode` (`DAILY_CAP_EXCEEDED` / `TIER_BLOCKED`) from the chat route.
+ * `reasonCode` from the chat route's daily USD cap (PHO-238 / PR #46) or
+ * tier-block (PHO-241 / PR #47) paths.
  *
- * Backend (chat/[provider]/route.ts) emits HTTP 429 via `createErrorResponse(InsufficientQuota, {
- *   dailyCostCap, dailyCostUsed, error: { message }, reasonCode, retryAfter, upgradeUrl
- * })`. The alert above this component already shows the specific Vietnamese message
- * (surfaced by `getMessageError` in PHO-238). This component adds an actionable
- * footer: cap usage summary + upgrade CTA + dismiss, so the user has a clear next
- * step instead of `<ErrorJsonViewer>`'s raw JSON dump (the previous fallback).
+ * Direction (Hien, 2026-05-03): notification, not transaction. Do NOT show
+ * `$used / $cap` numbers — feels punitive. Instead: friendly title, soft message,
+ * concrete model alternatives the user can switch to with one click, plus a
+ * "Mua thêm hạn mức" CTA pointing at the subscription page (placeholder until
+ * the Polar/Sepay extra-credits checkout ships in a future ticket).
+ *
+ * Replaces the previous `<ErrorJsonViewer>` JSON-dump fallback that triggered
+ * nga.ntv's `$exception (null type)` PostHog event when she hit the T3 cap.
  */
 interface BillingLimitProps {
   data: ChatMessage;
 }
 
 interface BillingLimitBody {
-  dailyCostCap?: number;
-  dailyCostUsed?: number;
   error?: { message?: string } | string;
-  message?: string;
   reasonCode?: 'DAILY_CAP_EXCEEDED' | 'TIER_BLOCKED';
   retryAfter?: number;
+  /** Tier of the blocked request — drives the per-tier alternatives list. */
+  tier?: number;
   upgradeUrl?: string;
 }
 
-// Only allow same-origin paths so a poisoned backend payload can't redirect off-site.
-const safeUpgradeUrl = (raw: unknown): string =>
-  typeof raw === 'string' && raw.startsWith('/') ? raw : '/settings/subscription';
+interface ModelAlternative {
+  label: string;
+  model: string;
+  provider: string;
+  reason: string;
+}
+
+/**
+ * Suggest 2–3 in-tier-or-below alternatives the user can keep working on.
+ *
+ * NOTE: keep this list sync'd with `src/config/pricing.ts` `TIER2_MODELS` —
+ * we deliberately suggest only Tier 2 fallbacks (premium picks the user can
+ * still afford), never propose models the user already exhausted.
+ *
+ * Open-source candidates (Kimi K2.6, DeepSeek V4) are intentionally OMITTED
+ * until PHO-237 Phase 3 ships their integration; this list will grow then.
+ */
+const getModelAlternatives = (
+  reasonCode: 'DAILY_CAP_EXCEEDED' | 'TIER_BLOCKED' | undefined,
+  blockedTier: number | undefined,
+): ModelAlternative[] => {
+  if (reasonCode === 'TIER_BLOCKED' && blockedTier === 3) {
+    return [
+      {
+        label: 'Claude Sonnet 4.6',
+        model: 'anthropic/claude-sonnet-4.6',
+        provider: 'vercelaigateway',
+        reason: 'Chất lượng cao, đủ tốt cho phần lớn nghiên cứu chuyên sâu',
+      },
+      {
+        label: 'Gemini 2.5 Pro',
+        model: 'google/gemini-2.5-pro',
+        provider: 'vercelaigateway',
+        reason: 'Ngữ cảnh 1M tokens, mạnh khi đọc PDF dài',
+      },
+      {
+        label: 'Gemini 2.5 Flash',
+        model: 'google/gemini-2.5-flash',
+        provider: 'vercelaigateway',
+        reason: 'Nhanh, tiết kiệm — hợp với hỏi nhanh',
+      },
+    ];
+  }
+  if (reasonCode === 'DAILY_CAP_EXCEEDED') {
+    return [
+      {
+        label: 'Gemini 2.5 Flash',
+        model: 'google/gemini-2.5-flash',
+        provider: 'vercelaigateway',
+        reason: 'Tốc độ cao, hạn mức rộng hơn',
+      },
+      {
+        label: 'Claude Sonnet 4.6',
+        model: 'anthropic/claude-sonnet-4.6',
+        provider: 'vercelaigateway',
+        reason: 'Chất lượng cao, vẫn dùng được hôm nay',
+      },
+    ];
+  }
+  return [];
+};
+
+// Same-origin guard so a poisoned backend payload can't redirect off-site.
+const safeUpgradeUrl = (raw: unknown, source: string): string => {
+  const base = typeof raw === 'string' && raw.startsWith('/') ? raw : '/settings/subscription';
+  const sep = base.includes('?') ? '&' : '?';
+  return `${base}${sep}source=${source}`;
+};
+
+const useStyles = createStyles(({ css, token }) => ({
+  alt: css`
+    cursor: pointer;
+
+    width: 100%;
+    padding-block: 10px;
+    padding-inline: 12px;
+    border: 1px solid ${token.colorBorderSecondary};
+    border-radius: 8px;
+
+    text-align: start;
+
+    background: ${token.colorBgContainer};
+
+    transition: all 0.15s ease;
+
+    &:hover {
+      border-color: ${token.colorPrimary};
+      background: ${token.colorPrimaryBg};
+    }
+  `,
+  altLabel: css`
+    font-weight: 500;
+    color: ${token.colorText};
+  `,
+  altReason: css`
+    margin-block-start: 2px;
+    font-size: 12px;
+    color: ${token.colorTextTertiary};
+  `,
+  description: css`
+    line-height: 1.5;
+    color: ${token.colorTextSecondary};
+    text-align: center;
+  `,
+  sectionLabel: css`
+    font-size: 12px;
+    font-weight: 500;
+    color: ${token.colorTextSecondary};
+  `,
+  title: css`
+    font-size: 15px;
+    font-weight: 600;
+    color: ${token.colorText};
+    text-align: center;
+  `,
+}));
 
 const BillingLimit = memo<BillingLimitProps>(({ data }) => {
+  const { styles } = useStyles();
   const body = ((data.error?.body as BillingLimitBody | undefined) ?? {}) as BillingLimitBody;
   const reasonCode = body.reasonCode;
-  const upgradeUrl = safeUpgradeUrl(body.upgradeUrl);
-  const isTierBlocked = reasonCode === 'TIER_BLOCKED';
+  const blockedTier = body.tier;
 
+  const updateAgentConfig = useAgentStore((s) => s.updateAgentConfig);
   const deleteMessage = useChatStore((s) => s.deleteMessage);
 
+  const isTierBlocked = reasonCode === 'TIER_BLOCKED';
   const title = isTierBlocked
-    ? 'Gói hiện tại không hỗ trợ model này'
-    : 'Đã đạt giới hạn chi phí hôm nay';
+    ? '✨ Model này chưa có trong gói của bạn'
+    : '🌙 Bạn đã dùng hết hạn mức hôm nay';
+  const description = isTierBlocked
+    ? 'Hãy thử model thay thế chất lượng tương đương, hoặc nâng cấp gói để mở khoá.'
+    : 'Hạn mức sẽ reset lúc 0:00 (giờ Việt Nam). Trong khi chờ, bạn vẫn dùng được các model khác.';
 
-  // Prefer the backend's specific message (e.g. "Bạn đã dùng hết hạn mức Tier 3
-  // hôm nay ($26.50/$26.00)..."); fall back to whatever the alert layer received.
-  const description =
-    (typeof body.error === 'object' ? body.error?.message : body.error) ||
-    body.message ||
-    data.error?.message ||
-    'Hiện không thể gửi tin nhắn. Vui lòng thử model khác hoặc nâng cấp gói.';
+  const alternatives = getModelAlternatives(reasonCode, blockedTier);
 
-  const showUsageLine =
-    typeof body.dailyCostUsed === 'number' && typeof body.dailyCostCap === 'number';
+  const switchToModel = useCallback(
+    (alt: ModelAlternative) => {
+      void updateAgentConfig({ model: alt.model, provider: alt.provider });
+      deleteMessage(data.id);
+    },
+    [updateAgentConfig, deleteMessage, data.id],
+  );
 
-  const AvatarIcon = isTierBlocked ? Sparkles : AlertTriangle;
+  const upgradeUrl = safeUpgradeUrl(body.upgradeUrl, 'billing-limit-upgrade');
+  const buyExtraUrl = safeUpgradeUrl(body.upgradeUrl, 'billing-limit-buy-extra');
 
   return (
     <ErrorActionContainer>
-      <FormAction
-        avatar={<AvatarIcon size={48} strokeWidth={1.5} />}
-        description={description}
-        title={title}
-      >
-        <Flexbox gap={12} width={'100%'}>
-          {showUsageLine && (
-            <Flexbox style={{ fontSize: 12, opacity: 0.6, textAlign: 'center' }}>
-              {`Đã dùng $${body.dailyCostUsed!.toFixed(2)} / $${body.dailyCostCap!.toFixed(2)} hôm nay`}
-            </Flexbox>
-          )}
-          <Button block href={upgradeUrl} type={'primary'}>
-            Nâng cấp gói
-          </Button>
-          <Button block onClick={() => deleteMessage(data.id)}>
-            Đóng
-          </Button>
+      <Center gap={8}>
+        <div className={styles.title}>{title}</div>
+        <div className={styles.description}>{description}</div>
+      </Center>
+
+      {alternatives.length > 0 && (
+        <Flexbox gap={8} width={'100%'}>
+          <div className={styles.sectionLabel}>💡 Gợi ý model thay thế</div>
+          <Flexbox gap={6} width={'100%'}>
+            {alternatives.map((alt) => (
+              <button
+                className={styles.alt}
+                key={alt.model}
+                onClick={() => switchToModel(alt)}
+                type={'button'}
+              >
+                <Flexbox align={'center'} horizontal justify={'space-between'}>
+                  <Flexbox>
+                    <div className={styles.altLabel}>{alt.label}</div>
+                    <div className={styles.altReason}>{alt.reason}</div>
+                  </Flexbox>
+                  <ChevronRight opacity={0.4} size={16} />
+                </Flexbox>
+              </button>
+            ))}
+          </Flexbox>
         </Flexbox>
-      </FormAction>
+      )}
+
+      <Flexbox gap={8} width={'100%'}>
+        <Button block href={buyExtraUrl} icon={ShoppingCart} type={'primary'}>
+          Mua thêm hạn mức
+        </Button>
+        <Button block href={upgradeUrl} icon={Sparkles}>
+          Nâng cấp gói
+        </Button>
+        <Button block onClick={() => deleteMessage(data.id)} variant={'text'}>
+          Đóng
+        </Button>
+      </Flexbox>
     </ErrorActionContainer>
   );
 });

--- a/src/features/Conversation/Error/BillingLimit.tsx
+++ b/src/features/Conversation/Error/BillingLimit.tsx
@@ -1,0 +1,90 @@
+import { Button } from '@lobehub/ui';
+import { AlertTriangle, Sparkles } from 'lucide-react';
+import { memo } from 'react';
+import { Flexbox } from 'react-layout-kit';
+
+import { useChatStore } from '@/store/chat';
+import { ChatMessage } from '@/types/message';
+
+import { ErrorActionContainer, FormAction } from './style';
+
+/**
+ * BillingLimit — rendered for `InsufficientQuota` errors that carry a Pho-specific
+ * `reasonCode` (`DAILY_CAP_EXCEEDED` / `TIER_BLOCKED`) from the chat route.
+ *
+ * Backend (chat/[provider]/route.ts) emits HTTP 429 via `createErrorResponse(InsufficientQuota, {
+ *   dailyCostCap, dailyCostUsed, error: { message }, reasonCode, retryAfter, upgradeUrl
+ * })`. The alert above this component already shows the specific Vietnamese message
+ * (surfaced by `getMessageError` in PHO-238). This component adds an actionable
+ * footer: cap usage summary + upgrade CTA + dismiss, so the user has a clear next
+ * step instead of `<ErrorJsonViewer>`'s raw JSON dump (the previous fallback).
+ */
+interface BillingLimitProps {
+  data: ChatMessage;
+}
+
+interface BillingLimitBody {
+  dailyCostCap?: number;
+  dailyCostUsed?: number;
+  error?: { message?: string } | string;
+  message?: string;
+  reasonCode?: 'DAILY_CAP_EXCEEDED' | 'TIER_BLOCKED';
+  retryAfter?: number;
+  upgradeUrl?: string;
+}
+
+// Only allow same-origin paths so a poisoned backend payload can't redirect off-site.
+const safeUpgradeUrl = (raw: unknown): string =>
+  typeof raw === 'string' && raw.startsWith('/') ? raw : '/settings/subscription';
+
+const BillingLimit = memo<BillingLimitProps>(({ data }) => {
+  const body = ((data.error?.body as BillingLimitBody | undefined) ?? {}) as BillingLimitBody;
+  const reasonCode = body.reasonCode;
+  const upgradeUrl = safeUpgradeUrl(body.upgradeUrl);
+  const isTierBlocked = reasonCode === 'TIER_BLOCKED';
+
+  const deleteMessage = useChatStore((s) => s.deleteMessage);
+
+  const title = isTierBlocked
+    ? 'Gói hiện tại không hỗ trợ model này'
+    : 'Đã đạt giới hạn chi phí hôm nay';
+
+  // Prefer the backend's specific message (e.g. "Bạn đã dùng hết hạn mức Tier 3
+  // hôm nay ($26.50/$26.00)..."); fall back to whatever the alert layer received.
+  const description =
+    (typeof body.error === 'object' ? body.error?.message : body.error) ||
+    body.message ||
+    data.error?.message ||
+    'Hiện không thể gửi tin nhắn. Vui lòng thử model khác hoặc nâng cấp gói.';
+
+  const showUsageLine =
+    typeof body.dailyCostUsed === 'number' && typeof body.dailyCostCap === 'number';
+
+  const AvatarIcon = isTierBlocked ? Sparkles : AlertTriangle;
+
+  return (
+    <ErrorActionContainer>
+      <FormAction
+        avatar={<AvatarIcon size={48} strokeWidth={1.5} />}
+        description={description}
+        title={title}
+      >
+        <Flexbox gap={12} width={'100%'}>
+          {showUsageLine && (
+            <Flexbox style={{ fontSize: 12, opacity: 0.6, textAlign: 'center' }}>
+              {`Đã dùng $${body.dailyCostUsed!.toFixed(2)} / $${body.dailyCostCap!.toFixed(2)} hôm nay`}
+            </Flexbox>
+          )}
+          <Button block href={upgradeUrl} type={'primary'}>
+            Nâng cấp gói
+          </Button>
+          <Button block onClick={() => deleteMessage(data.id)}>
+            Đóng
+          </Button>
+        </Flexbox>
+      </FormAction>
+    </ErrorActionContainer>
+  );
+});
+
+export default BillingLimit;

--- a/src/features/Conversation/Error/index.tsx
+++ b/src/features/Conversation/Error/index.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { useProviderName } from '@/hooks/useProviderName';
 import { ChatMessage, ChatMessageError } from '@/types/message';
 
+import BillingLimit from './BillingLimit';
 import ChatInvalidAPIKey from './ChatInvalidApiKey';
 import ClerkLogin from './ClerkLogin';
 import ErrorJsonViewer from './ErrorJsonViewer';
@@ -99,6 +100,18 @@ const ErrorMessageExtra = memo<{ data: ChatMessage }>(({ data }) => {
 
     case AgentRuntimeErrorType.OllamaBizError: {
       return <OllamaBizError {...data} />;
+    }
+
+    // PHO-238: chat route emits InsufficientQuota with a `reasonCode` for daily
+    // USD cap / tier-block. Render the actionable BillingLimit UI; for any other
+    // InsufficientQuota (e.g. upstream provider quota), fall through to the
+    // default JSON viewer below.
+    case AgentRuntimeErrorType.InsufficientQuota: {
+      const reasonCode = (error.body as { reasonCode?: string } | undefined)?.reasonCode;
+      if (reasonCode === 'DAILY_CAP_EXCEEDED' || reasonCode === 'TIER_BLOCKED') {
+        return <BillingLimit data={data} />;
+      }
+      break;
     }
 
     /* ↓ cloud slot ↓ */


### PR DESCRIPTION
Frontend now renders an actionable **BillingLimit** UI for HTTP 429 from the chat route's daily USD cap (PHO-238 / PR #46) and tier-block (PHO-241 / PR #47) paths, replacing the previous raw-JSON dump from `<ErrorJsonViewer>`.

## Triggered by
nga.ntv (paying user) hit the T3 daily cap → got `$exception (null type)` in PostHog instead of a graceful Vietnamese message.

## Changes (3 files, +131/-1)

### 1. `packages/utils/src/fetch/parseError.ts`
Surface the backend-provided **specific** message on the alert. Backend has been embedding rich messages like `"Bạn đã dùng hết hạn mức Tier 3 hôm nay ($26.50/$26.00). Vui lòng dùng model Tier thấp hơn..."` in `body.error.message`, but `getMessageError` was overwriting them with the generic `t('response.InsufficientQuota')` translated key. Now prefers specific → falls back to generic.

Accepts three body shapes seen across callers:
- `body.error.message` ← chat route's `createErrorResponse(...)` shape
- `body.message` ← legacy / direct
- `body.error: string` ← raw routes (artifact-ai, research)

### 2. `src/features/Conversation/Error/BillingLimit.tsx` (new)
Pho-specific component following the existing `Error/*` pattern (`ErrorActionContainer` + `FormAction` from `style.tsx`). Renders:
- **Title** — \"Đã đạt giới hạn chi phí hôm nay\" / \"Gói hiện tại không hỗ trợ model này\" (toggled by `reasonCode`)
- **Description** — backend's specific Vietnamese message
- **Usage line** — `\$used / \$cap hôm nay` (when both numbers present)
- **CTA** — \"Nâng cấp gói\" → `upgradeUrl` (validated same-origin only to block payload-driven off-site redirects)
- **Dismiss** — \"Đóng\" → `useChatStore.deleteMessage(id)`

### 3. `src/features/Conversation/Error/index.tsx`
Add switch case for `AgentRuntimeErrorType.InsufficientQuota`:
- If `body.reasonCode === 'DAILY_CAP_EXCEEDED' | 'TIER_BLOCKED'` → render `<BillingLimit>`
- Else (upstream provider quota etc.) → fall through to the existing JSON viewer (no behavior change)

## Why this fixes nga.ntv's `\$exception`

The pre-stream 429 path is already structurally clean:
- `chat/[provider]/route.ts` → `createErrorResponse(InsufficientQuota, {...})` (HTTP 429)
- `fetchEventSource.onopen` → `!response.ok` → `throw await getMessageError(res)`
- `fetchEventSource` catches → calls `onerror` → `onErrorHandle?.(error)` (with `error.type === 'InsufficientQuota'`)
- chat store → sets on `ChatMessage.error` → renders via the switch

So no exception **escaped** the framework — but the previous default (`<ErrorJsonViewer>` showing `{ \"dailyCostCap\": 26, ... }` as JSON) made it **look** broken to the user, and any downstream auto-instrumentation that JSON-dumped the error could surface a low-quality `\$exception` event. Replacing that with a graceful component should cut both the perceived breakage and the noisy capture.

## Out of scope (flagged for follow-up)

1. **`/api/artifact-ai` and `/api/research/ai-summary` 429 shape**
   These routes return raw `{ reasonCode, error, retryAfter, ... }` (NOT wrapped in `createErrorResponse`'s `{ errorType, body }`). Frontend's `getMessageError` would see undefined `errorType` → no switch case matches. These features have their own UI flow distinct from the main chat. Should be aligned to `createErrorResponse(InsufficientQuota, ...)` in a follow-up so they reuse `<BillingLimit>` automatically.

2. **`/api/v1/chat` (OpenAI-compatible external API)**
   Different system (`phoWallet`), different consumer (curl/SDK users). Not in scope.

3. **Mid-stream cap errors**
   Daily USD cap is a **pre-flight** check (`checkDailyCostCap` runs before the LLM call), so cap rejections always come as HTTP 429 *before* the SSE stream starts. No mid-stream 429 plumbing needed.

## Verification

- ✓ `bun run type-check` clean (3 files touched)
- ✓ Pre-commit hooks: prettier + stylelint + eslint all passed
- ⚠ **No browser test** — reproducing requires triggering a real T3 cap on a deployed env; type-check + visual follow-the-pattern is the strongest check available locally. Recommend Hien tests in Preview by hitting T3 limit on a test account.

## Test plan post-merge

1. **Daily cap**: T3 user spams expensive model until \$cap reached → expect `<BillingLimit>` with title \"Đã đạt giới hạn chi phí hôm nay\", specific message from backend, \$used/\$cap line, working \"Nâng cấp gói\" → `/settings/subscription`.
2. **Tier block**: medical_beta user selects T3 model → expect title \"Gói hiện tại không hỗ trợ model này\" + upgrade CTA.
3. **PostHog**: monitor `\$exception` count from `InsufficientQuota` paths — should drop to ~0.
4. **Regression**: trigger any non-Pho `InsufficientQuota` (e.g. set OpenAI key with no quota) → should still fall through to JSON viewer (no `reasonCode`).

## Linear
PHO-238 (frontend follow-up to PR #46 / #47)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a friendly, action-first billing limit UI for 429 daily cap or tier block, with model alternatives and upgrade/buy-extra paths; fulfills PHO-238. Also updates `getMessageError` to avoid showing raw dollar amounts for these codes and uses backend `tier` to tailor suggestions.

- **New Features**
  - Render `BillingLimit` for `InsufficientQuota` with `DAILY_CAP_EXCEEDED` or `TIER_BLOCKED`.
  - Remove `$used / $cap`; use friendly title and description per reason.
  - Suggest tier-aware model alternatives; click switches model and dismisses the error.
  - Add “Mua thêm hạn mức” and “Nâng cấp gói” CTAs; same-origin URLs with `?source=billing-limit-*`.
  - Backend returns `tier` in the 429 body to drive suggestions.

- **Bug Fixes**
  - Replace raw JSON viewer for these 429s to reduce `$exception` noise.
  - In `getMessageError`, skip backend-specific message for billing-limit codes; fall back to the generic translation.

<sup>Written for commit bb4cc2a9c82dd0154f7863d99acfcab99b1bf654. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved error handling for billing and quota limits with contextual messaging.
  * Added model tier alternatives when requests are blocked due to usage caps or tier restrictions.
  * Enhanced error UI with clear upgrade and quota purchase options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->