### PR TITLE
⚡️ perf(chat): cut /chat CLS + kill react-virtuoso Zero-sized console-error storm

### DIFF
--- a/src/app/[variants]/(main)/chat/(workspace)/@conversation/loading.tsx
+++ b/src/app/[variants]/(main)/chat/(workspace)/@conversation/loading.tsx
@@ -1,12 +1,9 @@
-import { Skeleton } from 'antd';
-import { Flexbox } from 'react-layout-kit';
+import { SkeletonList } from '@/features/Conversation';
 
-export default () => (
-  <Flexbox flex={1} height={'100%'} style={{ position: 'relative' }} width={'100%'}>
-    <Flexbox flex={1} gap={16} padding={16}>
-      {Array.from({ length: 4 }).map((_, i) => (
-        <Skeleton active avatar key={i} paragraph={{ rows: 2 }} />
-      ))}
-    </Flexbox>
-  </Flexbox>
-);
+// PHO-92 (CLS): reuse the same skeleton the loaded list falls back to
+// (ChatList Suspense fallback + VirtualizedList first-load). The previous
+// bespoke full-width skeleton sat in a different container geometry
+// (left-aligned, padding 16) than the real content (WideScreenContainer:
+// centered, narrower, marginTop 24), so the loading -> content swap caused a
+// horizontal + vertical layout shift. SkeletonList matches the real geometry.
+export default () => <SkeletonList />;

--- a/src/app/[variants]/(main)/chat/loading.tsx
+++ b/src/app/[variants]/(main)/chat/loading.tsx
@@ -1,3 +1,20 @@
-import Loading from '@/components/Loading/BrandTextLoading';
+import { Flexbox } from 'react-layout-kit';
 
-export default () => <Loading />;
+import { SkeletonList } from '@/features/Conversation';
+
+// PHO-92 (CLS): the previous full-screen brand spinner reserved none of the
+// loaded workspace geometry, so the swap to the real shell (40px ChatHeader +
+// centered message list) rearranged the whole viewport. Mirror that geometry
+// here — a reserved header strip plus the same centered SkeletonList the
+// conversation falls back to — so the loading -> loaded transition barely
+// shifts. The session sidebar (@session) lives in the parent chat layout and
+// is already painted, so it must NOT be reserved here.
+export default () => (
+  <Flexbox height={'100%'} width={'100%'}>
+    {/* reserve ChatHeader height — see _layout/Desktop/ChatHeader (height: 40) */}
+    <Flexbox flex={'none'} height={40} />
+    <Flexbox flex={1} style={{ overflow: 'hidden', position: 'relative' }} width={'100%'}>
+      <SkeletonList />
+    </Flexbox>
+  </Flexbox>
+);

--- a/src/features/Conversation/components/VirtualizedList/Item.test.tsx
+++ b/src/features/Conversation/components/VirtualizedList/Item.test.tsx
@@ -1,0 +1,54 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import Item from './Item';
+
+// Regression guard for the react-virtuoso "Zero-sized element, this should not
+// happen" console.error storm (~400/day, 93% mobile) + the related /chat CLS.
+// react-virtuoso measures each rendered item's offsetHeight and logs an ERROR
+// when it is 0. Chat items render momentarily empty (dynamic ssr:false chunk
+// still loading, or a message id present in `mainDisplayChatIDs` before its
+// object lands in the store map during streaming). Flooring the item wrapper at
+// 1px keeps offsetHeight >= 1 so the spurious error never fires.
+describe('VirtualizedList <Item>', () => {
+  const baseProps = {
+    'data-index': 0,
+    'data-item-index': 0,
+    'data-known-size': 0,
+    'item': 'msg_1',
+  } as const;
+
+  it('floors an empty item wrapper at min-height 1px so it never measures 0', () => {
+    const { container } = render(<Item {...baseProps}>{null}</Item>);
+
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper.style.minHeight).toBe('1px');
+  });
+
+  it("preserves virtuoso's positioning style + data attrs and drops the item data prop", () => {
+    const { container } = render(
+      <Item
+        {...baseProps}
+        data-index={3}
+        data-known-size={88}
+        item="msg_42"
+        style={{ transform: 'translateY(120px)' }}
+      >
+        <span>message</span>
+      </Item>,
+    );
+
+    const wrapper = container.firstElementChild as HTMLElement;
+    // Virtuoso's own positioning style must survive...
+    expect(wrapper.style.transform).toBe('translateY(120px)');
+    // ...alongside the 1px floor...
+    expect(wrapper.style.minHeight).toBe('1px');
+    // ...and the data-* attributes virtuoso reads back for virtualization.
+    expect(wrapper.dataset.index).toBe('3');
+    expect(wrapper.dataset.knownSize).toBe('88');
+    // The row data must NOT leak onto the DOM (matches the default 'div' item).
+    expect(wrapper.hasAttribute('item')).toBe(false);
+    expect(wrapper.textContent).toBe('message');
+  });
+});

