### PR TITLE
🔒 fix(billing): remove hardcoded bypass token, enforce role-based check

### DIFF
--- a/scripts/test-failover.ts
+++ b/scripts/test-failover.ts
@@ -20,7 +20,10 @@ async function runBenchmark(testName: string, model: string, provider?: string) 
       console.error(
         '❌ PHO_GATEWAY_LABS_ADMIN_USER_ID not set in env — labs bypass requires admin attribution.',
       );
-      return;
+      // Fail fast so misconfigured CI cannot silently turn the benchmark into a
+      // no-op. Without this, the outer `main()` would continue and the process
+      // would exit 0 with no useful work done.
+      process.exit(1);
     }
 
     const response = await fetch(API_URL, {

--- a/scripts/test-failover.ts
+++ b/scripts/test-failover.ts
@@ -15,6 +15,14 @@ async function runBenchmark(testName: string, model: string, provider?: string) 
   const startTime = Date.now();
 
   try {
+    const adminUserId = process.env.PHO_GATEWAY_LABS_ADMIN_USER_ID;
+    if (!adminUserId) {
+      console.error(
+        '❌ PHO_GATEWAY_LABS_ADMIN_USER_ID not set in env — labs bypass requires admin attribution.',
+      );
+      return;
+    }
+
     const response = await fetch(API_URL, {
       body: JSON.stringify({
         messages: [{ content: 'Say "Hi" in strictly 2 words.', role: 'user' }],
@@ -25,6 +33,7 @@ async function runBenchmark(testName: string, model: string, provider?: string) 
       headers: {
         'Authorization': `Bearer ${process.env.PHO_GATEWAY_LABS_TOKEN}`,
         'Content-Type': 'application/json',
+        'X-Admin-User-Id': adminUserId,
       },
       method: 'POST',
     });

--- a/src/app/api/labs/pho-gateway/route.test.ts
+++ b/src/app/api/labs/pho-gateway/route.test.ts
@@ -33,9 +33,10 @@ vi.mock('@/utils/errorResponse', () => ({
   createErrorResponse: () => new Response('err', { status: 500 }),
 }));
 
-const buildRequest = (headers: Record<string, string>, body: unknown = { model: 'm' }): Request =>
+const DEFAULT_BODY = { model: 'm' };
+const buildRequest = (headers: Record<string, string>, body?: unknown): Request =>
   new Request('https://pho.chat/api/labs/pho-gateway', {
-    body: JSON.stringify(body),
+    body: JSON.stringify(body ?? DEFAULT_BODY),
     headers: { 'content-type': 'application/json', ...headers },
     method: 'POST',
   });

--- a/src/app/api/labs/pho-gateway/route.test.ts
+++ b/src/app/api/labs/pho-gateway/route.test.ts
@@ -135,20 +135,25 @@ describe('POST /api/labs/pho-gateway — admin-gated bypass', () => {
     const { captureServerEvent } = await import('@/libs/posthog-server');
 
     // Mismatched token → falls through to authenticatedHandler (which our mock
-    // is the identity wrapper around `coreHandler`). We only need to assert
-    // that the security event fires.
+    // is the identity wrapper around `coreHandler`). The handler reads the
+    // body and returns a Response; we assert on the security event AND on
+    // the promise resolving (no swallowed rejection).
     const res = await POST(
-      buildRequest({ Authorization: 'Bearer wrong_token' }, { model: 'm' }),
+      buildRequest(
+        { Authorization: 'Bearer wrong_token', 'X-Admin-User-Id': 'user_attacker' },
+        { model: 'm' },
+      ),
       {},
-    ).catch(() => null);
+    );
 
+    expect(res).toBeDefined();
     expect(captureServerEvent).toHaveBeenCalledWith(
       'billing_bypass_denied',
       'anonymous',
-      expect.objectContaining({ reason: 'invalid_labs_token' }),
+      expect.objectContaining({
+        reason: 'invalid_labs_token',
+        untrusted_admin_user_id: 'user_attacker',
+      }),
     );
-    // Response is whatever the (mocked) authenticated handler produces; we
-    // don't assert on its status here.
-    void res;
   });
 });

--- a/src/app/api/labs/pho-gateway/route.test.ts
+++ b/src/app/api/labs/pho-gateway/route.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the role-gated labs bypass on /api/labs/pho-gateway.
+ *
+ * The labs token alone is no longer sufficient — the caller must also
+ * present an `X-Admin-User-Id` header that resolves to an admin via
+ * `isAdmin()`. This file covers the security paths only; the inference
+ * fan-out is exercised by the existing failover script.
+ */
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/app/(backend)/middleware/auth', () => ({
+  checkAuth: (handler: any) => handler,
+}));
+
+vi.mock('@/libs/posthog-server', () => ({
+  captureServerEvent: vi.fn(),
+}));
+
+vi.mock('@/server/services/auth/adminGuard', () => ({
+  isAdmin: vi.fn(),
+}));
+
+vi.mock('@/server/modules/ModelRuntime', () => ({
+  initModelRuntimeWithUserPayload: vi.fn(),
+}));
+
+vi.mock('@/server/services/phoGateway', () => ({
+  phoGatewayService: { resolveProviderList: vi.fn(() => []) },
+}));
+
+vi.mock('@/utils/errorResponse', () => ({
+  createErrorResponse: () => new Response('err', { status: 500 }),
+}));
+
+const buildRequest = (headers: Record<string, string>, body: unknown = { model: 'm' }): Request =>
+  new Request('https://pho.chat/api/labs/pho-gateway', {
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json', ...headers },
+    method: 'POST',
+  });
+
+describe('POST /api/labs/pho-gateway — admin-gated bypass', () => {
+  const originalToken = process.env.PHO_GATEWAY_LABS_TOKEN;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.PHO_GATEWAY_LABS_TOKEN = 'test_token_value';
+  });
+
+  afterEach(() => {
+    process.env.PHO_GATEWAY_LABS_TOKEN = originalToken;
+  });
+
+  it('returns 503 when PHO_GATEWAY_LABS_TOKEN is not configured', async () => {
+    delete process.env.PHO_GATEWAY_LABS_TOKEN;
+    const { POST } = await import('./route');
+
+    const res = await POST(buildRequest({ Authorization: 'Bearer anything' }), {});
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 403 when token matches but X-Admin-User-Id header is missing', async () => {
+    const { POST } = await import('./route');
+    const { captureServerEvent } = await import('@/libs/posthog-server');
+
+    const res = await POST(buildRequest({ Authorization: 'Bearer test_token_value' }), {});
+
+    expect(res.status).toBe(403);
+    expect(captureServerEvent).toHaveBeenCalledWith(
+      'billing_bypass_denied',
+      'anonymous',
+      expect.objectContaining({ reason: 'missing_admin_user_id_header' }),
+    );
+  });
+
+  it('returns 403 when X-Admin-User-Id resolves to a non-admin', async () => {
+    const { POST } = await import('./route');
+    const { isAdmin } = await import('@/server/services/auth/adminGuard');
+    const { captureServerEvent } = await import('@/libs/posthog-server');
+    vi.mocked(isAdmin).mockResolvedValue(false);
+
+    const res = await POST(
+      buildRequest({
+        Authorization: 'Bearer test_token_value',
+        'X-Admin-User-Id': 'user_normal',
+      }),
+      {},
+    );
+
+    expect(res.status).toBe(403);
+    expect(isAdmin).toHaveBeenCalledWith('user_normal');
+    expect(captureServerEvent).toHaveBeenCalledWith(
+      'billing_bypass_denied',
+      'user_normal',
+      expect.objectContaining({ reason: 'non_admin_user_id' }),
+    );
+  });
+
+  it('logs billing_bypass_used and proceeds when token + admin header are valid', async () => {
+    const { POST } = await import('./route');
+    const { isAdmin } = await import('@/server/services/auth/adminGuard');
+    const { captureServerEvent } = await import('@/libs/posthog-server');
+    const { phoGatewayService } = await import('@/server/services/phoGateway');
+    vi.mocked(isAdmin).mockResolvedValue(true);
+    // Empty priority list → handleRequest falls through to createErrorResponse,
+    // which our mock returns as a 500. We're asserting on the bypass log, not
+    // on inference success.
+    vi.mocked(phoGatewayService.resolveProviderList).mockReturnValue([]);
+
+    await POST(
+      buildRequest(
+        {
+          Authorization: 'Bearer test_token_value',
+          'X-Admin-User-Id': 'user_admin',
+        },
+        { model: 'pho-test-fast', provider: 'groq' },
+      ),
+      {},
+    );
+
+    expect(captureServerEvent).toHaveBeenCalledWith(
+      'billing_bypass_used',
+      'user_admin',
+      expect.objectContaining({
+        endpoint: '/api/labs/pho-gateway',
+        model: 'pho-test-fast',
+        provider: 'groq',
+      }),
+    );
+  });
+
+  it('captures billing_bypass_denied when a Bearer token is presented but does not match', async () => {
+    const { POST } = await import('./route');
+    const { captureServerEvent } = await import('@/libs/posthog-server');
+
+    // Mismatched token → falls through to authenticatedHandler (which our mock
+    // is the identity wrapper around `coreHandler`). We only need to assert
+    // that the security event fires.
+    const res = await POST(
+      buildRequest({ Authorization: 'Bearer wrong_token' }, { model: 'm' }),
+      {},
+    ).catch(() => null);
+
+    expect(captureServerEvent).toHaveBeenCalledWith(
+      'billing_bypass_denied',
+      'anonymous',
+      expect.objectContaining({ reason: 'invalid_labs_token' }),
+    );
+    // Response is whatever the (mocked) authenticated handler produces; we
+    // don't assert on its status here.
+    void res;
+  });
+});

