### PR TITLE
📈 PCFIX-4: add TTFT ($ai_ttft_ms) to $ai_generation telemetry

### DIFF
--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -742,6 +742,9 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
       (async () => {
         let accumulatedText = '';
         let completed = false;
+        // PCFIX-4: time-to-first-token. Stamped on the first non-empty chunk so
+        // we can distinguish "stalled before first token" from "long stream".
+        let ttftMs: number | undefined;
 
         try {
           const reader = stream2.getReader();
@@ -750,6 +753,9 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
           for (;;) {
             const { done, value } = await reader.read();
             if (done) break;
+            if (ttftMs === undefined && value && value.length > 0) {
+              ttftMs = Date.now() - requestStartTime;
+            }
             accumulatedText += decoder.decode(value, { stream: true });
           }
           completed = true;
@@ -799,6 +805,8 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
                   planId: userPlanId,
                   provider: actualProviderUsed,
                   responseTimeMs,
+                  // PCFIX-4: TTFT (stream path only). Undefined if no chunk arrived before abort.
+                  ttftMs,
                 },
               );
             }

--- a/src/libs/__tests__/posthog-server.test.ts
+++ b/src/libs/__tests__/posthog-server.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Never hit a real DB/Clerk even if a test omits planId and the capture path
+// falls back to getUserPlanFromDB.
+vi.mock('@/server/services/subscription/getUserPlanFromDB', () => ({
+  getUserPlanFromDB: vi.fn().mockResolvedValue({ planId: 'fallback_plan', source: 'db' }),
+}));
+
+/**
+ * PCFIX-4: pin the $ai_ttft_ms contract on the server-side `$ai_generation`
+ * capture. TTFT is what lets dashboards tell "stalled before first token" apart
+ * from "long stream" — so it must be emitted when present and absent (not null)
+ * when the caller did not measure it (e.g. non-streaming paths).
+ */
+describe('captureAiGeneration — $ai_ttft_ms (PCFIX-4)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  const baseParams = {
+    costPoints: 10,
+    inputTokens: 100,
+    latencyMs: 5000,
+    model: 'anthropic/claude-sonnet-4.6',
+    outputTokens: 800,
+    planId: 'medical_beta', // pass plan to skip the DB fallback lookup
+    provider: 'vercelaigateway',
+    tier: 2,
+    userId: 'user_123',
+  };
+
+  beforeEach(() => {
+    // POSTHOG_KEY is read at module-load time, so stub env BEFORE the dynamic import.
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_KEY', 'phc_test_key');
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, statusText: 'OK' });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  const importFresh = async () => {
+    vi.resetModules();
+    return import('../posthog-server');
+  };
+
+  const capturedProperties = async () => {
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const init = fetchMock.mock.calls[0][1] as { body: string };
+    return JSON.parse(init.body).properties;
+  };
+
+  it('emits $ai_ttft_ms when ttftMs is provided (streaming path)', async () => {
+    const { captureAiGeneration } = await importFresh();
+
+    captureAiGeneration({ ...baseParams, ttftMs: 1234 });
+
+    const props = await capturedProperties();
+    expect(props.$ai_ttft_ms).toBe(1234);
+    // total wall-clock stays available for comparison.
+    expect(props.$ai_latency_ms).toBe(5000);
+  });
+
+  it('omits $ai_ttft_ms (not null) when ttftMs is undefined (non-streaming path)', async () => {
+    const { captureAiGeneration } = await importFresh();
+
+    captureAiGeneration({ ...baseParams }); // no ttftMs
+
+    const props = await capturedProperties();
+    expect('$ai_ttft_ms' in props).toBe(false);
+    expect(props.$ai_latency_ms).toBe(5000);
+  });
+
+  it('stamps ttftMs=0 explicitly rather than dropping it', async () => {
+    const { captureAiGeneration } = await importFresh();
+
+    // A first chunk arriving in the same millisecond yields ttftMs=0; that is a
+    // real measurement and must survive (0 !== undefined).
+    captureAiGeneration({ ...baseParams, ttftMs: 0 });
+
+    const props = await capturedProperties();
+    expect(props.$ai_ttft_ms).toBe(0);
+  });
+});

--- a/src/libs/posthog-server.ts
+++ b/src/libs/posthog-server.ts
@@ -40,6 +40,13 @@ export interface CaptureAiGenerationParams {
   provider: string;
   /** PHO-246: model tier (1/2/3) for cost-per-tier breakdowns. */
   tier?: number;
+  /**
+   * PCFIX-4: time-to-first-token in ms. Streaming paths set this when the first
+   * content chunk arrives; undefined for non-streaming / unmeasured calls.
+   * `$ai_latency_ms` (total wall-clock) minus this approximates stream duration,
+   * so we can tell "stalled before first token" from "long stream".
+   */
+  ttftMs?: number;
   userId: string;
 }
 
@@ -88,6 +95,8 @@ async function emitAiGeneration(params: CaptureAiGenerationParams): Promise<void
       $ai_output_tokens: params.outputTokens,
       $ai_partial: params.partial ?? false,
       $ai_provider: params.provider,
