### PR TITLE
🐛 fix(chat-history): authedProcedure for read endpoints (PHO-260)

### DIFF
--- a/src/server/routers/lambda/__tests__/message.test.ts
+++ b/src/server/routers/lambda/__tests__/message.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MessageModel } from '@/database/models/message';
 import { FileService } from '@/server/services/file';
 import { ChatMessage, CreateMessageParams } from '@/types/message';
 import { UpdateMessageRAGParams } from '@/types/message/rag';
+
+import { messageRouter } from '../message';
 
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn(),
@@ -13,8 +15,17 @@ vi.mock('@/server/services/file', () => ({
   FileService: vi.fn(),
 }));
 
-vi.mock('@/database/server', () => ({
-  getServerDB: vi.fn(),
+vi.mock('@/database/server', () => {
+  const mockServerDB = {} as any;
+
+  return {
+    getServerDB: vi.fn().mockResolvedValue(mockServerDB),
+    serverDB: mockServerDB,
+  };
+});
+
+vi.mock('@/const/auth', () => ({
+  enableClerk: true,
 }));
 
 describe('messageRouter', () => {
@@ -114,11 +125,7 @@ describe('messageRouter', () => {
 
   it('should handle getMessages', async () => {
     const mockQuery = vi.fn().mockResolvedValue([{ id: 'msg1' }]);
-    const mockGetFullFileUrl = vi
-      .fn()
-      .mockImplementation((path: string | null, file: { fileType: string }) => {
-        return Promise.resolve('url');
-      });
+    const mockGetFullFileUrl = vi.fn().mockResolvedValue('url');
 
     vi.mocked(MessageModel).mockImplementation(
       () =>
@@ -239,5 +246,51 @@ describe('messageRouter', () => {
       fileChunks: [{ id: 'c1', similarity: 0.9 }],
       ragQueryId: 'q1',
     });
+  });
+});
+
+describe('messageRouter.getMessages (PHO-260)', () => {
+  const userId = 'test-user-id';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws UNAUTHORIZED when ctx.userId is missing', async () => {
+    // Before PHO-260 this returned an empty list even when the caller had
+    // valid history — masking stale-Clerk-cookie races as "no messages".
+    // The procedure must surface UNAUTHORIZED so retryOnUnauthorizedLink can
+    // refresh the token before the user sees an empty conversation.
+    const caller = messageRouter.createCaller({ userId: undefined } as any);
+
+    await expect(caller.getMessages({})).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+  });
+
+  it('returns messages when authenticated', async () => {
+    const mockMessages = [{ content: 'hi', id: 'msg1' }];
+    const mockQuery = vi.fn().mockResolvedValue(mockMessages);
+    const mockGetFullFileUrl = vi.fn();
+
+    vi.mocked(MessageModel).mockImplementation(
+      () =>
+        ({
+          query: mockQuery,
+        }) as any,
+    );
+    vi.mocked(FileService).mockImplementation(
+      () =>
+        ({
+          getFullFileUrl: mockGetFullFileUrl,
+        }) as any,
+    );
+
+    const caller = messageRouter.createCaller({ userId } as any);
+    const input = { sessionId: 's1', topicId: 't1' };
+    const result = await caller.getMessages(input);
+
+    expect(result).toEqual(mockMessages);
+    expect(mockQuery).toHaveBeenCalledWith(input, expect.any(Object));
   });
 });

--- a/src/server/routers/lambda/message.ts
+++ b/src/server/routers/lambda/message.ts
@@ -2,8 +2,7 @@ import { z } from 'zod';
 
 import { MessageModel } from '@/database/models/message';
 import { updateMessagePluginSchema } from '@/database/schemas';
-import { getServerDB } from '@/database/server';
-import { authedProcedure, publicProcedure, router } from '@/libs/trpc/lambda';
+import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { FileService } from '@/server/services/file';
 import { ChatMessage } from '@/types/message';
@@ -88,8 +87,7 @@ export const messageRouter = router({
     return ctx.messageModel.getHeatmaps();
   }),
 
-  // TODO: 未来这部分方法也需要使用 authedProcedure
-  getMessages: publicProcedure
+  getMessages: messageProcedure
     .input(
       z.object({
         current: z.number().optional(),
@@ -98,17 +96,11 @@ export const messageRouter = router({
         topicId: z.string().nullable().optional(),
       }),
     )
-    .query(async ({ input, ctx }) => {
-      if (!ctx.userId) return [];
-      const serverDB = await getServerDB();
-
-      const messageModel = new MessageModel(serverDB, ctx.userId);
-      const fileService = new FileService(serverDB, ctx.userId);
-
-      return messageModel.query(input, {
-        postProcessUrl: (path) => fileService.getFullFileUrl(path),
-      });
-    }),
+    .query(async ({ input, ctx }) =>
+      ctx.messageModel.query(input, {
+        postProcessUrl: (path) => ctx.fileService.getFullFileUrl(path),
+      }),
+    ),
 
   rankModels: messageProcedure.query(async ({ ctx }) => {
     return ctx.messageModel.rankModels();

--- a/src/server/routers/lambda/session.test.ts
+++ b/src/server/routers/lambda/session.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SessionModel } from '@/database/models/session';
+import { SessionGroupModel } from '@/database/models/sessionGroup';
+
+import { sessionRouter } from './session';
+
+vi.mock('@/database/server', () => {
+  const mockServerDB = {} as any;
+
+  return {
+    getServerDB: vi.fn().mockResolvedValue(mockServerDB),
+    serverDB: mockServerDB,
+  };
+});
+
+vi.mock('@/database/models/session', () => ({
+  SessionModel: vi.fn(),
+}));
+
+vi.mock('@/database/models/sessionGroup', () => ({
+  SessionGroupModel: vi.fn(),
+}));
+
+vi.mock('@/const/auth', () => ({
+  enableClerk: true,
+}));
+
+describe('sessionRouter.getGroupedSessions (PHO-260)', () => {
+  const userId = 'test-user-id';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws UNAUTHORIZED when ctx.userId is missing', async () => {
+    // Before PHO-260 this returned an empty list and the client could not
+    // distinguish "stale Clerk session" from "user genuinely has no history".
+    // The procedure must now surface UNAUTHORIZED so retryOnUnauthorizedLink
+    // gets a chance to refresh the Clerk token.
+    const caller = sessionRouter.createCaller({ userId: undefined } as any);
+
+    await expect(caller.getGroupedSessions()).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+  });
+
+  it('returns grouped sessions when authenticated', async () => {
+    const mockResult = {
+      sessionGroups: [{ id: 'g1', name: 'Group 1' }],
+      sessions: [{ id: 's1' }],
+    };
+    const mockQueryWithGroups = vi.fn().mockResolvedValue(mockResult);
+
+    vi.mocked(SessionModel).mockImplementation(
+      () =>
+        ({
+          queryWithGroups: mockQueryWithGroups,
+        }) as any,
+    );
+    vi.mocked(SessionGroupModel).mockImplementation(() => ({}) as any);
+
+    const caller = sessionRouter.createCaller({ userId } as any);
+    const result = await caller.getGroupedSessions();
+
+    expect(result).toEqual(mockResult);
+    expect(mockQueryWithGroups).toHaveBeenCalled();
+  });
+});

--- a/src/server/routers/lambda/session.ts
+++ b/src/server/routers/lambda/session.ts
@@ -3,8 +3,7 @@ import { z } from 'zod';
 import { SessionModel } from '@/database/models/session';
 import { SessionGroupModel } from '@/database/models/sessionGroup';
 import { insertAgentSchema, insertSessionSchema } from '@/database/schemas';
-import { getServerDB } from '@/database/server';
-import { authedProcedure, publicProcedure, router } from '@/libs/trpc/lambda';
+import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { AgentChatConfigSchema } from '@/types/agent';
 import { LobeMetaDataSchema } from '@/types/meta';
@@ -95,14 +94,9 @@ export const sessionRouter = router({
       return data.id;
     }),
 
-  getGroupedSessions: publicProcedure.query(async ({ ctx }): Promise<ChatSessionList> => {
-    if (!ctx.userId) return { sessionGroups: [], sessions: [] };
-
-    const serverDB = await getServerDB();
-    const sessionModel = new SessionModel(serverDB, ctx.userId!);
-
-    return sessionModel.queryWithGroups();
-  }),
+  getGroupedSessions: sessionProcedure.query(
+    async ({ ctx }): Promise<ChatSessionList> => ctx.sessionModel.queryWithGroups(),
+  ),
 
   getSessions: sessionProcedure
     .input(

--- a/src/server/routers/lambda/topic.test.ts
+++ b/src/server/routers/lambda/topic.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TopicModel } from '@/database/models/topic';
+
+import { topicRouter } from './topic';
+
+vi.mock('@/database/server', () => {
+  const mockServerDB = {} as any;
+
+  return {
+    getServerDB: vi.fn().mockResolvedValue(mockServerDB),
+    serverDB: mockServerDB,
+  };
+});
+
+vi.mock('@/database/models/topic', () => ({
+  TopicModel: vi.fn(),
+}));
+
+vi.mock('@/const/auth', () => ({
+  enableClerk: true,
+}));
+
+describe('topicRouter.getTopics (PHO-260)', () => {
+  const userId = 'test-user-id';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws UNAUTHORIZED when ctx.userId is missing', async () => {
+    // See sessionRouter.getGroupedSessions test for the full story — same
+    // anti-pattern (`if (!ctx.userId) return []`) was nuking the topic list.
+    const caller = topicRouter.createCaller({ userId: undefined } as any);
+
+    await expect(caller.getTopics({})).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+  });
+
+  it('returns topics when authenticated', async () => {
+    const mockTopics = [{ id: 't1', title: 'Topic 1' }];
+    const mockQuery = vi.fn().mockResolvedValue(mockTopics);
+
+    vi.mocked(TopicModel).mockImplementation(
+      () =>
+        ({
+          query: mockQuery,
+        }) as any,
+    );
+
+    const caller = topicRouter.createCaller({ userId } as any);
+    const input = { sessionId: 's1' };
+    const result = await caller.getTopics(input);
+
+    expect(result).toEqual(mockTopics);
+    expect(mockQuery).toHaveBeenCalledWith(input);
+  });
+});

--- a/src/server/routers/lambda/topic.ts
+++ b/src/server/routers/lambda/topic.ts
@@ -1,8 +1,7 @@
 import { z } from 'zod';
 
 import { TopicModel } from '@/database/models/topic';
-import { getServerDB } from '@/database/server';
-import { authedProcedure, publicProcedure, router } from '@/libs/trpc/lambda';
+import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { BatchTaskResult } from '@/types/service';
 
@@ -90,8 +89,7 @@ export const topicRouter = router({
     return ctx.topicModel.queryAll();
   }),
 
-  // TODO: this procedure should be used with authedProcedure
-  getTopics: publicProcedure
+  getTopics: topicProcedure
     .input(
       z.object({
         current: z.number().optional(),
@@ -99,14 +97,7 @@ export const topicRouter = router({
         sessionId: z.string().nullable().optional(),
       }),
     )
-    .query(async ({ input, ctx }) => {
-      if (!ctx.userId) return [];
-
-      const serverDB = await getServerDB();
-      const topicModel = new TopicModel(serverDB, ctx.userId);
-
-      return topicModel.query(input);
-    }),
+    .query(async ({ input, ctx }) => ctx.topicModel.query(input)),
 
   hasTopics: topicProcedure.query(async ({ ctx }) => {
     return (await ctx.topicModel.count()) === 0;

--- a/src/store/session/slices/session/action.ts
+++ b/src/store/session/slices/session/action.ts
@@ -236,6 +236,8 @@ export const createSessionSlice: StateCreator<
           sessions: [],
         },
         onSuccess: (data) => {
+          const isFirstFetch = !get().isSessionsFirstFetchFinished;
+
           if (
             get().isSessionsFirstFetchFinished &&
             isEqual(get().sessions, data.sessions) &&
@@ -249,6 +251,28 @@ export const createSessionSlice: StateCreator<
             n('useFetchSessions/updateData') as any,
           );
           set({ isSessionsFirstFetchFinished: true }, false, n('useFetchSessions/onSuccess', data));
+
+          // PHO-260: signal an empty sidebar on the first fetch while signed in.
+          // Could be a brand-new user (legitimate) or a stale-cookie race that
+          // returned an empty list before link-level retry kicks in. Volume of
+          // this event vs. real new-user signups tells us how widespread the
+          // history-empty regression is.
+          if (
+            isFirstFetch &&
+            isLogin &&
+            data.sessions.length === 0 &&
+            data.sessionGroups.length === 0
+          ) {
+            try {
+              const analytics = getSingletonAnalyticsOptional();
+              analytics?.track({
+                name: 'chat_history_empty_after_login',
+                properties: { source: 'useFetchSessions' },
+              });
+            } catch {
+              // telemetry must never break UX
+            }
+          }
         },
         suspense: true,
       },


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix
- [x] ✅ test

#### 🔀 变更说明 | Description of Change

**P0 — Chat history sidebar hiển thị trống dù DB có đầy đủ data.**

User `nguyenmai360@gmail.com` (Clerk `user_3AI5p0YWpqgCiccT6u6qM0f0D3y`, nữ bác sĩ) có **53 topics + 653 messages + 9 sessions** trong Neon production nhưng sidebar trống. User đã tạo các topic mới với tiêu đề `"Xem lại chat"`, `"Mở lại lịch sử"` → đang vùng vẫy tìm lịch sử cũ. Vì write paths (`createTopic`, `createMessage`, ...) đều dùng `authedProcedure` đúng cách nên user vẫn tạo được chat mới — bug bị che giấu hoàn toàn ở phía observability.

##### Root cause

3 read endpoint khai báo `publicProcedure` và nuốt im lỗi auth:

| File | Endpoint | Hành vi sai |
|---|---|---|
| `src/server/routers/lambda/session.ts` | `getGroupedSessions` | `if (!ctx.userId) return { sessionGroups: [], sessions: [] }` |
| `src/server/routers/lambda/topic.ts` | `getTopics` | `if (!ctx.userId) return []` |
| `src/server/routers/lambda/message.ts` | `getMessages` | `if (!ctx.userId) return []` |

Khi Clerk cookie stale (boot race / JWK rotation / JWT expired mid-session), `ctx.userId = null` → endpoint trả 200 OK + array rỗng → UI indistinguishable với "user chưa có lịch sử". Không có log, không Sentry, không tín hiệu nào để escalate.

##### Fix

1. **Server (3 file)**: chuyển sang `{session,topic,message}Procedure` — đều derived từ `authedProcedure` đã có sẵn trong file. Missing `userId` giờ throw `UNAUTHORIZED` thay vì trả mảng rỗng. Xoá `getServerDB` + `publicProcedure` import không còn dùng. KHÔNG đụng vào schema, middleware, hay endpoint khác.

2. **Client (zero change)**: `src/libs/trpc/client/lambda.ts` đã có `retryOnUnauthorizedLink` (PHO-251 / PHO-252) — detect 401 → poll `useUserStore` chờ Clerk hydration (max 2s) → `silentRefresh({ skipCache: true })` singleflight → retry → fallback `forceReauth` khi escalate. UX trên cookie stale giờ: ~1s delay rồi load lại đầy đủ, thay vì empty state vĩnh viễn.

3. **Telemetry** (`useFetchSessions` `onSuccess`): emit PostHog event `chat_history_empty_after_login` khi `isLogin && isFirstFetch && data.sessions.length === 0 && data.sessionGroups.length === 0`. Dùng `getSingletonAnalyticsOptional` (cùng pattern với `createSession` đã có sẵn). Wrap try/catch — telemetry không bao giờ phá UX.

4. **Tests** (createCaller pattern, theo `agent.test.ts` / `user.test.ts`):
   - `src/server/routers/lambda/session.test.ts` (mới): UNAUTHORIZED throw + happy path cho `getGroupedSessions`.
   - `src/server/routers/lambda/topic.test.ts` (mới): UNAUTHORIZED throw + happy path cho `getTopics`.
   - `src/server/routers/lambda/__tests__/message.test.ts` (mở rộng): thêm describe `messageRouter.getMessages (PHO-260)` với 2 test tương đương.

##### Impact lên `nguyenmai360`

**Zero action required.** Lần load trang tiếp theo sau khi deploy, chị thấy lại 53 topic. Không cần clear cache, không cần logout/login. Client recovery infra hiện hữu tự xử lý whatever stale state session của chị đang ở.

#### 📝 补充信息 | Additional Information

- ✅ `bun run type-check` — pass
- ✅ `bunx vitest run` 3 file tests — 2 + 2 + 10 tests pass
- ⏭️ Skipped per `Plan Step 3.2`: SWR-level `shouldRetryOnError` trong `useFetchSessions` / `useFetchTopics`. Lý do: `retryOnUnauthorizedLink` đã handle 401 ở link level — thêm tầng SWR sẽ là double-retry, có thể che giấu bug khác. Nếu sau deploy thấy event `chat_history_empty_after_login` vẫn còn → reopen và bổ sung.
- Follow-up tickets (đã nêu trong prompt gốc, không nằm trong PR này): PHO-261 (audit toàn bộ `publicProcedure` cho anti-pattern "silently return empty"), PHO-262 (XOR-token fallback → short-lived signed JWT), PHO-263 (PostHog alert khi `chat_history_empty_after_login > 5 events/day`).

Linear: PHO-260

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty chat history by requiring auth on read endpoints and surfacing 401 so the client can auto-refresh and load real data. Addresses Linear PHO-260; users now see their history after a brief retry instead of a permanent empty state.

- **Bug Fixes**
  - Switched `session.getGroupedSessions`, `topic.getTopics`, and `message.getMessages` from `publicProcedure` to `{session,topic,message}Procedure` (derived from `authedProcedure`). Missing auth now throws `UNAUTHORIZED` instead of returning empty lists.
  - Used middleware-injected models/services (`ctx.sessionModel`, `ctx.topicModel`, `ctx.messageModel`, `ctx.fileService`); removed `getServerDB` in these queries.
  - Client already handles 401 via `retryOnUnauthorizedLink` (silent Clerk refresh + retry). No user action needed.
  - Added telemetry: track `chat_history_empty_after_login` on the first empty fetch after login to monitor regressions.
  - Added tests for all three routes: assert `UNAUTHORIZED` without `userId` and happy-path queries.

<sup>Written for commit 8af6d3f412340b8af0974dfd66be57646a92c318. Summary will update on new commits. <a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/54?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Message, session, and topic API endpoints now require user authentication to ensure secure access to user data.
  * Enhanced analytics tracking with new event for monitoring empty chat history scenarios after successful login.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thaohienhomes/pho-chat-v1/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->