### PR TITLE
⚡️ perf(chat): bound history for context-caching models with a high ceiling

### DIFF
--- a/src/store/agent/slices/chat/selectors/chatConfig.ts
+++ b/src/store/agent/slices/chat/selectors/chatConfig.ts
@@ -17,14 +17,27 @@ const useModelBuiltinSearch = (s: AgentStoreState) =>
 const searchFCModel = (s: AgentStoreState) =>
   currentAgentChatConfig(s).searchFCModel || DEFAULT_AGENT_SEARCH_FC_MODEL;
 
+// 上下文缓存模型的历史上限。缓存让重复前缀变得很便宜，所以不按普通 historyCount
+// 截断，而是携带（近乎）完整历史；但仍用一个较高的上限兜底，避免超长会话导致
+// token 成本与延迟失控。只有超过该上限的会话才会被裁剪到最近的消息（更早的轮次
+// 仍由历史摘要覆盖）。
+const MAX_CONTEXT_CACHING_HISTORY_COUNT = 120;
+
+// 是否为「开启上下文缓存且命中缓存模型」——此前这种情况会携带完整历史。
+const isContextCachingFullHistory = (s: AgentStoreState) => {
+  const config = currentAgentConfig(s);
+  const chatConfig = currentAgentChatConfig(s);
+  const enableContextCaching = !chatConfig.disableContextCaching;
+
+  return enableContextCaching && contextCachingModels.has(config.model);
+};
+
 const enableHistoryCount = (s: AgentStoreState) => {
   const config = currentAgentConfig(s);
   const chatConfig = currentAgentChatConfig(s);
 
-  // 如果开启了上下文缓存，且当前模型类型匹配，则不开启历史记录
-  const enableContextCaching = !chatConfig.disableContextCaching;
-
-  if (enableContextCaching && contextCachingModels.has(config.model)) return false;
+  // 缓存模型：仍开启历史计数，但用高上限（见 historyCount）兜底，避免无上限的超长上下文
+  if (isContextCachingFullHistory(s)) return true;
 
   // 当开启搜索时，针对 claude 3.7 sonnet 模型不开启历史记录
   const enableSearch = isAgentEnableSearch(s);
@@ -36,6 +49,10 @@ const enableHistoryCount = (s: AgentStoreState) => {
 
 const historyCount = (s: AgentStoreState): number => {
   const chatConfig = currentAgentChatConfig(s);
+
+  // 缓存模型使用高上限而非用户的 historyCount（后者面向非缓存截断），
+  // 在保留缓存收益的同时给成本兜底。
+  if (isContextCachingFullHistory(s)) return MAX_CONTEXT_CACHING_HISTORY_COUNT;
 
   return chatConfig.historyCount ?? (DEFAULT_AGENT_CHAT_CONFIG.historyCount as number); // historyCount 为 0 即不携带历史消息
 };


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] ⚡️ perf

#### 🔀 变更说明 | Description of Change

Cost-control follow-up (context-window ceiling).

Context-caching models (Claude Sonnet/Opus, etc.) currently send the **full** conversation history untruncated — `enableHistoryCount` returns `false` for them in `chatConfig.ts`, because prompt caching (now enabled, #59) makes the repeated prefix cheap. The downside: there is **no upper bound**, so a runaway-long thread keeps growing token cost + latency and eventually trips the per-request input token cap (hard reject).

This change keeps (almost) full history for caching models — preserving cache hits for normal conversations — but bounds it at a generous `MAX_CONTEXT_CACHING_HISTORY_COUNT = 120` messages. Only conversations longer than 120 messages get trimmed to the most recent ones; older turns remain covered by the injected history summary.

- `enableHistoryCount`: caching models now return `true` (was `false`).
- `historyCount`: caching models return the `120` ceiling instead of the user's `historyCount` (which targets non-caching truncation).
- Non-caching and search paths are unchanged.

Single file: `src/store/agent/slices/chat/selectors/chatConfig.ts`.

#### 📝 补充信息 | Additional Information

Effectively no change for the vast majority of conversations (< 120 messages); only caps the extreme long-thread tail. The per-request input-token cap by tier remains the hard server-side backstop.

https://claude.ai/code/session_01CqrRs7AC76qKxvkmAnLuoQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqrRs7AC76qKxvkmAnLuoQ)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound chat history for context-caching models to a high ceiling (historyCount = 120) to prevent runaway token cost/latency and input-token cap failures, while keeping cache benefits. Non-caching and search behavior are unchanged; older turns stay covered by the history summary.

<sup>Written for commit 2cbe82631327afe96e1741bd464f7ac0681dfa61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