--- a/src/app/api/labs/pho-gateway/route.test.ts
+++ b/src/app/api/labs/pho-gateway/route.test.ts
@@ -50,7 +50,14 @@ describe('POST /api/labs/pho-gateway — admin-gated bypass', () => {
   });
 
   afterEach(() => {
-    process.env.PHO_GATEWAY_LABS_TOKEN = originalToken;
+    // Assigning `undefined` to a process.env key coerces to the string
+    // 'undefined' and leaks state across tests. Delete-or-restore preserves
+    // the original-unset case correctly.
+    if (originalToken === undefined) {
+      delete process.env.PHO_GATEWAY_LABS_TOKEN;
+    } else {
+      process.env.PHO_GATEWAY_LABS_TOKEN = originalToken;
+    }
   });
 
   it('returns 503 when PHO_GATEWAY_LABS_TOKEN is not configured', async () => {

--- a/src/app/api/labs/pho-gateway/route.ts
+++ b/src/app/api/labs/pho-gateway/route.ts
@@ -2,7 +2,9 @@ import { AgentRuntimeErrorType, ModelRuntime } from '@lobechat/model-runtime';
 import { ChatErrorType } from '@lobechat/types';
 
 import { checkAuth } from '@/app/(backend)/middleware/auth';
+import { captureServerEvent } from '@/libs/posthog-server';
 import { initModelRuntimeWithUserPayload } from '@/server/modules/ModelRuntime';
+import { isAdmin } from '@/server/services/auth/adminGuard';
 import { phoGatewayService } from '@/server/services/phoGateway';
 import { ChatStreamPayload } from '@/types/openai/chat';
 import { createErrorResponse } from '@/utils/errorResponse';
@@ -97,9 +99,15 @@ const coreHandler = async (req: Request, { jwtPayload }: any) => {
 const authenticatedHandler = checkAuth(coreHandler);
 
 export const POST = async (req: Request, options: any) => {
-  // Benchmark Bypass Logic (for test-failover script)
+  // Benchmark bypass for the CI test-failover script. Two-factor:
+  //   1. Shared `PHO_GATEWAY_LABS_TOKEN` (env-only, rotatable).
+  //   2. `X-Admin-User-Id` header → must resolve to an admin via Clerk
+  //      (`isAdmin()` checks env allowlist + Clerk role metadata).
+  // Token alone is NOT sufficient — that was the cost-leak we're closing.
   const authHeader = req.headers.get('Authorization') || req.headers.get('authorization');
   const labsToken = process.env.PHO_GATEWAY_LABS_TOKEN;
+  const adminUserIdHeader = req.headers.get('x-admin-user-id');
+  const tokenPresented = !!authHeader && authHeader.startsWith('Bearer ');
 
   if (!labsToken) {
     console.error('[labs/pho-gateway] PHO_GATEWAY_LABS_TOKEN not configured');
@@ -109,10 +117,56 @@ export const POST = async (req: Request, options: any) => {
     });
   }
 
-  if (authHeader === `Bearer ${labsToken}`) {
-    console.log('[Labs/PhoGateway] ✅ Authorized via PHO_GATEWAY_LABS_TOKEN bypass');
+  const tokenMatches = authHeader === `Bearer ${labsToken}`;
+
+  if (tokenMatches) {
+    if (!adminUserIdHeader) {
+      captureServerEvent('billing_bypass_denied', 'anonymous', {
+        endpoint: '/api/labs/pho-gateway',
+        reason: 'missing_admin_user_id_header',
+      });
+      console.warn('[Labs/PhoGateway] ❌ Token presented without X-Admin-User-Id header');
+      return new Response(
+        JSON.stringify({ error: 'X-Admin-User-Id header required for labs bypass' }),
+        { headers: { 'Content-Type': 'application/json' }, status: 403 },
+      );
+    }
+
+    const adminAuthorized = await isAdmin(adminUserIdHeader);
+    if (!adminAuthorized) {
+      captureServerEvent('billing_bypass_denied', adminUserIdHeader, {
+        endpoint: '/api/labs/pho-gateway',
+        reason: 'non_admin_user_id',
+      });
+      console.warn(
+        `[Labs/PhoGateway] ❌ Bypass denied: userId ${adminUserIdHeader} is not an admin`,
+      );
+      return new Response(
+        JSON.stringify({ error: 'Forbidden: admin role required for labs bypass' }),
+        { headers: { 'Content-Type': 'application/json' }, status: 403 },
+      );
+    }
+
     const data = (await req.json()) as ChatStreamPayload;
-    return handleRequest(data, {} as any);
+    captureServerEvent('billing_bypass_used', adminUserIdHeader, {
+      endpoint: '/api/labs/pho-gateway',
+      model: data?.model,
+      provider: data?.provider,
+    });
+    console.log(
+      `[Labs/PhoGateway] ✅ Authorized via PHO_GATEWAY_LABS_TOKEN bypass (admin=${adminUserIdHeader})`,
+    );
+    return handleRequest(data, { userId: adminUserIdHeader } as any);
+  }
+
+  // Token mismatch with a Bearer header — likely an attacker probing the
+  // endpoint. Capture for security visibility, then fall through to the
+  // standard authenticated handler so legitimate Clerk-JWT callers still work.
+  if (tokenPresented) {
+    captureServerEvent('billing_bypass_denied', adminUserIdHeader || 'anonymous', {
+      endpoint: '/api/labs/pho-gateway',
+      reason: 'invalid_labs_token',
+    });
   }
 
   return authenticatedHandler(req, options);

--- a/src/app/api/labs/pho-gateway/route.ts
+++ b/src/app/api/labs/pho-gateway/route.ts
@@ -2,6 +2,7 @@ import { AgentRuntimeErrorType, ModelRuntime } from '@lobechat/model-runtime';
 import { ChatErrorType } from '@lobechat/types';
 
 import { checkAuth } from '@/app/(backend)/middleware/auth';
+import { pino } from '@/libs/logger';
 import { captureServerEvent } from '@/libs/posthog-server';
 import { initModelRuntimeWithUserPayload } from '@/server/modules/ModelRuntime';
 import { isAdmin } from '@/server/services/auth/adminGuard';
@@ -110,7 +111,10 @@ export const POST = async (req: Request, options: any) => {
   const tokenPresented = !!authHeader && authHeader.startsWith('Bearer ');
 
   if (!labsToken) {
-    console.error('[labs/pho-gateway] PHO_GATEWAY_LABS_TOKEN not configured');
+    pino.error(
+      { endpoint: '/api/labs/pho-gateway' },
+      'PHO_GATEWAY_LABS_TOKEN not configured — labs bypass disabled',
+    );
     return new Response(JSON.stringify({ error: 'Service not configured' }), {
       headers: { 'Content-Type': 'application/json' },
       status: 503,
@@ -125,7 +129,10 @@ export const POST = async (req: Request, options: any) => {
         endpoint: '/api/labs/pho-gateway',
         reason: 'missing_admin_user_id_header',
       });
-      console.warn('[Labs/PhoGateway] ❌ Token presented without X-Admin-User-Id header');
+      pino.warn(
+        { endpoint: '/api/labs/pho-gateway' },
+        'Labs bypass denied: token presented without X-Admin-User-Id header',
+      );
       return new Response(
         JSON.stringify({ error: 'X-Admin-User-Id header required for labs bypass' }),
         { headers: { 'Content-Type': 'application/json' }, status: 403 },
@@ -138,8 +145,9 @@ export const POST = async (req: Request, options: any) => {
         endpoint: '/api/labs/pho-gateway',
         reason: 'non_admin_user_id',
       });
-      console.warn(
-        `[Labs/PhoGateway] ❌ Bypass denied: userId ${adminUserIdHeader} is not an admin`,
+      pino.warn(
+        { adminUserIdHeader, endpoint: '/api/labs/pho-gateway' },
+        'Labs bypass denied: claimed userId is not an admin',
       );
       return new Response(
         JSON.stringify({ error: 'Forbidden: admin role required for labs bypass' }),
@@ -153,8 +161,9 @@ export const POST = async (req: Request, options: any) => {
       model: data?.model,
       provider: data?.provider,
     });
-    console.log(
-      `[Labs/PhoGateway] ✅ Authorized via PHO_GATEWAY_LABS_TOKEN bypass (admin=${adminUserIdHeader})`,
+    pino.info(
+      { adminUserId: adminUserIdHeader, model: data?.model, provider: data?.provider },
+      'Labs bypass authorized via PHO_GATEWAY_LABS_TOKEN',
     );
     return handleRequest(data, { userId: adminUserIdHeader } as any);
   }
@@ -162,10 +171,15 @@ export const POST = async (req: Request, options: any) => {
   // Token mismatch with a Bearer header — likely an attacker probing the
   // endpoint. Capture for security visibility, then fall through to the
   // standard authenticated handler so legitimate Clerk-JWT callers still work.
+  // Distinct-id is fixed to 'anonymous' because no identity has been verified
+  // yet — using the attacker-controlled header as identity would let probes
+  // pollute another user's PostHog timeline. The header is preserved as an
+  // explicitly untrusted property for forensics.
   if (tokenPresented) {
-    captureServerEvent('billing_bypass_denied', adminUserIdHeader || 'anonymous', {
+    captureServerEvent('billing_bypass_denied', 'anonymous', {
       endpoint: '/api/labs/pho-gateway',
       reason: 'invalid_labs_token',
+      untrusted_admin_user_id: adminUserIdHeader || null,
     });
   }
 

--- a/src/app/api/labs/pho-gateway/route.ts
+++ b/src/app/api/labs/pho-gateway/route.ts
@@ -1,5 +1,6 @@
 import { AgentRuntimeErrorType, ModelRuntime } from '@lobechat/model-runtime';
 import { ChatErrorType } from '@lobechat/types';
+import { timingSafeEqual } from 'node:crypto';
 
 import { checkAuth } from '@/app/(backend)/middleware/auth';
 import { pino } from '@/libs/logger';
@@ -11,6 +12,22 @@ import { ChatStreamPayload } from '@/types/openai/chat';
 import { createErrorResponse } from '@/utils/errorResponse';
 
 export const maxDuration = 300;
+
+/**
+ * Constant-time string equality. JS `===` short-circuits on the first
+ * differing byte, which would let a network-adjacent attacker recover a
+ * shared secret one byte at a time via response-latency measurements.
+ *
+ * Length is leaked (different-length strings return immediately), which is
+ * fine here: the expected value is `Bearer <fixed-token>`, so the length
+ * is structural rather than secret.
+ */
+const constantTimeEqual = (a: string, b: string): boolean => {
+  const aBuf = Buffer.from(a);
+  const bBuf = Buffer.from(b);
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
+};
 
 async function handleRequest(data: ChatStreamPayload, jwtPayload: any) {
   const { model, provider: requestedProvider } = data;
@@ -121,7 +138,7 @@ export const POST = async (req: Request, options: any) => {
     });
   }
 
-  const tokenMatches = authHeader === `Bearer ${labsToken}`;
+  const tokenMatches = !!authHeader && constantTimeEqual(authHeader, `Bearer ${labsToken}`);
 
   if (tokenMatches) {
     if (!adminUserIdHeader) {

--- a/src/app/api/subscription/models/allowed/route.ts
+++ b/src/app/api/subscription/models/allowed/route.ts
@@ -9,6 +9,7 @@ import { NextResponse } from 'next/server';
 
 import { PLAN_MODEL_ACCESS, getAllowedTiersForPlan } from '@/config/pricing';
 import { pino } from '@/libs/logger';
+import { captureServerEvent } from '@/libs/posthog-server';
 import { getUserPlanIdFromDB } from '@/server/services/subscription/getUserPlanFromDB';
 import { subscriptionModelAccessService } from '@/services/subscription/modelAccess';
 
@@ -34,15 +35,42 @@ interface AllowedModelsResponse {
  */
 export async function GET(): Promise<NextResponse<AllowedModelsResponse>> {
   try {
-    // STAGING BYPASS: Allow all models in preview/development environments for testing
-    // Requires explicit STAGING_TIER_BYPASS=true to prevent accidental production leaks
-    const isPreviewEnv =
-      process.env.STAGING_TIER_BYPASS === 'true' &&
-      (process.env.VERCEL_ENV === 'preview' ||
-        process.env.VERCEL_ENV === 'development' ||
-        process.env.NODE_ENV === 'development');
+    // STAGING BYPASS: Allow all models in preview/development environments for testing.
+    // Requires explicit STAGING_TIER_BYPASS=true. Hard guard: refuse to honor
+    // the env var on production deployments even if someone sets it by
+    // accident — never silently bypass billing.
+    const stagingFlag = process.env.STAGING_TIER_BYPASS === 'true';
+    const isNonProdEnv =
+      process.env.VERCEL_ENV === 'preview' ||
+      process.env.VERCEL_ENV === 'development' ||
+      process.env.NODE_ENV === 'development';
+    const isPreviewEnv = stagingFlag && isNonProdEnv;
+
+    if (stagingFlag && !isNonProdEnv) {
+      captureServerEvent('billing_bypass_denied', 'anonymous', {
+        endpoint: '/api/subscription/models/allowed',
+        node_env: process.env.NODE_ENV,
+        reason: 'staging_flag_in_production',
+        vercel_env: process.env.VERCEL_ENV,
+      });
+      pino.error(
+        { vercel_env: process.env.VERCEL_ENV },
+        'STAGING_TIER_BYPASS=true on production deployment — refusing bypass',
+      );
+      return NextResponse.json(
+        { error: 'Misconfigured: STAGING_TIER_BYPASS not allowed in production', success: false },
+        { status: 500 },
+      );
+    }
 
     if (isPreviewEnv) {
+      // userId may not be resolved yet (auth() runs below); use 'anonymous' so
+      // the event still lands and we can debug staging usage.
+      captureServerEvent('billing_bypass_used', 'anonymous', {
+        endpoint: '/api/subscription/models/allowed',
+        mode: 'staging_env_var',
+        vercel_env: process.env.VERCEL_ENV,
+      });
       console.warn(
         '⚠️ [STAGING BYPASS ACTIVE] Returning all tiers — STAGING_TIER_BYPASS=true, ' +
           `VERCEL_ENV=${process.env.VERCEL_ENV}, NODE_ENV=${process.env.NODE_ENV}`,

--- a/src/app/api/subscription/models/check/route.ts
+++ b/src/app/api/subscription/models/check/route.ts
@@ -9,6 +9,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { getModelTier } from '@/config/pricing';
 import { pino } from '@/libs/logger';
+import { captureServerEvent } from '@/libs/posthog-server';
 import { subscriptionModelAccessService } from '@/services/subscription/modelAccess';
 
 /**
@@ -72,14 +73,42 @@ export async function POST(request: NextRequest): Promise<NextResponse<CheckMode
     );
 
     // PREVIEW BYPASS: Allow all models in preview/development environments for testing
-    // Requires explicit STAGING_TIER_BYPASS=true to prevent accidental production leaks
-    const isPreviewEnv =
-      process.env.STAGING_TIER_BYPASS === 'true' &&
-      (process.env.VERCEL_ENV === 'preview' ||
-        process.env.VERCEL_ENV === 'development' ||
-        process.env.NODE_ENV === 'development');
+    // Requires explicit STAGING_TIER_BYPASS=true to prevent accidental production leaks.
+    // Hard guard: refuse to honor the env var on production deployments even if
+    // someone sets it by accident in Vercel — never silently bypass billing.
+    const stagingFlag = process.env.STAGING_TIER_BYPASS === 'true';
+    const isNonProdEnv =
+      process.env.VERCEL_ENV === 'preview' ||
+      process.env.VERCEL_ENV === 'development' ||
+      process.env.NODE_ENV === 'development';
+    const isPreviewEnv = stagingFlag && isNonProdEnv;
+
+    if (stagingFlag && !isNonProdEnv) {
+      // STAGING_TIER_BYPASS=true was set on a production deployment. Loud
+      // failure is correct: throw rather than silently bypass.
+      captureServerEvent('billing_bypass_denied', userId, {
+        endpoint: '/api/subscription/models/check',
+        node_env: process.env.NODE_ENV,
+        reason: 'staging_flag_in_production',
+        vercel_env: process.env.VERCEL_ENV,
+      });
+      pino.error(
+        { userId, vercel_env: process.env.VERCEL_ENV },
+        'STAGING_TIER_BYPASS=true on production deployment — refusing bypass',
+      );
+      return NextResponse.json(
+        { error: 'Misconfigured: STAGING_TIER_BYPASS not allowed in production', success: false },
+        { status: 500 },
+      );
+    }
 
     if (isPreviewEnv) {
+      captureServerEvent('billing_bypass_used', userId, {
+        endpoint: '/api/subscription/models/check',
+        mode: 'staging_env_var',
+        model_id: modelId,
+        vercel_env: process.env.VERCEL_ENV,
+      });
       console.warn('⚠️ [STAGING BYPASS ACTIVE] model check bypass — STAGING_TIER_BYPASS=true');
     }
 

--- a/src/app/api/subscription/upgrade/route.test.ts
+++ b/src/app/api/subscription/upgrade/route.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the bypassPayment hotfix on /api/subscription/upgrade.
+ *
+ * Pre-fix: any authenticated user could send `{ bypassPayment: true }` to
+ * skip the Sepay payment step and self-promote to a paid plan. The fix
+ * removes the flag from the public contract entirely and rejects any
+ * request that still includes it with a 403 + PostHog audit event.
+ */
+// @vitest-environment node
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { POST } from './route';
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock('@/database/server', () => ({
+  getServerDB: vi.fn(),
+}));
+
+vi.mock('@/libs/logger', () => ({
+  pino: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('@/libs/posthog-server', () => ({
+  captureServerEvent: vi.fn(),
+}));
+
+const buildRequest = (body: unknown): NextRequest =>
+  ({
+    headers: new Headers({ host: 'pho.chat', 'x-forwarded-proto': 'https' }),
+    json: async () => body,
+  }) as unknown as NextRequest;
+
+describe('POST /api/subscription/upgrade — bypassPayment hotfix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when caller is not authenticated', async () => {
+    const { auth } = await import('@clerk/nextjs/server');
+    vi.mocked(auth).mockResolvedValue({ userId: null } as any);
+
+    const res = await POST(buildRequest({ newPlanId: 'vn_pro', billingCycle: 'monthly' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects authenticated request that includes bypassPayment:true with 403', async () => {
+    const { auth } = await import('@clerk/nextjs/server');
+    const { captureServerEvent } = await import('@/libs/posthog-server');
+    vi.mocked(auth).mockResolvedValue({ userId: 'user_normal' } as any);
+
+    const res = await POST(
+      buildRequest({ newPlanId: 'vn_pro', billingCycle: 'monthly', bypassPayment: true }),
+    );
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/bypassPayment/i);
+    expect(captureServerEvent).toHaveBeenCalledWith(
+      'billing_bypass_denied',
+      'user_normal',
+      expect.objectContaining({
+        endpoint: '/api/subscription/upgrade',
+        reason: 'client_supplied_bypass_payment_flag',
+      }),
+    );
+  });
+
+  it('rejects bypassPayment:false (still client-supplied) with 403', async () => {
+    // Defense-in-depth: even a falsy value means the client knows about the
+    // flag. We treat the presence of the key as the signal, not the value.
+    const { auth } = await import('@clerk/nextjs/server');
+    vi.mocked(auth).mockResolvedValue({ userId: 'user_normal' } as any);
+
+    const res = await POST(
+      buildRequest({ newPlanId: 'vn_pro', billingCycle: 'monthly', bypassPayment: false }),
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it('does not reject a normal upgrade request that omits bypassPayment', async () => {
+    const { auth } = await import('@clerk/nextjs/server');
+    vi.mocked(auth).mockResolvedValue({ userId: 'user_normal' } as any);
+
+    const res = await POST(buildRequest({ newPlanId: '', billingCycle: '' }));
+    // Missing fields → 400, not the 403 from the bypass guard. This proves
+    // the bypass guard does not false-positive on legitimate traffic.
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/subscription/upgrade/route.ts
+++ b/src/app/api/subscription/upgrade/route.ts
@@ -88,7 +88,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const rawBody = (await request.json()) as Record<string, unknown>;
+    // `request.json()` may return null, an array, or a primitive — using the
+    // `in` operator on any of those throws and the outer catch would convert
+    // a malformed-body 400 into a misleading 500. Validate the shape first.
+    const parsedBody = await request.json();
+    if (!parsedBody || typeof parsedBody !== 'object' || Array.isArray(parsedBody)) {
+      return NextResponse.json(
+        { error: 'Invalid request body', success: false },
+        { status: 400 },
+      );
+    }
+    const rawBody = parsedBody as Record<string, unknown>;
 
     // Reject any client-supplied bypass flag — payment authorization MUST come
     // from the Sepay webhook handler (server-internal service call), never

--- a/src/app/api/subscription/upgrade/route.ts
+++ b/src/app/api/subscription/upgrade/route.ts
@@ -11,6 +11,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { subscriptions } from '@/database/schemas/billing';
 import { getServerDB } from '@/database/server';
 import { pino } from '@/libs/logger';
+import { captureServerEvent } from '@/libs/posthog-server';
 import { PLAN_TIERS, calculateProratedAmount } from '@/server/services/billing/proration';
 
 /**
@@ -56,11 +57,6 @@ const VALID_PLAN_IDS = new Set<PlanId>([
 
 interface UpgradeRequest {
   billingCycle: 'monthly' | 'yearly';
-  /**
-   * If true, skip payment requirement and just update subscription
-   * Used for downgrades or when payment is confirmed via webhook
-   */
-  bypassPayment?: boolean;
   newPlanId: string; // vn_free | vn_basic | vn_pro | vn_team (or legacy: starter | premium | ultimate)
   /** Order ID from completed Sepay payment (for upgrade with payment) */
   paymentOrderId?: string;
@@ -92,7 +88,29 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const body: UpgradeRequest = await request.json();
+    const rawBody = (await request.json()) as Record<string, unknown>;
+
+    // Reject any client-supplied bypass flag — payment authorization MUST come
+    // from the Sepay webhook handler (server-internal service call), never
+    // from a value the client can set in the request body. Surface as a 403
+    // and capture a security event so we can spot scraping/abuse in PostHog.
+    if ('bypassPayment' in rawBody) {
+      captureServerEvent('billing_bypass_denied', userId, {
+        endpoint: '/api/subscription/upgrade',
+        new_plan_id: typeof rawBody.newPlanId === 'string' ? rawBody.newPlanId : null,
+        reason: 'client_supplied_bypass_payment_flag',
+      });
+      pino.warn(
+        { userId, attemptedPlan: rawBody.newPlanId },
+        'Rejected client-supplied bypassPayment flag on /api/subscription/upgrade',
+      );
+      return NextResponse.json(
+        { error: 'bypassPayment is not accepted on this endpoint', success: false },
+        { status: 403 },
+      );
+    }
+
+    const body = rawBody as unknown as UpgradeRequest;
     const { newPlanId, billingCycle } = body;
 
     if (!newPlanId || !billingCycle) {
@@ -165,12 +183,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       'Processing subscription upgrade/downgrade',
     );
 
-    // For upgrades with payment required, create Sepay payment and return payment URL
-    // Only proceed with direct update if:
-    // - It's a downgrade (proratedAmount <= 0)
-    // - Or bypassPayment is true (payment already confirmed via webhook)
-    // - Or proratedAmount is 0 (no payment needed)
-    if (isUpgrade && proratedAmount > 0 && !body.bypassPayment) {
+    // For upgrades with prorated cost, ALWAYS create Sepay payment and return
+    // payment URL. The Sepay webhook (verified via HMAC) is responsible for
+    // applying the plan change once the user has paid — never the client.
+    // Direct update only happens for downgrades / zero-cost changes below.
+    if (isUpgrade && proratedAmount > 0) {
       // Create Sepay payment for upgrade fee
       const { SepayPaymentGateway, sepayGateway } = await import('@/libs/sepay');
       const { createPaymentRecord } = await import('@/server/services/billing/sepay');

--- a/src/libs/posthog-server.ts
+++ b/src/libs/posthog-server.ts
@@ -136,7 +136,15 @@ export function captureServerEvent(
   distinctId: string,
   properties: Record<string, unknown> = {},
 ): void {
-  if (!POSTHOG_KEY) return;
+  if (!POSTHOG_KEY) {
+    // Audit events for billing/security must not vanish silently when PostHog
+    // is misconfigured — that's exactly the failure mode where we most need
+    // to know. Loud warning, but still non-blocking.
+    console.warn(
+      `[PostHog Server] NEXT_PUBLIC_POSTHOG_KEY missing — dropping event '${event}' for distinctId '${distinctId}'`,
+    );
+    return;
+  }
   if (event.startsWith('$')) {
     console.warn(`[PostHog Server] event name '${event}' uses reserved $ prefix; skipping.`);
     return;
@@ -154,7 +162,17 @@ export function captureServerEvent(
     body: JSON.stringify(body),
     headers: { 'Content-Type': 'application/json' },
     method: 'POST',
-  }).catch((e) => {
-    console.warn(`[PostHog Server] ${event} capture failed:`, (e as Error)?.message);
-  });
+  })
+    .then((response) => {
+      if (!response.ok) {
+        // PostHog rejected the event — surface so misconfigured projects /
+        // rate limits show up in the function logs instead of disappearing.
+        console.warn(
+          `[PostHog Server] ${event} capture rejected: ${response.status} ${response.statusText}`,
+        );
+      }
+    })
+    .catch((e) => {
+      console.warn(`[PostHog Server] ${event} capture failed:`, (e as Error)?.message);
+    });
 }

--- a/src/libs/posthog-server.ts
+++ b/src/libs/posthog-server.ts
@@ -119,3 +119,42 @@ export function captureAiGeneration(params: CaptureAiGenerationParams): void {
     console.warn('[PostHog Server] $ai_generation capture failed:', (e as Error)?.message);
   });
 }
+
+/**
+ * Fire-and-forget capture of an arbitrary server-side event.
+ *
+ * Used for security/audit events where we need a durable trail but cannot
+ * block the request path. Examples: `billing_bypass_used`,
+ * `billing_bypass_denied`. Distinct-id is required so PostHog can attribute
+ * the event to a person; pass `'anonymous'` for unauthenticated callers.
+ *
+ * Event names MUST NOT start with `$` — that prefix is reserved for PostHog
+ * built-in events and will be silently filtered in some queries.
+ */
+export function captureServerEvent(
+  event: string,
+  distinctId: string,
+  properties: Record<string, unknown> = {},
+): void {
+  if (!POSTHOG_KEY) return;
+  if (event.startsWith('$')) {
+    console.warn(`[PostHog Server] event name '${event}' uses reserved $ prefix; skipping.`);
+    return;
+  }
+
+  const body = {
+    api_key: POSTHOG_KEY,
+    distinct_id: distinctId || 'anonymous',
+    event,
+    properties,
+    timestamp: new Date().toISOString(),
+  };
+
+  void fetch(`${POSTHOG_HOST}/capture/`, {
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+    method: 'POST',
+  }).catch((e) => {
+    console.warn(`[PostHog Server] ${event} capture failed:`, (e as Error)?.message);
+  });
+}


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix
- [x] ✅ test

#### 🔀 变更说明 | Description of Change

**Hotfix — billing cost leak.** Audit phát hiện 2 vector cho phép user bypass billing checks và 2 vector thiếu audit log. PR này bịt cả 4.

##### 1. `/api/subscription/upgrade` — RÒ NGHIÊM TRỌNG NHẤT
- Trước: bất kỳ user authenticated nào cũng có thể gửi `{ newPlanId: 'vn_pro', billingCycle: 'monthly', bypassPayment: true }` → upgrade Tier 3 miễn phí (flag từ client request body, không có server-side authorization).
- Sau: `bypassPayment` bị remove khỏi public contract hoàn toàn. Bất kỳ request nào còn key này (true OR false) → `403` + capture `billing_bypass_denied` PostHog event. Webhook flow không ảnh hưởng vì Sepay webhook (`src/app/api/payment/sepay/webhook/`) gọi service nội bộ, không qua REST endpoint này.

##### 2. `/api/labs/pho-gateway` — token-only bypass
- Trước: token đúng → bypass `checkAuth` middleware, gọi `handleRequest(data, {} as any)` (jwtPayload rỗng). Bất kỳ ai biết token cũng dùng được.
- Sau: token check + require header `X-Admin-User-Id` → verify với `isAdmin()` (đã có sẵn ở `src/server/services/auth/adminGuard.ts`). Non-admin → `403 + billing_bypass_denied`. Admin → `billing_bypass_used` log với model/provider, sau đó proceed với `{ userId: adminUserId }` trong jwtPayload.

##### 3 + 4. `/api/subscription/models/{check,allowed}` — staging bypass thiếu audit
- Giữ nguyên env gate `STAGING_TIER_BYPASS=true` AND non-prod env (đã ổn).
- **Hard guard mới**: nếu `STAGING_TIER_BYPASS=true` mà chạy trên production deployment (Vercel env var bị set nhầm) → throw `500` + log `billing_bypass_denied`. KHÔNG silent fallback (per ADR anti-pattern).
- Mỗi lần staging bypass active → capture `billing_bypass_used` PostHog event.

##### Infra
- `src/libs/posthog-server.ts`: thêm `captureServerEvent(event, distinctId, properties)` generic helper. Reject `$`-prefix names (PostHog reserved).
- `scripts/test-failover.ts`: bổ sung header `X-Admin-User-Id` từ env mới `PHO_GATEWAY_LABS_ADMIN_USER_ID`. CI cần set env này.

##### Test cases (vitest, 2 file mới)
- `src/app/api/subscription/upgrade/route.test.ts`: 401 unauth → 403 nếu có `bypassPayment:true` → 403 nếu có `bypassPayment:false` (key presence là tín hiệu) → 400 missing fields (chứng minh không false-positive trên traffic hợp lệ).
- `src/app/api/labs/pho-gateway/route.test.ts`: 503 nếu env token chưa set → 403 thiếu admin header → 403 non-admin → admin success log `billing_bypass_used` → invalid token log `billing_bypass_denied`.

##### Files NOT touched (không phải billing bypass)
- `src/server/routers/async/caller.ts:24` — `VERCEL_AUTOMATION_BYPASS_SECRET` là Vercel Deployment Protection.
- `apps/desktop/src/main/modules/networkProxy/validator.ts:16` — proxy bypass list (localhost).
- `scripts/activate-prod.ts:86` — `promoCode: 'BYPASS-TEST'` chỉ là string label.

#### 📝 补充信息 | Additional Information

**Pre-merge checks:** local install bị block bởi sandbox CDN restriction (`xlsx@https://cdn.sheetjs.com/...` → 403 Forbidden). Lint / typecheck / build / vitest sẽ chạy qua `.github/workflows/test.yml` khi PR build.

**Anh Hiên cần làm sau khi merge:**
1. **Vercel:** rotate `PHO_GATEWAY_LABS_TOKEN` env var (giá trị mới, không reuse cũ).
2. **Vercel:** set `PHO_GATEWAY_LABS_ADMIN_USER_ID` (Clerk user ID của admin chạy CI test-failover).
3. **Vercel:** verify `STAGING_TIER_BYPASS` KHÔNG có trong Production environment (chỉ Preview/Development).
4. **PostHog:** monitor 2 event mới trong 24h:
   - `billing_bypass_used` — admin sử dụng bypass hợp lệ (expected: thấp, từ CI script)
   - `billing_bypass_denied` — attempt thất bại (expected: 0; > 0 = dấu hiệu probe/abuse)
5. **Cost dashboard:** verify giảm sau 24-48h (đặc biệt Tier 3 model usage từ free users).

**Out of scope hotfix này:**
- Endpoint riêng cho admin manual upgrade (sẽ tạo sau, dùng `assertAdmin()` từ `adminGuard.ts`).
- Migrating Sepay webhook signature verification (đã có HMAC verify ở webhook handler).

https://claude.ai/code/session_01JfeGVMTksswH924CDmoHcF

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfeGVMTksswH924CDmoHcF)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes billing bypasses and stops free upgrades. Enforces an admin-gated labs token with constant-time checks and better audit logging.

- **Bug Fixes**
  - `/api/subscription/upgrade`: removed `bypassPayment` from the public API. Any request that includes it (true or false) returns 403 and logs `billing_bypass_denied`. Webhook upgrades are unchanged. Also validates JSON is a plain object to avoid 400→500 on malformed bodies.
  - `/api/labs/pho-gateway`: token is now env-only and must be paired with `X-Admin-User-Id` that passes `isAdmin()`. Missing/non-admin → 403 + `billing_bypass_denied`. Valid admin → logs `billing_bypass_used` and runs as that user. Invalid Bearer tokens now log with distinctId `anonymous` and include `untrusted_admin_user_id`. Token comparison uses constant-time equality.
  - `/api/subscription/models/{check,allowed}`: keeps `STAGING_TIER_BYPASS` for non-prod, but returns 500 (with `billing_bypass_denied`) if set on production. When used in non-prod, logs `billing_bypass_used`.
  - Added `captureServerEvent()` in the PostHog server lib (rejects `$`-prefixed names), with warnings when the key is missing and logging of non-OK responses.
  - `scripts/test-failover.ts`: requires `PHO_GATEWAY_LABS_ADMIN_USER_ID` and exits 1 if missing to prevent silent no-ops.

- **Migration**
  - Rotate `PHO_GATEWAY_LABS_TOKEN`.
  - Set `PHO_GATEWAY_LABS_ADMIN_USER_ID` to a valid admin Clerk user ID (required for CI).
  - Ensure `STAGING_TIER_BYPASS` is not set in production.
  - Monitor PostHog: `billing_bypass_used` (low, expected from CI) and `billing_bypass_denied` (should be 0).

<sup>Written for commit 71811213bcd6e148aa49c975d9a8855fe296330f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened authentication requirements for billing bypass flows, now requiring both authorization tokens and admin verification.
  * Added validation to prevent staging tier bypass misconfiguration on production deployments.

* **Tests**
  * Added comprehensive test coverage for payment upgrade security and admin-gated API endpoints.

* **Chores**
  * Enhanced server-side event tracking for security-related activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->