+      // PCFIX-4: time-to-first-token (stream paths). Undefined values are dropped by JSON.stringify.
+      $ai_ttft_ms: params.ttftMs,
       ...(params.costUSD !== undefined && { $ai_cost_usd: params.costUSD }),
       // PHO-246: cost-per-plan / cost-per-tier breakdowns.
       ...(planId !== undefined && { planId }),

--- a/src/server/services/billing/credits.ts
+++ b/src/server/services/billing/credits.ts
@@ -114,6 +114,13 @@ export interface UsageLogParams {
   provider: string;
   responseTimeMs?: number;
   sessionId?: string;
+  /**
+   * PCFIX-4: time-to-first-token (ms) for streaming responses. Forwarded to
+   * PostHog as `$ai_ttft_ms` so we can tell "stalled before first token" (high
+   * TTFT) apart from "long stream" (low TTFT, high total). Undefined for
+   * non-streaming paths where the full response is buffered before metering.
+   */
+  ttftMs?: number;
 }
 
 /**
@@ -341,6 +348,7 @@ export async function processModelUsage(
         planId: usageLog.planId,
         provider: usageLog.provider,
         tier,
+        ttftMs: usageLog.ttftMs,
         userId,
       });
     }


### PR DESCRIPTION
## What & Why

`$ai_latency_ms` (server-side `$ai_generation`) is **total wall-clock only**. It cannot distinguish:
- **"stalled before first token"** (bad UX — user stares at a blank screen), from
- **"long stream"** (a 31k-token answer that takes 100s is physically expected, not a bug).

This gap surfaced while investigating the **01/06 sonnet-4.6 latency spike** (avg 38.3s, max 250s). The investigation concluded that spike was **user behaviour** (a cluster of `medical_beta` tier-2 users requesting very long answers — output↔latency = +0.47, input↔latency ≈ 0), **not a code regression** — no LLM-config change exists in git for the window. But it proved we're flying half-blind on latency: without TTFT we can't tell a stall from a long-but-healthy stream.

This PR adds **TTFT (time-to-first-token)** as `$ai_ttft_ms` so dashboards can split the two.

## Changes (additive only — no billing logic touched)

- **`src/libs/posthog-server.ts`** — add `ttftMs?` to `CaptureAiGenerationParams`; emit `$ai_ttft_ms`. Undefined values are dropped by `JSON.stringify`, so non-streaming calls stay **absent (not null)**.
- **`src/server/services/billing/credits.ts`** — add `ttftMs?` to `UsageLogParams`; forward it to `captureAiGeneration`.
- **`src/app/(backend)/webapi/chat/[provider]/route.ts`** — stamp `ttftMs` on the **first non-empty stream chunk**; sticky so a same-millisecond first chunk (`0ms`) survives. Non-streaming branch leaves it undefined (full response is buffered before metering).
- **`src/libs/__tests__/posthog-server.test.ts`** — new unit test pinning the contract: emitted when present, absent when undefined, `0` preserved.

## Verification

- ✅ Types: 0 IDE diagnostics on all 4 files.
- ✅ Lint: `prettier` + `eslint --fix` run manually (lint-staged equivalent), exit 0.
- ✅ Tests: `posthog-server.test.ts` 3/3 pass.
- ⚠️ Committed with `--no-verify` (approved): the repo pre-commit hook runs full-repo `tsgo --noEmit`, which OOMs on the dev machine (`ERROR_COMMITMENT_LIMIT`) — environment limit, not this code. **CI type-check is the backstop.**

## Scope / Follow-up

- Covers the **main in-UI chat path** (the production source of `provider=vercelaigateway` `$ai_generation` events).
- `research/ai-summary` + `artifact-ai` streaming paths can adopt the same 3-line pattern via the shared `UsageLogParams.ttftMs` — left as a trivial follow-up to keep this diff surgical.

## Notes

- Base: `main`. Independent of #57 (CLS). Does **not** touch billing WIP or model routing.
- Once merged + verified in PostHog (compare `$ai_ttft_ms` vs `$ai_latency_ms` on a few streamed sonnet-4.6 calls), this closes the PCFIX-4 measurement gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add time-to-first-token telemetry (`$ai_ttft_ms`) to server-side `$ai_generation` events to distinguish stalls before first token from normal long streams. Addresses PCFIX-4 by improving latency visibility alongside `$ai_latency_ms`.

- **New Features**
  - `src/libs/posthog-server.ts`: add `ttftMs` to `CaptureAiGenerationParams`; emit `$ai_ttft_ms` (undefined values omitted).
  - `src/server/services/billing/credits.ts`: thread `ttftMs` through `UsageLogParams` to `captureAiGeneration`.
  - `src/app/(backend)/webapi/chat/[provider]/route.ts`: set `ttftMs` on the first non-empty stream chunk; preserve `0ms`; non-streaming leaves it undefined.
  - `src/libs/__tests__/posthog-server.test.ts`: tests for present/absent emission and preserving `0`.

<sup>Written for commit 19eca1cbeff7d08e19c17f27dcac56fd245d3a4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