--- a/src/features/Conversation/components/VirtualizedList/Item.tsx
+++ b/src/features/Conversation/components/VirtualizedList/Item.tsx
@@ -1,0 +1,28 @@
+import { ItemProps } from 'react-virtuoso';
+
+// PHO-92 (CLS) / observability: react-virtuoso re-measures every rendered item's
+// `offsetHeight` through a ResizeObserver and logs
+// `react-virtuoso: Zero-sized element, this should not happen` at ERROR severity
+// (-> console.error -> PostHog via consoleErrorForwarding) whenever a *visible*
+// item wrapper measures 0. In the chat list this fires transiently while an item
+// is momentarily empty: the dynamic (ssr:false) ChatItem chunk is still loading,
+// or a message id is briefly in `mainDisplayChatIDs` before its object lands in
+// the store map during streaming / add / delete. Mobile samples that window far
+// more often (URL-bar / soft-keyboard / dvh resizes fire the observer constantly),
+// which is why ~93% of the errors are mobile. Flooring every item wrapper at 1px
+// guarantees offsetHeight >= 1, so the spurious error — and the 0 -> real-height
+// layout shift (CLS) it signals — never fire. Real messages are far taller, so the
+// floor is layout-neutral.
+//
+// Kept in its own dependency-light module so it can be unit-tested without dragging
+// the chat store (and its `@/utils/*` graph) through the vitest module resolver.
+//
+// `item` (the row data) is stripped: virtuoso passes it only to *custom* Item
+// components, never to the default 'div' item, so dropping it keeps the rendered
+// DOM identical to the default item apart from the 1px floor.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
+const Item = ({ item, style, ...props }: ItemProps<string>) => (
+  <div {...props} style={{ ...style, minHeight: 1 }} />
+);
+
+export default Item;

--- a/src/features/Conversation/components/VirtualizedList/index.tsx
+++ b/src/features/Conversation/components/VirtualizedList/index.tsx
@@ -10,6 +10,7 @@ import { chatSelectors } from '@/store/chat/selectors';
 
 import AutoScroll from '../AutoScroll';
 import SkeletonList from '../SkeletonList';
