### PR TITLE
⚡️ perf(model-runtime): enable Vercel AI Gateway automatic prompt caching

### DIFF
--- a/packages/model-runtime/src/providers/vercelaigateway/index.ts
+++ b/packages/model-runtime/src/providers/vercelaigateway/index.ts
@@ -29,13 +29,18 @@ export const LobeVercelAIGatewayAI = createOpenAICompatibleRuntime({
   baseURL: 'https://ai-gateway.vercel.sh/v1',
   chatCompletion: {
     handlePayload: (payload) => {
-      const { model, reasoning_effort, verbosity, ...rest } = payload;
+      const { model, reasoning_effort, verbosity, enabledContextCaching = true, ...rest } = payload;
 
+      const providerOptions: any = {};
       // Enable Vercel AI Gateway automatic prompt caching. The gateway inserts
       // cache_control markers on static prefixes (system prompt + earlier turns)
       // for providers that support it (e.g. Anthropic), and is a no-op otherwise.
       // This cuts input cost on long, repeated-prefix conversations.
-      const providerOptions: any = { gateway: { caching: 'auto' } };
+      // Respect the user's context-caching opt-out (defaults on), matching the
+      // native anthropic provider's `enabledContextCaching` behaviour.
+      if (enabledContextCaching) {
+        providerOptions.gateway = { caching: 'auto' };
+      }
       if (reasoning_effort || verbosity) {
         providerOptions.openai = {};
         if (reasoning_effort) {

--- a/packages/model-runtime/src/providers/vercelaigateway/index.ts
+++ b/packages/model-runtime/src/providers/vercelaigateway/index.ts
@@ -31,15 +31,20 @@ export const LobeVercelAIGatewayAI = createOpenAICompatibleRuntime({
     handlePayload: (payload) => {
       const { model, reasoning_effort, verbosity, ...rest } = payload;
 
-      const providerOptions: any = {};
-      if (reasoning_effort) {
-        providerOptions.openai = {
-          reasoningEffort: reasoning_effort,
-          reasoningSummary: 'auto'
-        };
-      }
-      if (verbosity) {
-        providerOptions.openai.textVerbosity = verbosity;
+      // Enable Vercel AI Gateway automatic prompt caching. The gateway inserts
+      // cache_control markers on static prefixes (system prompt + earlier turns)
+      // for providers that support it (e.g. Anthropic), and is a no-op otherwise.
+      // This cuts input cost on long, repeated-prefix conversations.
+      const providerOptions: any = { gateway: { caching: 'auto' } };
+      if (reasoning_effort || verbosity) {
+        providerOptions.openai = {};
+        if (reasoning_effort) {
+          providerOptions.openai.reasoningEffort = reasoning_effort;
+          providerOptions.openai.reasoningSummary = 'auto';
+        }
+        if (verbosity) {
+          providerOptions.openai.textVerbosity = verbosity;
+        }
       }
 
       return {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] ⚡️ perf

#### 🔀 变更说明 | Description of Change

**Audit:** Vercel AI Gateway credit spend over the last 3 days (1–3 Jun 2026).

Telemetry (PostHog `$ai_generation`, project 306983) showed ~**97% of cost (~$47 / 3 days)** came from normal chat (`$ai_feature=chat`) on **`anthropic/claude-sonnet-4.6`** routed through the gateway:

| Day | #generations | avg input tok | avg output tok | avg $/call |
|---|---|---|---|---|
| 1 Jun | 73 | 19,951 | 5,869 | $0.148 |
| 2 Jun | 156 | 13,239 | 4,233 | $0.103 |
| 3 Jun | 125 | 14,379 | 7,906 | $0.162 |

Root cause: large repeated-prefix contexts (~13–20k input tokens/call) with **no prompt caching**, so the full conversation prefix was re-billed every turn. Not a code regression (no model/gateway/caching commit around the spike) and not pipeline fan-out (content-visualizer is a stub; vision/translation cost is negligible).

**Fix:** Set `providerOptions.gateway.caching: 'auto'` in the `vercelaigateway` provider `handlePayload` (single chokepoint covering all gateway chat traffic, incl. `webapi/chat/[provider]`). The gateway inserts `cache_control` markers on static prefixes for caching-capable providers (Anthropic) and is a no-op otherwise, so enabling globally is safe. Cache reads cut ~90% of input cost on the repeated prefix.

Also fixes a latent crash: `providerOptions.openai.textVerbosity` was set when only `verbosity` (not `reasoning_effort`) was provided, leaving `providerOptions.openai` undefined.

#### 📝 补充信息 | Additional Information

**Verification (post-merge / preview):**
- Run a multi-turn chat on `anthropic/claude-sonnet-4.6` with `DEBUG_VERCELAIGATEWAY_CHAT_COMPLETION=1`; confirm request body carries `providerOptions.gateway.caching='auto'` and response usage shows `cache_read_input_tokens > 0` on turn 2+.
- After 1–2 days, re-check PostHog `get-llm-total-costs-for-project` (projectId 306983); expect a clear drop in avg $/call for sonnet-4.6 on long conversations.

**Follow-ups (not in this PR):** context-window trimming/summarization, daily spend guardrail/alert, and gating premium models by plan/tier.

https://claude.ai/code/session_01CqrRs7AC76qKxvkmAnLuoQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqrRs7AC76qKxvkmAnLuoQ)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Vercel AI Gateway automatic prompt caching for chat requests to cut input token costs on long conversations (notably `anthropic/claude-sonnet-4.6`), while honoring the `enabledContextCaching` opt-out. Also fix a crash when only `verbosity` is provided.

- **Bug Fixes**
  - Ensure `providerOptions.openai` is defined before setting `textVerbosity`.
  - Respect `enabledContextCaching` (default true) and strip it from the forwarded request.

<sup>Written for commit 040a8e637d0fc9bd77b2421bdc366f8ca531cd5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic prompt caching is now enabled by default for Vercel AI Gateway interactions.
  * Enhanced configuration flexibility for reasoning and verbosity settings, with improved support for independent verbosity adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->