### PR TITLE
🧹 cleanup: align artifact-ai + ai-summary 429 shape

### DIFF
--- a/src/app/api/artifact-ai/route.ts
+++ b/src/app/api/artifact-ai/route.ts
@@ -1,3 +1,4 @@
+import { AgentRuntimeErrorType } from '@lobechat/model-runtime';
 import { eq } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -14,6 +15,7 @@ import { checkDailyCostCap } from '@/server/services/billing/dailyCostAggregatio
 import { getSecondsUntilMidnightVN } from '@/server/services/billing/dailyCostCaps';
 import { phoGatewayService } from '@/server/services/phoGateway';
 import { getUserPlanIdFromDB } from '@/server/services/subscription/getUserPlanFromDB';
+import { createErrorResponse } from '@/utils/errorResponse';
 
 export const maxDuration = 60;
 
@@ -88,6 +90,7 @@ export async function POST(req: NextRequest) {
 
   // PHO-238 EMERGENCY: hard daily USD cap per (plan, tier). Pre-flight read,
   // safe to run before checkTierAccess (no tier-slot side effect).
+  // Shape mirrors chat/[provider] so <BillingLimit> renders the same UI here.
   const usdCapCheck = await checkDailyCostCap(userId, userPlanId, modelTier);
   if (!usdCapCheck.allowed) {
     console.warn(
@@ -95,25 +98,27 @@ export async function POST(req: NextRequest) {
         `($${usdCapCheck.dailyCostUsed.toFixed(2)}/$${usdCapCheck.dailyCostCap.toFixed(2)}, ` +
         `Plan: ${userPlanId}, Tier: ${modelTier}, User: ${userId})`,
     );
-    const retryAfter = getSecondsUntilMidnightVN();
-    return NextResponse.json(
-      {
-        dailyCostCap: usdCapCheck.dailyCostCap,
-        dailyCostUsed: usdCapCheck.dailyCostUsed,
-        error: usdCapCheck.reason,
-        reasonCode: usdCapCheck.reasonCode,
-        retryAfter,
+    return createErrorResponse(AgentRuntimeErrorType.InsufficientQuota, {
+      dailyCostCap: usdCapCheck.dailyCostCap,
+      dailyCostUsed: usdCapCheck.dailyCostUsed,
+      error: {
+        message: usdCapCheck.reason || 'Bạn đã đạt giới hạn chi phí hôm nay cho tier này.',
       },
-      { headers: { 'Retry-After': String(retryAfter) }, status: 429 },
-    );
+      provider: 'pho-chat',
+      reasonCode: usdCapCheck.reasonCode,
+      retryAfter: getSecondsUntilMidnightVN(),
+      tier: modelTier,
+      upgradeUrl: '/settings/subscription',
+    });
   }
 
   const tierAccess = await checkTierAccess(userId, modelTier, userPlanId);
   if (!tierAccess.allowed) {
-    return NextResponse.json(
-      { error: tierAccess.reason || 'Model này yêu cầu gói cao hơn.' },
-      { status: 403 },
-    );
+    return createErrorResponse(AgentRuntimeErrorType.InsufficientQuota, {
+      error: { message: tierAccess.reason || 'Model này yêu cầu gói cao hơn.' },
+      provider: 'pho-chat',
+      upgradeUrl: '/settings/subscription',
+    });
   }
   const tierSlotAcquired = tierAccess.slotAcquired || false;
 

--- a/src/app/api/research/ai-summary/route.ts
+++ b/src/app/api/research/ai-summary/route.ts
@@ -1,3 +1,4 @@
+import { AgentRuntimeErrorType } from '@lobechat/model-runtime';
 import { eq } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -14,6 +15,7 @@ import { checkDailyCostCap } from '@/server/services/billing/dailyCostAggregatio
 import { getSecondsUntilMidnightVN } from '@/server/services/billing/dailyCostCaps';
 import { phoGatewayService } from '@/server/services/phoGateway';
 import { getUserPlanIdFromDB } from '@/server/services/subscription/getUserPlanFromDB';
+import { createErrorResponse } from '@/utils/errorResponse';
 
 export const maxDuration = 300;
 
@@ -89,6 +91,7 @@ export async function POST(req: NextRequest) {
 
   // PHO-238 EMERGENCY: hard daily USD cap per (plan, tier). Pre-flight read,
   // safe to run before checkTierAccess (no tier-slot side effect).
+  // Shape mirrors chat/[provider] so <BillingLimit> renders the same UI here.
   const usdCapCheck = await checkDailyCostCap(userId, userPlanId, modelTier);
   if (!usdCapCheck.allowed) {
     console.warn(
@@ -96,25 +99,27 @@ export async function POST(req: NextRequest) {
         `($${usdCapCheck.dailyCostUsed.toFixed(2)}/$${usdCapCheck.dailyCostCap.toFixed(2)}, ` +
         `Plan: ${userPlanId}, Tier: ${modelTier}, User: ${userId})`,
     );
-    const retryAfter = getSecondsUntilMidnightVN();
-    return NextResponse.json(
-      {
-        dailyCostCap: usdCapCheck.dailyCostCap,
-        dailyCostUsed: usdCapCheck.dailyCostUsed,
-        error: usdCapCheck.reason,
-        reasonCode: usdCapCheck.reasonCode,
-        retryAfter,
+    return createErrorResponse(AgentRuntimeErrorType.InsufficientQuota, {
+      dailyCostCap: usdCapCheck.dailyCostCap,
+      dailyCostUsed: usdCapCheck.dailyCostUsed,
+      error: {
+        message: usdCapCheck.reason || 'Bạn đã đạt giới hạn chi phí hôm nay cho tier này.',
       },
-      { headers: { 'Retry-After': String(retryAfter) }, status: 429 },
-    );
+      provider: 'pho-chat',
+      reasonCode: usdCapCheck.reasonCode,
+      retryAfter: getSecondsUntilMidnightVN(),
+      tier: modelTier,
+      upgradeUrl: '/settings/subscription',
+    });
   }
 
   const tierAccess = await checkTierAccess(userId, modelTier, userPlanId);
   if (!tierAccess.allowed) {
-    return NextResponse.json(
-      { error: tierAccess.reason || 'Model này yêu cầu gói cao hơn.' },
-      { status: 403 },
-    );
+    return createErrorResponse(AgentRuntimeErrorType.InsufficientQuota, {
+      error: { message: tierAccess.reason || 'Model này yêu cầu gói cao hơn.' },
+      provider: 'pho-chat',
+      upgradeUrl: '/settings/subscription',
+    });
   }
   const tierSlotAcquired = tierAccess.slotAcquired || false;
 

--- a/src/features/Portal/Artifacts/Body/Renderer/React/buildIframeHtml.ts
+++ b/src/features/Portal/Artifacts/Body/Renderer/React/buildIframeHtml.ts
@@ -303,7 +303,15 @@ export function buildIframeHtml(encodedCode: string, title: string, identifier?:
           })
         })
         .then(function(r) { return r.json(); })
-        .then(function(d) { return d.text || d.error || 'No response'; });
+        .then(function(d) {
+          if (d && d.text) return d.text;
+          // Billing/tier errors use createErrorResponse shape:
+          //   { body: { error: { message } }, errorType }
+          // Auth/validation errors still use raw NextResponse: { error: '...' }
+          var nestedMsg = d && d.body && d.body.error && d.body.error.message;
+          var rawMsg = d && typeof d.error === 'string' ? d.error : null;
+          return nestedMsg || rawMsg || 'No response';
+        });
       }
     };
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change

PR #46 wired the daily USD cost cap into 3 routes, but only `chat/[provider]` returned via `createErrorResponse(InsufficientQuota, …)`. The artifact-ai and research/ai-summary routes returned a flat raw `NextResponse.json({ error: 'string', reasonCode, … }, { status: 429 })`, which the new `<BillingLimit>` UI (PR #49) cannot recognize — it expects:

```
{ body: { error: { message }, reasonCode, tier, … }, errorType: 'InsufficientQuota' }
```

This PR aligns both routes to the **exact** chat/[provider] shape so the same backend → parseError → BillingLimit pipeline works for all three routes.

##### What changed

- `src/app/api/artifact-ai/route.ts` — daily-cap (429) and tier-access paths both go through `createErrorResponse(InsufficientQuota, …)` with the canonical fields: `reasonCode`, `error: { message }`, `retryAfter`, `tier`, `upgradeUrl`, `dailyCostCap`, `dailyCostUsed`, `provider: 'pho-chat'`.
- `src/app/api/research/ai-summary/route.ts` — same migration.
- `src/features/Portal/Artifacts/Body/Renderer/React/buildIframeHtml.ts` — `window.phoChat.askAI` now extracts the message from the new nested shape (`d.body.error.message`) with a fallback to the legacy flat `d.error` string for auth/validation errors that still use `NextResponse.json`.

##### Reference shape (chat/[provider]:490–503, unchanged)

```ts
return createErrorResponse(AgentRuntimeErrorType.InsufficientQuota, {
  dailyCostCap: usdCapCheck.dailyCostCap,
  dailyCostUsed: usdCapCheck.dailyCostUsed,
  error: { message: usdCapCheck.reason || '…' },
  provider: 'pho-chat',
  reasonCode: usdCapCheck.reasonCode, // 'DAILY_CAP_EXCEEDED' | 'TIER_BLOCKED'
  retryAfter: getSecondsUntilMidnightVN(),
  tier: modelTier,
  upgradeUrl: '/settings/subscription',
});
```

#### 📝 补充信息 | Additional Information

**Status code change for the tier-access path**: previously returned **403** in artifact-ai and research/ai-summary. After this PR it returns **429** via `createErrorResponse(InsufficientQuota)`, matching `chat/[provider]:528–536`. Callers (`Writing/Screening/ManuscriptReviewer/EvidenceSummarizer/AiRobFiller`) only check `res.ok` and throw a generic `Error('API error: ' + res.status)`, so this status change is not a breaking change at the call sites.

**Out of scope (follow-up)**: the research/* callers above don't surface `<BillingLimit>` yet — they throw a plain Error which is rendered as a generic message. Wiring the iframe + research callers into a BillingLimit-style modal/toast is a separate task; this PR only normalizes the backend so that wiring lands cleanly in one place.

**Linear**: PHO-238

## Test plan

- [ ] Trigger daily cap on `/api/artifact-ai` → response is `429` with `{ body: { reasonCode: 'DAILY_CAP_EXCEEDED', error: { message }, tier, retryAfter, upgradeUrl }, errorType: 'InsufficientQuota' }`
- [ ] Trigger daily cap on `/api/research/ai-summary` → same shape
- [ ] Existing `chat/[provider]` flow unchanged (no diff to that file)
- [ ] React artifact `window.phoChat.askAI(...)` shows the Vietnamese cap message instead of `[object Object]` or "No response"
- [ ] `bun run type-check` passes locally (✓ verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies 429 InsufficientQuota responses for artifact and research routes to match the chat route so the `<BillingLimit>` UI reliably detects and renders quota/tier limits. Also updates the iframe helper to read the new nested error message. (Linear: PHO-238)

- **Bug Fixes**
  - `/api/artifact-ai` and `/api/research/ai-summary` now use `createErrorResponse(InsufficientQuota)` with the same fields as `chat/[provider]`: `reasonCode`, `error.message`, `tier`, `retryAfter`, `upgradeUrl`, `dailyCostCap`, `dailyCostUsed`, `provider: 'pho-chat'`.
  - Tier-block path now returns 429 (was 403) to align with chat; callers only use `res.ok`, so no breaking change.
  - `window.phoChat.askAI` extracts `d.body.error.message` with a fallback to legacy `d.error`.
  - No changes to `chat/[provider]`.

<sup>Written for commit 6a04d31d4ec339ff366c73240d9badb7a9bc106c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