+import Item from './Item';
 import { VirtuosoContext } from './VirtuosoContext';
 
 interface VirtualizedListProps {
@@ -69,6 +70,7 @@ const VirtualizedList = memo<VirtualizedListProps>(({ mobile, dataSource, itemCo
         atBottomStateChange={setAtBottom}
         atBottomThreshold={50 * (mobile ? 2 : 1)}
         components={{
+          Item,
           List,
         }}
         computeItemKey={(_, item) => item}


### PR DESCRIPTION
> **Draft** per spec — flip to Ready only after the dashboard confirms CLS dropped **and** the `Zero-sized element` error went to ~0 on new sessions.

## Why
PostHog `$web_vitals` (7d, project 306983) shows CLS concentrated almost entirely on **`/chat`** (p75 **0.237**, max **1.281**); every other route is already "Good" (<0.1). The shifts trace to load-time placeholders whose geometry doesn't match the loaded layout — **and**, as the expanded section below shows, to react-virtuoso measuring chat items at height 0.

## What changed (loading placeholders)
- **`chat/loading.tsx`** — was a full-screen centered brand spinner (`BrandTextLoading`) that reserved none of the workspace shell, so the swap to the real `[40px ChatHeader + centered message list]` rearranged the whole viewport. Now reserves that geometry: a 40px header strip + the same `SkeletonList` the conversation falls back to. The `@session` sidebar lives in the **parent** chat layout (already painted during this loading state), so it is deliberately **not** reserved here.
- **`@conversation/loading.tsx`** — was a bespoke full-width, left-aligned skeleton (padding 16) while the real content sits in `WideScreenContainer` (centered, narrower, `marginTop 24`) → a guaranteed horizontal + vertical shift. Now reuses `SkeletonList`, matching the loaded geometry exactly.

Both files now render the **same** `SkeletonList` the loaded list uses (`ChatList` Suspense fallback + `VirtualizedList` first-load), so loading → fallback → content stays geometrically stable.

---

## ⬆️ Expanded (2026-06-02): root cause of the *same* shift — and the console-error storm

After #55 turned on `console.error` → PostHog forwarding, production surfaced **~407 `$exception` / 4 days (mechanism=console.error), all one bug**: `react-virtuoso: Zero-sized element, this should not happen`. **93% mobile, 93% `showMobileWorkspace=true`, 96% `session=`, only 4 users** — i.e. every one fired while the **message list was on screen**.

### Root cause — verified against react-virtuoso 4.18.1 source (corrects the audit's container-height guess)
- react-virtuoso re-measures each rendered item's `offsetHeight` via a ResizeObserver and logs the message at **ERROR** severity when it's `0` (`dist/index.mjs`, `vo()` → the `m === 0` branch).
- That observer is **guarded by `offsetParent !== null`** — a `display:none` / hidden list is **never measured**. So the *container-height-0 / mobile-workspace-toggle* hypothesis is **ruled out**: the error can only come from a **visible** list whose individual **item** is momentarily 0-height.
- In the chat list that happens because `@conversation/…/ChatList/Content.tsx` renders `MainChatItem` via `dynamic(…, { ssr: false })` with no placeholder (renders `null` while the chunk loads), and `ChatItem` returns `item && (…)` → empty when `getMessageById(id)` is briefly out of sync during streaming / add / delete.
- **Why 93% mobile:** mobile fires the item ResizeObserver far more often (URL-bar / soft-keyboard / `dvh` viewport changes), so it samples the transient 0-height window ~13× more than desktop. The **same `0 → real-height` correction is the CLS** this PR targets — one bug, two symptoms.

### Fix — `VirtualizedList` item floor
New custom `components.Item` for the message-list `Virtuoso` that floors every item wrapper at `min-height: 1px` → `offsetHeight ≥ 1` always → the `m === 0` ERROR (and the `0 → N` layout jump) never fire, **content-agnostic** (covers dynamic-chunk load, streaming desync, any empty item). Otherwise behaviourally identical to virtuoso's default `div` item — it also strips the custom-only `item` prop so the rendered DOM matches the default. Kept in its own dependency-light `Item.tsx` so it's unit-testable (`Item.test.tsx`) without dragging the chat store through the vitest resolver. The shared `VirtualizedList` also backs the **Portal thread chat**, so both surfaces are fixed by one change.

Adversarially reviewed across 3 lenses (mechanism / regression / scope) — all **confirmed**. No chat-container refactor; no AI/model or billing WIP touched.

## Approach note (important)
The CLI can't open a browser, so there was **no live DevTools/replay measurement**. The skeleton change is **defensive** (aligns *every* load-time skeleton to the loaded geometry); the item-floor change is **root-cause** (verified against the library source + the PostHog stack/distribution). **Real acceptance is the dashboard, not code review.**

## Acceptance (production, post-deploy — Android Chrome where 92% of errors occur)
- `react-virtuoso: Zero-sized element` → **~0** on the error-tracking tile.
- CLS p75 `/chat` **< 0.1** (tile "Web Vitals percentiles", dashboard "Phở Chat v1 — Health & UX Audit") on new mobile sessions.

## Follow-up (not in this PR) → PHO-276
Add fingerprint **dedup / sampling** to `consoleErrorForwarding.ts` so a single client defect can't mint hundreds of `$exception` events again (this one bug = 400+/day). Volume self-drops once the floor lands; dedup is defense-in-depth for the next one.

## Deliberately NOT touched
- No chat-container refactor (per spec: would stop and report first).
- No AI/model logic, no billing/subscription WIP.
- Other suspects (ChatInput, avatars) are already height-reserved by flex/Avatar sizing — touching them would be a refactor, not reserve-space.
- Fonts: repo uses no `next/font`/HarmonyOS web font with FOUT risk → out of scope.

## Verify
- eslint + type-check clean (pre-commit hook + manual `tsgo --noEmit` = exit 0); `Item.test.tsx` 2/2 green.
- After preview/staging deploy: confirm on a fresh **mobile** session that the error tile → ~0 and CLS p75 `/chat` < 0.1.

Refs PHO-92.
