### PR TITLE
🔍 chore(observability): PHO-247 promo Clerk-drift telemetry

### DIFF
--- a/src/app/api/promo/activate/route.ts
+++ b/src/app/api/promo/activate/route.ts
@@ -17,6 +17,14 @@ import { getUserPlanFromDB } from '@/server/services/subscription/getUserPlanFro
  * If the Clerk write fails after DB succeeds, we log a warning but still
  * return success to the user; a reconciliation cron resyncs Clerk later.
  *
+ * PHO-247: drift observability layer on top of PHO-241. When the Clerk
+ * sync fails after a successful DB write we additionally emit a
+ * `promo_clerk_sync_failed` PostHog event so admin can monitor frequency
+ * and trigger manual reconciliation when the rate exceeds threshold.
+ * The Clerk metadata also carries `planSyncedAt` (epoch ms) so the
+ * client-side cache can detect a stale value and refetch from the
+ * DB-backed `/api/subscription` endpoint.
+ *
  * Also sends a welcome email on successful activation.
  *
  * Currently supports:
@@ -251,6 +259,11 @@ export async function POST(request: NextRequest) {
         publicMetadata: {
           ...clerkUser.publicMetadata,
           planId,
+          // PHO-247: epoch ms of the last successful DB→Clerk sync. The
+          // client cache can compare this against the DB-backed
+          // /api/subscription response to detect stale Clerk metadata and
+          // force a refetch instead of trusting the cached value.
+          planSyncedAt: Date.now(),
           previousPlanId: existingPlan.planId,
           promoActivatedAt: new Date().toISOString(),
           promoCode: normalizedCode,
@@ -265,6 +278,28 @@ export async function POST(request: NextRequest) {
           userId,
         clerkError,
       );
+
+      // PHO-247: emit a structured PostHog event so admin can monitor
+      // drift frequency. Wrapped in its own try/catch — analytics MUST
+      // NOT mask the underlying Clerk failure or break the response.
+      try {
+        const { serverAnalytics } = await import('@/libs/analytics');
+        serverAnalytics.track({
+          name: 'promo_clerk_sync_failed',
+          properties: {
+            error_message: clerkError instanceof Error ? clerkError.message : String(clerkError),
+            previous_plan_id: existingPlan.planId,
+            promo_code: normalizedCode,
+            target_plan_id: planId,
+          },
+          userId,
+        });
+      } catch (analyticsError) {
+        console.error(
+          '⚠️ [Promo] PostHog drift event capture failed (non-critical):',
+          analyticsError,
+        );
+      }
     }
 
     // =============================================


### PR DESCRIPTION
## Context

PHO-247 was filed as a P1 security fix for promo Clerk-drift (vuthanhhuong / PHO-233 incident). On audit, the **DB-first inversion was already shipped in PHO-241/A1.6** (commit `03d360753a`, four weeks ago):

- `STEP 1 (AUTHORITATIVE)` writes users + subscriptions and throws on failure → outer catch returns 500
- `STEP 2 (DISPLAY ONLY)` writes Clerk metadata; failure is logged + swallowed → 200 OK
- DB is never rolled back on Clerk failure

What was missing was **observability**: today there is no signal telling admin that a drift event happened. This PR adds that signal.

## Changes

`src/app/api/promo/activate/route.ts` (+35 lines)

1. Emit `promo_clerk_sync_failed` PostHog event in the Clerk catch block.
   - Properties: `target_plan_id`, `previous_plan_id`, `promo_code`, `error_message`, `userId`
   - Wrapped in its own try/catch so analytics can't mask the underlying Clerk error
   - Uses existing `serverAnalytics.track` pattern from `src/app/api/payment/sepay/webhook/route.ts:252`
2. Add `planSyncedAt` (epoch ms) to Clerk `publicMetadata` so the client cache can detect stale values and refetch from `/api/subscription` instead of trusting the cached metadata.
3. Update header comment to document PHO-247 layering on top of PHO-241.

## Intentionally out of scope

- **`plan_activated_at` / `plan_activated_by` columns on `users`** — would require a schema migration. The existing audit trail (`promoActivations.activatedAt`, `subscriptions.currentPeriodStart`, `subscriptions.updatedAt`) covers the same ground without one.
- **Nightly Clerk reconciliation cron** — separate ticket.
- **One-time SQL audit of historical drift cases** — should run on Neon Console post-merge (query below), not in code.

## Audit query for historical drift (run on Neon Console after merge)

\`\`\`sql
-- Find users whose subscription says paid but DB plan is free
SELECT
  u.id,
  u.email,
  u.current_plan_id,
  s.plan_id AS subscription_plan,
  s.payment_provider,
  s.current_period_start
FROM users u
JOIN subscriptions s ON s.user_id = u.id
WHERE s.status = 'active'
  AND s.payment_provider = 'promo'
  AND u.current_plan_id = 'vn_free'
ORDER BY s.current_period_start DESC;
\`\`\`

Each row = one drift case to investigate manually.

## Test plan

- [ ] DB success + Clerk success → user activated, no PostHog event fired
- [ ] DB success + Clerk failure → user activated (DB truth), warning logged, `promo_clerk_sync_failed` fired
- [ ] DB failure first → 500 returned, Clerk untouched, no PostHog event
- [ ] Verify event arrives in PostHog: project \"Phở Chat\" (id 306983), event name `promo_clerk_sync_failed`
- [ ] Post-deploy monitor: PostHog dashboard alert when event count > 10/day → triggers manual reconciliation

## Verification

- `bunx tsgo --noEmit` → 0 errors
- `bunx eslint src/app/api/promo/activate/route.ts` → exit 0
- Pre-commit hook (prettier + eslint + stylelint) → all green

Linear: PHO-247
Parent epic: PHO-238

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds observability for promo Clerk-drift in activation. On Clerk sync failure, we emit a PostHog `promo_clerk_sync_failed` event and write `planSyncedAt` to Clerk `publicMetadata` so clients can detect stale data (PHO-247).

- **New Features**
  - Emit `promo_clerk_sync_failed` with properties: `target_plan_id`, `previous_plan_id`, `promo_code`, `error_message`, `userId` (in a safe try/catch so it never masks the Clerk error).
  - Add `planSyncedAt` (epoch ms) to Clerk `publicMetadata` to let the client refetch from the DB-backed `/api/subscription` when metadata is stale.

<sup>Written for commit 758cb1ddb1f180580a955c2c9435295518bef5af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

