### PR TITLE
fix(observability): forward console.error → PostHog + collapse feature-flag eval burst

### DIFF
--- a/src/app/[variants]/(main)/settings/llm/ProviderList/providers.tsx
+++ b/src/app/[variants]/(main)/settings/llm/ProviderList/providers.tsx
@@ -63,6 +63,11 @@ import { useOpenAIProvider } from './OpenAI';
  * Checks both individual provider flags and group flags.
  */
 const useFilteredProviders = (providers: ProviderItem[]): ProviderItem[] => {
+  // TODO(PCFIX-1): each useFeatureFlagEnabled() below emits a `$feature_flag_called`
+  // event. This is INTENTIONALLY left as-is: it runs only on the settings/llm page,
+  // not the per-load chat path that PCFIX-1 fixed (see usePostHogFeatureFlags, which
+  // reads the consolidated variants map instead). If this filtering ever moves onto a
+  // hot path, consolidate these the same way to avoid re-introducing the flag burst.
   // Check group flags
   const premiumEnabled = useFeatureFlagEnabled('llm-group-premium');
   const fastEnabled = useFeatureFlagEnabled('llm-group-fast');

--- a/src/components/Analytics/LobeAnalyticsProvider.tsx
+++ b/src/components/Analytics/LobeAnalyticsProvider.tsx
@@ -12,6 +12,8 @@ import { BUSINESS_LINE } from '@/const/analytics';
 import { isDesktop } from '@/const/version';
 import { isDev } from '@/utils/env';
 
+import { installConsoleErrorForwarding } from './consoleErrorForwarding';
+
 type Props = {
   children: ReactNode;
   ga4Config: GoogleAnalyticsProviderConfig;
@@ -82,11 +84,11 @@ export const LobeAnalyticsProvider = memo(
             // Filter benign exceptions from PostHog error tracking
             // These are noise that pollute error dashboards without actionable value
             const benignPatterns = [
-              'ResizeObserver loop',          // Browser layout recalc noise
-              'signal is aborted',            // User navigated away during fetch
-              'zaloJSV2',                     // Zalo in-app browser injection
-              'zalo_h5_event_handler',        // Zalo WebView event handler
-              'Cannot prefetch',              // Next.js external URL prefetch
+              'ResizeObserver loop', // Browser layout recalc noise
+              'signal is aborted', // User navigated away during fetch
+              'zaloJSV2', // Zalo in-app browser injection
+              'zalo_h5_event_handler', // Zalo WebView event handler
+              'Cannot prefetch', // Next.js external URL prefetch
               'Attempted to assign to readonly property', // Safari strict mode quirk
             ];
             const origCapture = posthog.capture.bind(posthog);
@@ -102,6 +104,14 @@ export const LobeAnalyticsProvider = memo(
               }
               return origCapture(eventName, properties, options);
             };
+
+            // TASK 0: forward handled `console.error` calls to PostHog error
+            // tracking. `capture_exceptions` only autocaptures UNCAUGHT errors
+            // (window.onerror) + unhandled rejections; handled errors logged via
+            // console.error never became `$exception`. Routed through the wrapped
+            // `posthog.capture` above, so the benign-pattern filter applies and no
+            // double-capture occurs (we intentionally do NOT hook window.onerror).
+            installConsoleErrorForwarding(posthog);
 
             // Ensure properties are available for instant Feature Flag evaluation
             posthog.setPersonPropertiesForFlags({

--- a/src/components/Analytics/LobeAnalyticsProviderWrapper.tsx
+++ b/src/components/Analytics/LobeAnalyticsProviderWrapper.tsx
@@ -24,6 +24,15 @@ export const LobeAnalyticsProviderWrapper = memo<Props>(({ children }) => {
         // ship with non-null payloads. Read these via `properties.$exception_list`
         // (array) — the legacy flat fields ($exception_type/_message/_stack)
         // were removed in PostHog JS ≥ 1.95.
+        //
+        // ⚠️ TASK 0: keep this a plain `true`. Boolean `true` enables ONLY
+        // capture_unhandled_errors + capture_unhandled_rejections; it leaves
+        // posthog-js's native `capture_console_errors` OFF. We forward console.error
+        // ourselves via installConsoleErrorForwarding() (LobeAnalyticsProvider) to
+        // tag `mechanism: 'console.error'` and keep a hook point for PII scrub/
+        // sampling. Do NOT switch this to an object that sets
+        // `capture_console_errors: true` while that helper is installed — the two
+        // would DOUBLE-CAPTURE every console.error. Pick one path, not both.
         capture_exceptions: true,
         capture_performance: { web_vitals: true },
         debug: analyticsEnv.DEBUG_POSTHOG_ANALYTICS,

--- a/src/components/Analytics/__tests__/consoleErrorForwarding.test.ts
+++ b/src/components/Analytics/__tests__/consoleErrorForwarding.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __resetConsoleErrorForwardingForTests,
+  installConsoleErrorForwarding,
+} from '../consoleErrorForwarding';
+
+describe('installConsoleErrorForwarding', () => {
+  let originalConsoleError: typeof console.error;
+  let nativeSpy: ReturnType<typeof vi.fn>;
+  let captureException: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalConsoleError = console.error;
+    // Replace the native console.error with a spy BEFORE installing, so the
+    // forwarder wraps our spy and we can assert native logging is preserved.
+    nativeSpy = vi.fn();
+    console.error = nativeSpy as unknown as typeof console.error;
+    captureException = vi.fn();
+  });
+
+  afterEach(() => {
+    __resetConsoleErrorForwardingForTests(originalConsoleError);
+    vi.restoreAllMocks();
+  });
+
+  it('forwards a string console.error as a synthesized Error', () => {
+    installConsoleErrorForwarding({ captureException });
+
+    console.error('Something broke:', 'detail');
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const [error, props] = captureException.mock.calls[0];
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('Something broke:');
+    expect((error as Error).message).toContain('detail');
+    expect(props).toEqual({ mechanism: 'console.error' });
+  });
+
+  it('preserves the original Error instance (and its stack) when present', () => {
+    installConsoleErrorForwarding({ captureException });
+
+    const original = new Error('boom');
+    console.error('Failed to fetch:', original);
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException.mock.calls[0][0]).toBe(original);
+  });
+
+  it('still calls the underlying native console.error', () => {
+    installConsoleErrorForwarding({ captureException });
+
+    console.error('hello');
+
+    expect(nativeSpy).toHaveBeenCalledWith('hello');
+  });
+
+  it('does not capture when there is no meaningful message', () => {
+    installConsoleErrorForwarding({ captureException });
+
+    console.error();
+    console.error('   ');
+
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent — installing twice wraps console.error only once', () => {
+    installConsoleErrorForwarding({ captureException });
+    const afterFirst = console.error;
+    installConsoleErrorForwarding({ captureException });
+
+    expect(console.error).toBe(afterFirst);
+
+    console.error('once');
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not loop if captureException itself logs via console.error', () => {
+    captureException.mockImplementation(() => {
+      // Simulate PostHog internally logging an error during capture.
+      console.error('internal capture failure');
+    });
+
+    installConsoleErrorForwarding({ captureException });
+
+    console.error('trigger');
+
+    // Re-entrancy guard: the inner console.error must not trigger a second capture.
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('never throws even if captureException throws', () => {
+    captureException.mockImplementation(() => {
+      throw new Error('capture exploded');
+    });
+
+    installConsoleErrorForwarding({ captureException });
+
+    expect(() => console.error('trigger')).not.toThrow();
+  });
+
+  it('is a no-op when the client lacks captureException', () => {
+    const before = console.error;
+    installConsoleErrorForwarding({});
+
+    // console.error must be left untouched.
+    expect(console.error).toBe(before);
+  });
+});

--- a/src/components/Analytics/consoleErrorForwarding.ts
+++ b/src/components/Analytics/consoleErrorForwarding.ts
@@ -48,6 +48,10 @@ const toError = (args: unknown[]): Error | null => {
  *  - We do NOT hook `window.onerror` / `window.onunhandledrejection` — autocapture
  *    already owns those channels, so we only forward the disjoint `console.error`
  *    channel.
+ *  - posthog-js's own `capture_console_errors` option MUST stay OFF while this
+ *    helper is installed (it is, because `capture_exceptions: true` only turns on
+ *    unhandled errors + rejections). Enabling both would double-capture — see the
+ *    warning at the `capture_exceptions` config in LobeAnalyticsProviderWrapper.
  *  - Benign-pattern filtering is applied centrally on the wrapped `posthog.capture`
  *    (see LobeAnalyticsProvider), and `captureException` routes through it, so
  *    `$exception` noise is suppressed there too.

--- a/src/components/Analytics/consoleErrorForwarding.ts
+++ b/src/components/Analytics/consoleErrorForwarding.ts
@@ -1,0 +1,97 @@
+/**
+ * Minimal shape of the PostHog client methods this module relies on.
+ */
+interface PostHogLike {
+  captureException?: (error: Error, additionalProperties?: Record<string, unknown>) => void;
+}
+
+const HOOK_FLAG = '__phoConsoleErrorForwardingInstalled';
+
+/**
+ * Build an Error from `console.error(...)` arguments.
+ *
+ * Prefers a real Error instance among the args (preserving its stack); otherwise
+ * synthesizes one from the formatted message. Returns null when there is nothing
+ * meaningful to report (e.g. `console.error()` with no/empty args).
+ */
+const toError = (args: unknown[]): Error | null => {
+  const existing = args.find((a): a is Error => a instanceof Error);
+  if (existing) return existing;
+
+  const message = args
+    .map((a) => {
+      if (typeof a === 'string') return a;
+      try {
+        return JSON.stringify(a);
+      } catch {
+        return String(a);
+      }
+    })
+    .join(' ')
+    .trim()
+    .slice(0, 1000);
+
+  return message ? new Error(message) : null;
+};
+
+/**
+ * Forward `console.error(...)` calls to PostHog error tracking as `$exception`.
+ *
+ * Why: PostHog's `capture_exceptions` (Exception Autocapture) only covers
+ * UNCAUGHT errors (`window.onerror`) and unhandled promise rejections. Errors the
+ * app *handles* and logs via `console.error` (caught exceptions, failed fetches,
+ * React render errors) never reach the error dashboard. A single session replay
+ * showed 16 such console errors while only ~2 `$exception` events landed in a week.
+ * This closes that visibility gap.
+ *
+ * Double-capture is avoided by design:
+ *  - We do NOT hook `window.onerror` / `window.onunhandledrejection` — autocapture
+ *    already owns those channels, so we only forward the disjoint `console.error`
+ *    channel.
+ *  - Benign-pattern filtering is applied centrally on the wrapped `posthog.capture`
+ *    (see LobeAnalyticsProvider), and `captureException` routes through it, so
+ *    `$exception` noise is suppressed there too.
+ *  - A re-entrancy guard prevents loops if capture internally logs via console.error.
+ *  - Idempotent: installs at most once per page (guarded on `window`).
+ */
+export const installConsoleErrorForwarding = (posthog: PostHogLike): void => {
+  if (typeof window === 'undefined') return;
+  if (typeof posthog?.captureException !== 'function') return;
+  if ((window as unknown as Record<string, unknown>)[HOOK_FLAG]) return;
+  (window as unknown as Record<string, unknown>)[HOOK_FLAG] = true;
+
+  const originalConsoleError = console.error.bind(console);
+  let forwarding = false;
+
+  // eslint-disable-next-line no-console
+  console.error = (...args: unknown[]) => {
+    // Always preserve native logging first.
+    originalConsoleError(...args);
+
+    if (forwarding) return; // guard against recursion (capture → console.error → ...)
+    try {
+      forwarding = true;
+      const error = toError(args);
+      if (error) {
+        posthog.captureException!(error, { mechanism: 'console.error' });
+      }
+    } catch {
+      // Error tracking must never break the host app.
+    } finally {
+      forwarding = false;
+    }
+  };
+};
+
+/**
+ * Test-only: reset the install guard and restore the original console.error.
+ * Exposed so unit tests can re-exercise installation in isolation.
+ */
+export const __resetConsoleErrorForwardingForTests = (
+  originalConsoleError: typeof console.error,
+) => {
+  if (typeof window !== 'undefined') {
+    (window as unknown as Record<string, unknown>)[HOOK_FLAG] = false;
+  }
+  console.error = originalConsoleError;
+};

--- a/src/hooks/useIsProviderEnabled.ts
+++ b/src/hooks/useIsProviderEnabled.ts
@@ -19,6 +19,10 @@ export const useIsProviderEnabled = (providerId: string): boolean => {
   const providerFlag = getProviderFlag(providerId);
   const groupFlag = getProviderGroupFlag(providerId);
 
+  // TODO(PCFIX-1): useFeatureFlagEnabled emits a `$feature_flag_called` event per
+  // call. Left as-is on purpose — this hook is not on the per-load chat path that
+  // PCFIX-1 de-bursted (usePostHogFeatureFlags now reads the consolidated variants
+  // map). If this hook starts rendering on a hot path, switch to that pattern.
   // Check individual provider flag
   const providerEnabled = useFeatureFlagEnabled(providerFlag || '__no_flag__');
   // Check group flag

--- a/src/hooks/usePostHogFeatureFlags.test.ts
+++ b/src/hooks/usePostHogFeatureFlags.test.ts
@@ -1,0 +1,130 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { usePostHogFeatureFlags } from './usePostHogFeatureFlags';
+
+type Variants = Record<string, boolean | string>;
+
+/**
+ * Build a fake PostHog client. By default the `onFeatureFlags` callback fires
+ * immediately with the given variants (mirroring "flags already loaded").
+ */
+const makePosthog = (variants: Variants, { fireCallback = true, cached = {} as Variants } = {}) => {
+  const isFeatureEnabled = vi.fn();
+  const getFeatureFlag = vi.fn();
+  const onFeatureFlags = vi.fn((cb: (flags: string[], variants: Variants) => void) => {
+    if (fireCallback) {
+      const enabled = Object.keys(variants).filter((k) => !!variants[k]);
+      cb(enabled, variants);
+    }
+    return () => {};
+  });
+  const getFlagVariants = vi.fn(() => cached);
+
+  return {
+    getFeatureFlag,
+    isFeatureEnabled,
+    onFeatureFlags,
+    ph: {
+      featureFlags: { getFlagVariants },
+      getFeatureFlag,
+      isFeatureEnabled,
+      onFeatureFlags,
+    },
+  };
+};
+
+describe('usePostHogFeatureFlags', () => {
+  beforeEach(() => {
+    delete (window as any).posthog;
+  });
+
+  afterEach(() => {
+    delete (window as any).posthog;
+    vi.restoreAllMocks();
+  });
+
+  it('resolves provider flags from the onFeatureFlags variants map', async () => {
+    const { ph } = makePosthog({
+      'llm-provider-anthropic': true,
+      'llm-provider-openai': false,
+    });
+    (window as any).posthog = ph;
+
+    const { result } = renderHook(() => usePostHogFeatureFlags());
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    expect(result.current.isFeatureEnabled('llm-provider-anthropic')).toBe(true);
+    expect(result.current.isFeatureEnabled('llm-provider-openai')).toBe(false);
+    // Undefined flag => fail-open (visible).
+    expect(result.current.isFeatureEnabled('llm-provider-google')).toBe(true);
+  });
+
+  it('does NOT emit per-flag exposure events (PCFIX-1 — no burst)', async () => {
+    const { ph, isFeatureEnabled, getFeatureFlag, onFeatureFlags } = makePosthog({
+      'llm-provider-anthropic': true,
+      'llm-provider-openai': true,
+    });
+    (window as any).posthog = ph;
+
+    const { result } = renderHook(() => usePostHogFeatureFlags());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    // The whole point: flags are read in ONE consolidated pass via onFeatureFlags,
+    // never via the per-flag APIs that fire `$feature_flag_called`.
+    expect(isFeatureEnabled).not.toHaveBeenCalled();
+    expect(getFeatureFlag).not.toHaveBeenCalled();
+    expect(onFeatureFlags).toHaveBeenCalledTimes(1);
+  });
+
+  it('enables all providers when >60% of defined flags are false (safety)', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // 3 defined, 3 false => 100% false > 60% => enable all.
+    const { ph } = makePosthog({
+      'llm-provider-anthropic': false,
+      'llm-provider-google': false,
+      'llm-provider-openai': false,
+    });
+    (window as any).posthog = ph;
+
+    const { result } = renderHook(() => usePostHogFeatureFlags());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    expect(result.current.isFeatureEnabled('llm-provider-anthropic')).toBe(true);
+    expect(result.current.isFeatureEnabled('llm-provider-openai')).toBe(true);
+    expect(result.current.isFeatureEnabled('llm-provider-google')).toBe(true);
+  });
+
+  it('falls back to getFlagVariants cache when the callback has not fired yet', async () => {
+    const { ph, onFeatureFlags } = makePosthog(
+      {},
+      {
+        // 1/3 false (under the 60% safety threshold) so openai stays disabled.
+        cached: {
+          'llm-provider-anthropic': true,
+          'llm-provider-google': true,
+          'llm-provider-openai': false,
+        },
+        fireCallback: false,
+      },
+    );
+    (window as any).posthog = ph;
+
+    const { result } = renderHook(() => usePostHogFeatureFlags());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    expect(onFeatureFlags).toHaveBeenCalledTimes(1);
+    expect(result.current.isFeatureEnabled('llm-provider-openai')).toBe(false);
+    expect(result.current.isFeatureEnabled('llm-provider-anthropic')).toBe(true);
+  });
+
+  it('fails open (everything enabled) while PostHog is not available', () => {
+    // No window.posthog set.
+    const { result } = renderHook(() => usePostHogFeatureFlags());
+
+    expect(result.current.ready).toBe(false);
+    expect(result.current.isFeatureEnabled('llm-provider-anthropic')).toBe(true);
+    expect(result.current.isFeatureEnabled('anything-else')).toBe(true);
+  });
+});

--- a/src/hooks/usePostHogFeatureFlags.ts
+++ b/src/hooks/usePostHogFeatureFlags.ts
@@ -23,11 +23,19 @@ const LLM_PROVIDER_FLAGS = [
 /** Safety: if >60% flags are false, treat as misconfiguration and enable all */
 const MISCONFIGURATION_THRESHOLD = 0.6;
 
+/** Map of flagKey -> resolved value, as delivered by PostHog. */
+type FlagVariants = Record<string, boolean | string>;
+
 /**
  * Hook to access PostHog feature flags on the CLIENT side.
  *
- * Uses `window.posthog` (exposed by LobeAnalyticsProvider) with the
- * official `onFeatureFlags()` callback and `isFeatureEnabled()` API.
+ * PCFIX-1: flags are read in a SINGLE consolidated pass from the variants map
+ * delivered by `onFeatureFlags(cb)` (with `posthog.featureFlags.getFlagVariants()`
+ * as the already-loaded fallback). We deliberately avoid calling
+ * `isFeatureEnabled()` / `getFeatureFlag()` per flag, because each such call emits
+ * a `$feature_flag_called` event — previously ~12 events per page load (one per
+ * provider flag), a synchronous burst that contributed to INP/CLS. Reading from
+ * the variants map fires ZERO per-flag events while preserving identical values.
  *
  * FAIL-OPEN: If PostHog is not loaded or flags haven't been fetched yet,
  * `isFeatureEnabled` returns TRUE so all providers remain visible.
@@ -45,15 +53,15 @@ export const usePostHogFeatureFlags = () => {
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
-    const readFlags = (ph: any) => {
+    const readFlags = (variants: FlagVariants | undefined) => {
       const flags: Record<string, boolean> = {};
       let falseCount = 0;
       let definedCount = 0;
 
       for (const key of LLM_PROVIDER_FLAGS) {
-        // isFeatureEnabled returns true/false/undefined
-        // undefined means flag not defined → treat as true (fail-open)
-        const value = ph.isFeatureEnabled(key);
+        // `variants` holds the resolved value for every evaluated flag.
+        // undefined => flag not defined in project => treat as true (fail-open).
+        const value = variants?.[key];
         flags[key] = value === undefined ? true : !!value;
         if (value !== undefined) {
           definedCount++;
@@ -81,20 +89,22 @@ export const usePostHogFeatureFlags = () => {
     };
 
     const setupFlags = (ph: any) => {
-      // onFeatureFlags fires when flags are loaded (or immediately if already loaded)
-      ph.onFeatureFlags(() => {
-        readFlags(ph);
+      // Single consolidated read: onFeatureFlags delivers the full variants map at
+      // once (and fires immediately if flags are already loaded). No per-flag
+      // isFeatureEnabled() calls => no `$feature_flag_called` burst (PCFIX-1).
+      ph.onFeatureFlags((_enabledKeys: string[], variants: FlagVariants) => {
+        readFlags(variants);
       });
 
-      // Also check if flags are already available right now
-      // (onFeatureFlags might not fire if flags were loaded before this hook mounts)
+      // Belt-and-suspenders: if flags were already cached before the listener was
+      // attached, read them straight from the local cache (no network, no events).
       try {
-        const existingFlags = ph.featureFlags?.getFlags?.();
-        if (existingFlags && existingFlags.length > 0) {
-          readFlags(ph);
+        const cached: FlagVariants | undefined = ph.featureFlags?.getFlagVariants?.();
+        if (cached && Object.keys(cached).length > 0) {
+          readFlags(cached);
         }
       } catch {
-        // getFlags might not exist in all PostHog versions
+        // getFlagVariants might not exist in all PostHog versions — onFeatureFlags covers it.
       }
     };
 


### PR DESCRIPTION
# fix(observability): forward console.error → PostHog + collapse feature-flag eval burst

**Branch:** `fix/posthog-error-tracking-flag-burst`
**Commits:** `dc01e8b3` (TASK 0) · `89cf8af5` (PCFIX-1)
**Spec:** `FIX-SPEC-claude-code-handoff.md` (TASK 0, PCFIX-1)
**Scope:** 5 files (Analytics + 2 hooks). KHÔNG đụng các file subscription/billing đang dở.

---

## Vì sao

Audit PostHog 7 ngày (project Phở Chat) phát hiện 2 vấn đề nền ảnh hưởng diện rộng:

1. **Error tracking đang "mù".** Cả tuần chỉ ~2 `$exception` được ghi, trong khi 1 session replay đã lộ 16 console error không bao giờ tới dashboard. `capture_exceptions` chỉ autocapture lỗi *uncaught* (`window.onerror`) + unhandled rejection; lỗi đã `try/catch` rồi `console.error` thì không thành `$exception`.
2. **Feature-flag eval burst.** Mỗi lần tải trang chat, hook đọc 12 cờ `llm-provider-*` bằng `isFeatureEnabled()` per-flag → mỗi call phát 1 `$feature_flag_called` ⇒ ~12 event đồng bộ/lần tải, góp phần INP spike + CLS. (Đo được: 540 event / 39 user / 40 session, ~12/session.)

---

## Thay đổi

### TASK 0 — forward `console.error` → PostHog (`dc01e8b3`)
- Thêm `src/components/Analytics/consoleErrorForwarding.ts` (+ test) và wire vào `LobeAnalyticsProvider`.
- Route qua `posthog.captureException` → đi qua wrapped `posthog.capture` nên benign-pattern filter tự áp.
- **Cố ý KHÔNG hook `window.onerror`/`onunhandledrejection`** (autocapture đã sở hữu) → tránh double-capture; chỉ forward kênh rời `console.error`.
- An toàn: re-entrancy guard, idempotent (guard trên `window`), no-op khi thiếu `captureException`, không bao giờ throw, giữ nguyên native logging.

### PCFIX-1 — gộp feature-flag eval (`89cf8af5`)
- `usePostHogFeatureFlags` đọc **1 lần** từ map `variants` của `onFeatureFlags(cb)` (fallback `featureFlags.getFlagVariants()` — đều từ cache, **0 event/flag**).
- Bỏ hẳn `isFeatureEnabled()` per-flag → hết burst `$feature_flag_called`.
- Giữ nguyên hành vi: fail-open (`undefined → true`), ngưỡng safety >60% false → enable-all, dev log. Giá trị flag y hệt → **không đổi việc chọn provider**.

---

## Kiểm thử
- `tsgo` typecheck: sạch.
- eslint: sạch.
- 13 unit test mới pass (8 TASK 0 + 5 PCFIX-1). Test PCFIX-1 khẳng định bất biến cốt lõi: `isFeatureEnabled`/`getFeatureFlag` **không** được gọi, `onFeatureFlags` gọi đúng 1 lần.

## Verify sau deploy (staging trước)
- Tile **"🔴 Flag Burst — feature_flag_called per session"**: flag_calls/session giảm **~12 → ~0** cho session mới.
- Tile **"🔴 Error visibility — exceptions tracked per day"**: tăng từ ~0–2/ngày lên phản ánh số lỗi thật.
- (Dashboard: `Phở Chat v1 — Health & UX Audit`, PostHog project 306983.)

---

## ⚠️ Reviewer cần xác nhận / theo dõi

1. **`captureException` có thực sự đi qua wrapped `capture`?** Comment giả định version posthog-js đang dùng route `captureException` vào instance `capture` đã reassign (để benign filter áp lên cả kênh console.error). Nhờ reviewer xác nhận đúng với version trong `package.json` — nếu version đó gọi internal khác thì filter không áp.

   > ✅ **ĐÃ VERIFY — posthog-js `1.352.0` (bản cài trong repo).** Đọc thẳng `dist/module.full.js`:
   > `captureException(err, props)` → `exceptions.sendExceptionEvent(t)` →
   > `return this._instance.capture("$exception", t, {_noTruncate:true, _batchKey:"exceptionEvent"})`.
   > `this._instance` chính là instance đã reassign `posthog.capture`, nên benign-pattern filter **áp lên cả console.error forwarding**. Bonus: `sendExceptionEvent` còn tự skip exception do chính PostHog SDK ném (suppression `this.Ee`). → **Concern này coi như đóng.**

2. **Volume `console.error`.** Forward *mọi* console.error có thể làm tăng mạnh `$exception` (React warnings prod, lib bên thứ ba, log lặp) → nhiễu dashboard + tốn quota PostHog. Benign filter hiện chỉ 6 pattern cố định. **Theo dõi volume trên staging**; nếu cao → thêm sampling hoặc allow/deny list.
3. **PII.** Message console.error (slice 1000 ký tự) có thể chứa token/body/thông tin user trước khi gửi. Đề xuất follow-up: scrub PII trước khi forward. (Không chặn merge.)

## Ngoài phạm vi (đúng spec)
- `useIsProviderEnabled` + `providers.tsx` (trang settings/llm) vẫn dùng `useFeatureFlagEnabled` per-flag — chỉ chạy ở trang settings, không phải burst mỗi lần tải chat. Nên thêm `// TODO(PCFIX-1)` tại 2 chỗ này để sau không tưởng nhầm là sót.
- PCFIX-2 (CLS) tách PR riêng — phụ thuộc PCFIX-1 (bootstrap flag sớm tự giảm CLS), làm sau khi xác nhận burst đã hết.

## Git
- Branch lệch sau main (main đã có commit billing monthly-points). **Rebase `main` vào branch trước khi merge**, chạy lại typecheck + eslint + 13 test, rồi push/mở PR.

---

## Phụ lục — Verify của Claude (posthog-js 1.352.0)

Hai phát hiện khi đọc source `node_modules/posthog-js/dist/module.full.js` để chốt các giả định của PR:

### A. Không double-capture với native autocapture — đã chứng minh bằng code
posthog-js normalize config exception autocapture (hàm `Ar()`):

```js
defaults = { capture_unhandled_errors:false, capture_unhandled_rejections:false, capture_console_errors:false }
// capture_exceptions là OBJECT  → merge object đó lên defaults
// capture_exceptions === true   → CHỈ bật unhandled_errors + unhandled_rejections
//                                  (capture_console_errors VẪN = false)
```

Config hiện tại là `capture_exceptions: true` (boolean) ⇒ `capture_console_errors = false`.
Vậy PostHog **không** tự hook `console.error`; helper `consoleErrorForwarding` là đường duy nhất forward kênh này ⇒ **không double-capture**, và gap "16 console error không lên dashboard" là thật.

### B. Có sẵn option native `capture_console_errors` — lựa chọn thiết kế cho reviewer
posthog-js hỗ trợ bật console-error forwarding ngay trong config (không cần custom helper):

```ts
capture_exceptions: {
  capture_unhandled_errors: true,
  capture_unhandled_rejections: true,
  capture_console_errors: true, // <-- thay cho custom helper
}
```

Native cũng đi qua `captureException → this._instance.capture` nên benign filter vẫn áp.
PR này **cố ý dùng custom helper** thay vì native vì:
- gắn được property `mechanism: 'console.error'` để lọc/định danh trên dashboard;
- kiểm soát truncate (1000 ký tự) và là chỗ tự nhiên để thêm **PII scrub / sampling** (concern #2, #3) sau này — native là hộp đen khó chèn;
- đã có 8 unit test bao bất biến (idempotent, re-entrancy, no-throw, no-op).

Nếu reviewer ưu tiên ít code hơn, có thể đổi sang native trong follow-up — cả hai đều đúng. Lưu ý: concern volume/PII (#2, #3) áp dụng **như nhau** cho cả hai cách.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward handled console errors to PostHog and collapsed feature-flag evaluation to remove the per-flag event burst. This restores error visibility and reduces sync work on page load without changing provider selection.

- **Bug Fixes**
  - Console errors → PostHog: Forward `console.error` to `posthog.captureException` (through the wrapped `posthog.capture` benign filter). No `window.onerror` hooks, keeps native logging, idempotent, and re-entrancy guarded. Leave `capture_exceptions: true` (do not enable `capture_console_errors`) to avoid double-capture.
  - Flag evaluation: Read all `llm-provider-*` flags once via `onFeatureFlags` variants (fallback `featureFlags.getFlagVariants()`), removing per-flag `isFeatureEnabled` calls and the `$feature_flag_called` burst. Behavior unchanged (fail-open + >60% false safety kept). Settings-only per-flag reads remain with a TODO.

<sup>Written for commit 33bbe457fa07d499a3589f06961f7ebeff54409c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Console errors are now forwarded to analytics with automatic detection.

* **Improvements**
  * Expanded error message suppression filters for cleaner analytics.
  * Optimized feature flag retrieval to read from consolidated data source.

* **Tests**
  * Added comprehensive test coverage for console error forwarding.
  * Enhanced feature flag hook test suite.

* **Documentation**
  * Updated inline documentation for analytics configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->