### PR TITLE
🔒️ fix(billing): complete daily cost cap table for all paid plans

### DIFF
--- a/src/server/services/billing/dailyCostCaps.ts
+++ b/src/server/services/billing/dailyCostCaps.ts
@@ -27,24 +27,50 @@ export interface DailyCostCap {
 
 const DEFAULT_CAPS: DailyCostCap = { tier1: 1, tier2: 0, tier3: 0 };
 
+// IMPORTANT: every plan in `PLAN_MODEL_ACCESS` (src/config/pricing.ts) MUST have
+// an entry here, kept in sync with that plan's `allowedTiers`:
+//   - a tier the plan is NOT allowed to use stays at 0 (blocked);
+//   - a tier the plan IS allowed to use MUST be > 0, otherwise the plan is
+//     silently blocked from it (cap === 0 means "deny").
+// Plans missing here fall back to DEFAULT_CAPS (tier2/3 = 0), which wrongly
+// blocks paid Tier 2 plans — the bug this complete table guards against. Values
+// are USD/day starting points and stay env-overridable via DAILY_CAP_{PLAN}_T{TIER}.
 const PLAN_CAPS: Record<string, DailyCostCap> = {
-  // Lifetime plans
+  // Global lifetime / premium — Tier 1 & 2 only (no Tier 3)
+  gl_lifetime: { tier1: 5, tier2: 10, tier3: 0 },
+
+  gl_premium: { tier1: 5, tier2: 10, tier3: 0 },
+
+  // Global standard — Tier 1 & 2 (30 T2 msgs/day)
+  gl_standard: { tier1: 3, tier2: 5, tier3: 0 },
+
+  // Free plans — Tier 1 only
+  gl_starter: { tier1: 1, tier2: 0, tier3: 0 },
+
+  // Lifetime deal plans — all tiers
   lifetime_early_bird: { tier1: 10, tier2: 10, tier3: 10 },
 
   lifetime_last_call: { tier1: 10, tier2: 10, tier3: 10 },
 
   lifetime_standard: { tier1: 10, tier2: 10, tier3: 10 },
 
-  // Promo / beta plans
   // PHO-238: T3 hard-blocked at $0 — medical_beta is FREE-tier and was burning $26/hr.
   // Defense-in-depth: also blocked via PLAN_MODEL_ACCESS.allowedTiers + dailyTier3Limit=0.
   medical_beta: { tier1: 5, tier2: 3, tier3: 0 },
 
+  // VN basic (Phở Tái) — Tier 1 & 2 (30 T2 msgs/day)
+  vn_basic: { tier1: 2, tier2: 3, tier3: 0 },
+
   vn_free: { tier1: 1, tier2: 0, tier3: 0 },
 
+  // VN subscription plans — all tiers
   vn_premium: { tier1: 5, tier2: 5, tier3: 5 },
-  // Subscription plans
+
   vn_pro: { tier1: 5, tier2: 5, tier3: 5 },
+
+  // VN team (pooled enterprise) — all tiers
+  vn_team: { tier1: 10, tier2: 10, tier3: 10 },
+
   vn_ultimate: { tier1: 10, tier2: 10, tier3: 10 },
 };
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix

#### 🔀 变更说明 | Description of Change

Hardening follow-up to the cost-control work (#59, #60).

`PLAN_CAPS` in `dailyCostCaps.ts` was **missing** `gl_lifetime`, `gl_premium`, `gl_standard`, `gl_starter`, `vn_basic` and `vn_team`. Missing plans fall back to `DEFAULT_CAPS` (`{ tier1: 1, tier2: 0, tier3: 0 }`), and since `getDailyCostCap` returning `0` is treated as **deny**, any paid plan that *allows* Tier 2 but was absent here got **silently blocked from Tier 2** unless a `DAILY_CAP_*_T2` env var happened to be set in that environment.

This was latent before, but became higher-impact after #60 made `/api/v1/chat` also enforce these caps.

This PR adds explicit caps for **every** plan in `PLAN_MODEL_ACCESS`, kept consistent with each plan's `allowedTiers`:
- allowed tier → positive USD/day cap (no longer wrongly blocked);
- disallowed tier → `0` (defense-in-depth, matches `allowedTiers`).

| Plan | allowedTiers | T1 | T2 | T3 |
|---|---|---|---|---|
| gl_starter | [1] | 1 | 0 | 0 |
| vn_basic | [1,2] | 2 | 3 | 0 |
| gl_standard | [1,2] | 3 | 5 | 0 |
| gl_premium | [1,2] | 5 | 10 | 0 |
| gl_lifetime | [1,2] | 5 | 10 | 0 |
| vn_team | [1,2,3] | 10 | 10 | 10 |

Values are starting points and remain env-overridable via `DAILY_CAP_{PLAN}_T{TIER}` (env still takes precedence, so environments that already set these are unaffected). Also adds a doc note requiring this table to stay in sync with `PLAN_MODEL_ACCESS.allowedTiers`.

#### 📝 补充信息 | Additional Information

Single file: `src/server/services/billing/dailyCostCaps.ts`. No logic/signature change — only completes the lookup table and documents the invariant. No behaviour change where `DAILY_CAP_*` env vars are already set.

https://claude.ai/code/session_01CqrRs7AC76qKxvkmAnLuoQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqrRs7AC76qKxvkmAnLuoQ)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completed the `PLAN_CAPS` table in `src/server/services/billing/dailyCostCaps.ts` to match `PLAN_MODEL_ACCESS.allowedTiers`, fixing unintended Tier 2 denial for paid plans. Restores correct daily caps now that `/api/v1/chat` enforces them.

- **Bug Fixes**
  - Added caps for `gl_lifetime`, `gl_premium`, `gl_standard`, `gl_starter`, `vn_basic`, `vn_team`.
  - Allowed tiers have >0 USD/day; disallowed tiers are `0` (defense-in-depth).
  - Caps remain env-overridable via `DAILY_CAP_{PLAN}_T{TIER}`.
  - Prevents fallback to `DEFAULT_CAPS` that blocked Tier 2 on paid plans.

<sup>Written for commit d49904b7ff8ad98a03388dbd1941f8151f052120. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended billing plan cost cap configurations to include additional plan entries with enhanced synchronization documentation, preventing silent fallback to default caps and improving configuration completeness across all available plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->