### PR TITLE
🔒️ fix(billing): enforce plan/tier gating + daily cost caps on /api/v1/chat

### DIFF
--- a/src/app/api/v1/chat/route.ts
+++ b/src/app/api/v1/chat/route.ts
@@ -4,7 +4,15 @@ import { getApiModels, getModelCost, getValidModelIds } from '@/config/modelCata
 import { getModelTier } from '@/config/pricing';
 import { getServerDB } from '@/database/server';
 import { initModelRuntimeWithUserPayload } from '@/server/modules/ModelRuntime';
+import {
+  checkDailyRequestCap,
+  checkTierAccess,
+  getUserCreditBalance,
+} from '@/server/services/billing/credits';
+import { checkDailyCostCap } from '@/server/services/billing/dailyCostAggregation';
+import { getSecondsUntilMidnightVN } from '@/server/services/billing/dailyCostCaps';
 import { phoGatewayService } from '@/server/services/phoGateway';
+import { getUserPlanIdFromDB } from '@/server/services/subscription/getUserPlanFromDB';
 
 export const maxDuration = 120;
 
@@ -202,6 +210,96 @@ export async function POST(request: NextRequest): Promise<NextResponse | Respons
         },
       },
       { status: 400 },
+    );
+  }
+
+  // ── Plan / tier gating + daily cost guardrails (parity with web chat route) ──
+  // The public API previously bypassed checkTierAccess and the daily USD cost
+  // caps, letting any pho_ key call premium (Tier 2/3) models regardless of plan
+  // and with no daily ceiling. Mirror the web route's enforcement here. DB is the
+  // single source of truth for the plan (not users.currentPlanId).
+  const userPlanId = await getUserPlanIdFromDB(user.dbUserId);
+  const modelTier = getModelTier(model);
+
+  // Daily request cap (circuit breaker) — reuses tier counters, no extra query.
+  const creditStatus = await getUserCreditBalance(user.dbUserId);
+  if (creditStatus) {
+    const reqCap = checkDailyRequestCap(creditStatus, userPlanId);
+    if (!reqCap.allowed) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 'daily_request_cap_reached',
+            daily_request_cap: reqCap.dailyRequestCap,
+            message: reqCap.reason || 'Daily request limit reached. Upgrade your plan.',
+          },
+        },
+        { headers: { 'Retry-After': String(getSecondsUntilMidnightVN()) }, status: 429 },
+      );
+    }
+  }
+
+  // Per-request input token cap by tier (~4 chars/token) — blocks single huge calls.
+  const INPUT_TOKEN_CAP_BY_TIER: Record<number, number> = { 1: 16_000, 2: 64_000, 3: 200_000 };
+  const tokenCap = INPUT_TOKEN_CAP_BY_TIER[modelTier] || 16_000;
+  const estimatedInputTokens = Math.ceil(
+    messages.reduce((acc: number, m: any) => acc + String(m?.content ?? '').length, 0) / 4,
+  );
+  if (estimatedInputTokens > tokenCap) {
+    return NextResponse.json(
+      {
+        error: {
+          code: 'input_too_long',
+          estimated_input_tokens: estimatedInputTokens,
+          input_token_cap: tokenCap,
+          message: `Input too long for this tier (~${estimatedInputTokens} tokens > ${tokenCap}). Shorten the prompt or upgrade your plan.`,
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  // Daily USD cost cap per (user, plan, tier). reasonCode TIER_BLOCKED => the plan
+  // can't use this tier at all (403); DAILY_CAP_EXCEEDED => ceiling hit (429).
+  const usdCap = await checkDailyCostCap(user.dbUserId, userPlanId, modelTier);
+  if (!usdCap.allowed) {
+    const blockedByPlan = usdCap.reasonCode === 'TIER_BLOCKED';
+    return NextResponse.json(
+      {
+        error: {
+          code: blockedByPlan ? 'model_not_allowed_for_plan' : 'daily_cost_cap_reached',
+          daily_cost_cap: usdCap.dailyCostCap,
+          daily_cost_used: usdCap.dailyCostUsed,
+          message: usdCap.reason || 'Daily cost limit reached for this tier.',
+          tier: modelTier,
+        },
+      },
+      {
+        headers: blockedByPlan ? undefined : { 'Retry-After': String(getSecondsUntilMidnightVN()) },
+        status: blockedByPlan ? 403 : 429,
+      },
+    );
+  }
+
+  // Tier access + atomic daily-slot acquisition for Tier 2/3 (shared quota with web).
+  const tierAccess = await checkTierAccess(user.dbUserId, modelTier, userPlanId);
+  if (!tierAccess.allowed) {
+    // canUseTier=false / dailyLimit=0 => plan can't use this tier (403);
+    // otherwise the daily Tier 2/3 slot quota is exhausted (429).
+    const blockedByPlan = !tierAccess.dailyLimit;
+    return NextResponse.json(
+      {
+        error: {
+          code: blockedByPlan ? 'model_not_allowed_for_plan' : 'tier_quota_reached',
+          daily_limit: tierAccess.dailyLimit,
+          message: tierAccess.reason || 'This model requires a higher plan.',
+          tier: modelTier,
+        },
+      },
+      {
+        headers: blockedByPlan ? undefined : { 'Retry-After': String(getSecondsUntilMidnightVN()) },
+        status: blockedByPlan ? 403 : 429,
+      },
     );
   }
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix

#### 🔀 变更说明 | Description of Change

Follow-up to the Vercel AI Gateway cost audit (#59).

The public OpenAI-compatible API `POST /api/v1/chat` only validated the API key, a **flat** model whitelist (`getValidModelIds()`) and a flat per-message point cost. It **bypassed** the plan/tier gating and daily USD cost caps that the web chat route (`webapi/chat/[provider]`) enforces. Net effect: any `pho_` API key could call premium **Tier 2/3** models (Claude Sonnet 4.6, Opus 4.6, GPT-5.x) regardless of the user's plan, with **no daily cost ceiling** (bounded only by 60 req/min + point balance).

This PR mirrors the web route's enforcement, applied **before** billing/model dispatch:

- Resolve the plan **DB-first** via `getUserPlanIdFromDB(dbUserId)` (not the legacy `users.currentPlanId`).
- **Daily request cap** (circuit breaker) via `checkDailyRequestCap`.
- **Per-request input token cap** by tier (16k / 64k / 200k, ~4 chars/token).
- **Daily USD cost cap** per `(user, plan, tier)` via `checkDailyCostCap`.
- **Tier access + atomic daily-slot acquisition** for Tier 2/3 via `checkTierAccess` — shares the same daily quota counters as the web route (no more bypass).

Structured API errors on block:
- `403 model_not_allowed_for_plan` — plan can't use this tier.
- `429 daily_cost_cap_reached` / `tier_quota_reached` / `daily_request_cap_reached` (+ `Retry-After` to VN midnight).
- `400 input_too_long` — prompt exceeds the tier's input cap.

Single file changed: `src/app/api/v1/chat/route.ts` (reuses existing billing services; no new infra).

#### 📝 补充信息 | Additional Information

**Behaviour change:** existing API-key integrations that call a premium model not allowed by their plan will now receive `403/429` instead of being served. This is the intended fix (closes the cost-leak / gating bypass).

**Note:** Tier 2/3 acquires an atomic daily slot before dispatch; on the rare all-providers-failed path the slot is not released (parity with the existing web route).

https://claude.ai/code/session_01CqrRs7AC76qKxvkmAnLuoQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqrRs7AC76qKxvkmAnLuoQ)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces plan/tier gating, daily USD cost caps, and request/input limits on the public POST /api/v1/chat API to match the web chat route. Blocks unauthorized premium model usage and prevents runaway costs.

- **Bug Fixes**
  - Resolve plan from DB via `getUserPlanIdFromDB`.
  - Apply daily request cap and per-request input token caps by tier (16k/64k/200k).
  - Enforce daily USD cost cap per user/plan/tier.
  - Check tier access and atomically acquire Tier 2/3 daily slots (shared counters with web).
  - Return structured errors: 403 `model_not_allowed_for_plan`; 429 `daily_cost_cap_reached`/`tier_quota_reached`/`daily_request_cap_reached` with `Retry-After` to VN midnight; 400 `input_too_long`.

<sup>Written for commit 0705b801cbc6993e29a974df2615839177332520. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

