### PR TITLE
🔒️ fix(billing): cap medical_beta Tier 2 at 30 msgs/day (atomic)

### DIFF
--- a/src/config/pricing.ts
+++ b/src/config/pricing.ts
@@ -604,7 +604,11 @@ export const PLAN_MODEL_ACCESS: Record<string, PlanModelAccess> = {
   // VN_PLANS.medical_beta.dailyTier3Limit = 0 and dailyCostCaps.ts T3 = $0.
   medical_beta: {
     allowedTiers: [1, 2],
-    dailyLimits: { tier2: -1 },
+    // PHO cost audit (2026-06): medical_beta is a near-free promo. Tier 2 was
+    // unlimited and a single user burned ~$22/day on it, far above the intended
+    // $3/day USD cap (which can be slipped by a request-timing race or an env
+    // override). An atomic per-day message limit hard-bounds it. Tunable.
+    dailyLimits: { tier2: 30 },
     defaultModel: 'llama-3.1-8b-instant',
     defaultProvider: 'groq',
     models: [...TIER1_MODELS, ...TIER2_MODELS],


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix

#### 🔀 变更说明 | Description of Change

Direct outcome of the heavy-user cost audit.

The audit found a **`medical_beta`** user (a near-free promo plan, ~₫999K/yr) burning **~$22/day on Tier 2** — across 3 days every day was multiples above the intended **$3/day** USD cost cap (PHO-238), including today, after the caching + cap fixes shipped.

Root-cause analysis: `usage_logs.userId` / `modelTier` / read paths are consistent (no key mismatch), so the USD cap *should* read this user's spend. The remaining explanations are (a) a high `DAILY_CAP_MEDICAL_BETA_T2` env override in prod, or (b) the USD cap being a **pre-call read** that can be slipped by request-timing races (cost is only logged after the response completes).

Rather than rely on the timing-sensitive USD cap, this bounds the spend **atomically**: `medical_beta.dailyLimits.tier2` goes from `-1` (unlimited) → **30 messages/day**, enforced by `checkTierAccess` → `atomicAcquireTierSlot` (single-SQL increment+check, race-proof and unaffected by env). 30 is a starting value and is easily tuned.

Single line + comment in `src/config/pricing.ts` (`PLAN_MODEL_ACCESS.medical_beta`).

#### 📝 补充信息 | Additional Information

Behaviour change: medical_beta loses "unlimited Tier 2" (was a promo selling point) — now 30 T2 msgs/day. Tier 1 stays unlimited; Tier 3 stays blocked. Separately worth checking the Vercel `DAILY_CAP_MEDICAL_BETA_T2` env var in case an override is masking the $3 USD cap.

https://claude.ai/code/session_01CqrRs7AC76qKxvkmAnLuoQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqrRs7AC76qKxvkmAnLuoQ)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap `medical_beta` Tier 2 at 30 messages/day. The limit is enforced atomically to hard-cap spend and prevent timing-race overspend, aligning with PHO-238’s $3/day intent.

<sup>Written for commit 0b8a9b07c1f0e172a3e525a196129ce929ed9d4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

