### PR TITLE
👷 fix(ci): decouple lint from Test Database job + declare vitest globals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,26 @@ config.overrides = [
       'typescript-sort-keys/string-enum': 0,
     },
   },
+
+  {
+    // Vitest runs with `globals: true` (see vitest.config.mts), so test files use
+    // `vi`/`describe`/`it`/`expect`/lifecycle hooks as runtime globals without importing
+    // them. Declare them here so ESLint stops flagging `no-undef`.
+    files: ['**/*.test.{js,jsx,ts,tsx}', '**/__tests__/**/*.{js,jsx,ts,tsx}', 'tests/**/*.{js,jsx,ts,tsx}'],
+    globals: {
+      afterAll: 'readonly',
+      afterEach: 'readonly',
+      beforeAll: 'readonly',
+      beforeEach: 'readonly',
+      describe: 'readonly',
+      expect: 'readonly',
+      it: 'readonly',
+      suite: 'readonly',
+      test: 'readonly',
+      vi: 'readonly',
+      vitest: 'readonly',
+    },
+  },
 ];
 
 module.exports = config;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,35 @@ permissions:
   contents: read
 
 jobs:
+  # Standalone lint gate — decoupled from the Test Database job (PHO-276) so the DB
+  # tests get real signal instead of being skipped behind a failing lint step.
+  # Allowed to be red as tracked tech-debt until the baseline ESLint errors are
+  # cleaned; as its own job it does not mask any other job's result.
+  lint:
+    name: Lint
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          package-manager-cache: false
+
+      - name: Install bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install deps
+        run: bun i
+
+      - name: Lint
+        run: bun run lint
+
   # Package tests - using each package's own test script
   test-intenral-packages:
     runs-on: ubuntu-latest
@@ -153,9 +182,6 @@ jobs:
 
       - name: Install deps
         run: bun i
-
-      - name: Lint
-        run: bun run lint
 
       - name: Test Client DB
         run: bun run --filter @lobechat/database test:client-db


### PR DESCRIPTION
## Why

The `Test CI / Test Database` check has been red on `main` since ~2026-05-03 (10+ consecutive runs). The job ran `bun run lint` as a **gate step before** the DB tests, so a pre-existing ESLint baseline (`193 problems / 109 errors / 84 warnings`) made `Test Client DB` + `Test Coverage` **skip** — the DB tests this job exists to run **have not executed in ~1 month**.

Surfaced while investigating PR #55, whose CI signal was masked by this baseline (it added 0 lint errors).

## What

1. **Decouple lint into its own `lint` job.** The Test Database job no longer runs `bun run lint`; it goes straight to the DB tests. Lint is now a standalone job that stays **honestly red** as tracked tech-debt (PHO-276) and — being separate — masks no other job's result.
2. **Declare Vitest globals for test files in `.eslintrc.js`.** `vitest.config.mts` sets `globals: true`, so `vi`/`describe`/`it`/lifecycle hooks are genuine runtime globals (not missing imports). This clears the **25 `'vi' is not defined` no-undef errors** — verified locally with `eslint … --fix-dry-run`: **109 → 84 errors**. It's the only config-gap subset; the remaining 84 are real scattered issues left to PHO-276.

## ⚠️ Reviewer notes

- **The `lint` job will be RED.** That is expected and intentional — the baseline cleanup is PHO-276, not this PR. This PR only stops lint from blocking the DB tests.
- **This makes the DB tests run for the first time in ~1 month.** If the `Test Database` job comes back red once unblocked, that is a **new finding** to triage separately (noted in PHO-276) — it is NOT a regression introduced here.
- Out of scope (deliberately): cleaning the 84 scattered lint errors, and `lint:style` / `type-check` (which never ran behind the failing `lint:ts` — verify in PHO-276).

Refs PHO-276. Related to #55.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split lint into its own CI job and removed it from the Test Database job so DB tests run again. Declared `vitest` globals in `.eslintrc.js` to stop false `no-undef` errors.

- **Bug Fixes**
  - Added a standalone `lint` job in `.github/workflows/test.yml`; Test Database now runs only DB tests. Lint may stay red; cleanup is tracked in PHO-276.
  - Declared test globals (`vi`, `describe`, `it`, hooks) in `.eslintrc.js` to align with `vitest` `globals: true`, clearing 25 `no-undef` errors; remaining lint issues are separate debt.

<sup>Written for commit 0af0e43ece23a6a0a3036c07ce018092d2f83664. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced linting configuration to properly recognize testing framework globals, reducing false positives during code quality checks.
  * Optimized CI/CD pipeline by separating linting into a dedicated workflow job for improved build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->