### PR TITLE
🔒️ fix(billing): lower medical_beta T2 cost cap to $1/day + cap observability

### DIFF
--- a/src/server/services/billing/dailyCostAggregation.ts
+++ b/src/server/services/billing/dailyCostAggregation.ts
@@ -100,6 +100,12 @@ export async function checkDailyCostCap(
 
   const dailyCostUsed = await getDailyTierCostUSD(userId, tier);
 
+  // Opt-in observability: flip DEBUG_COST_CAPS=1 to confirm in prod logs that this
+  // cap check actually runs for a given user/tier and what cap vs used it resolved.
+  if (process.env.DEBUG_COST_CAPS === '1') {
+    console.log('[billing] cost cap check', { dailyCostCap, dailyCostUsed, planId, tier, userId });
+  }
+
   if (dailyCostUsed >= dailyCostCap) {
     console.warn('[billing] DAILY CAP HIT', {
       dailyCostCap,

--- a/src/server/services/billing/dailyCostCaps.ts
+++ b/src/server/services/billing/dailyCostCaps.ts
@@ -55,8 +55,11 @@ const PLAN_CAPS: Record<string, DailyCostCap> = {
   lifetime_standard: { tier1: 10, tier2: 10, tier3: 10 },
 
   // PHO-238: T3 hard-blocked at $0 — medical_beta is FREE-tier and was burning $26/hr.
-  // Defense-in-depth: also blocked via PLAN_MODEL_ACCESS.allowedTiers + dailyTier3Limit=0.
-  medical_beta: { tier1: 5, tier2: 3, tier3: 0 },
+  // 2026-06 cost audit: a medical_beta user still burned ~$22/day on Tier 2 (cap was $3
+  // but this USD cap is a timing-sensitive pre-read). Lowered T2 to $1/day; the real
+  // hard stop is the atomic 30-msg/day Tier 2 limit in PLAN_MODEL_ACCESS.medical_beta.
+  // Defense-in-depth: also blocked via allowedTiers + dailyTier3Limit=0.
+  medical_beta: { tier1: 5, tier2: 1, tier3: 0 },
 
   // VN basic (Phở Tái) — Tier 1 & 2 (30 T2 msgs/day)
   vn_basic: { tier1: 2, tier2: 3, tier3: 0 },
@@ -85,12 +88,32 @@ const PLAN_CAPS: Record<string, DailyCostCap> = {
  * Returns 0 when the tier is fully blocked for this plan. Callers MUST treat
  * `cap === 0` as "deny" rather than "no cap".
  */
+// Track which env overrides we've already logged so the warning below fires at
+// most once per (process, env key) instead of on every request.
+const loggedEnvOverrides = new Set<string>();
+
 export function getDailyCostCap(planId: string, tier: number): number {
   const envKey = `DAILY_CAP_${planId.toUpperCase()}_T${tier}`;
   const envVal = process.env[envKey];
   if (envVal !== undefined && envVal !== '') {
     const parsed = Number.parseFloat(envVal);
-    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      // Surface active env overrides once per process. A too-high override silently
+      // masking the static cap is the leading hypothesis for why the medical_beta
+      // $3 cap did not bite in the 2026-06 audit — make it visible in prod logs.
+      if (!loggedEnvOverrides.has(envKey)) {
+        loggedEnvOverrides.add(envKey);
+        const staticCaps = PLAN_CAPS[planId] ?? DEFAULT_CAPS;
+        const staticCap =
+          tier === 1 ? staticCaps.tier1 : tier === 2 ? staticCaps.tier2 : staticCaps.tier3;
+        console.warn('[billing] daily cost cap ENV OVERRIDE active', {
+          envKey,
+          overrideValue: parsed,
+          staticCap,
+        });
+      }
+      return parsed;
+    }
   }
 
   const caps = PLAN_CAPS[planId] ?? DEFAULT_CAPS;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix

#### 🔀 变更说明 | Description of Change

Follow-up to the heavy-user cost audit (chosen option: "check env + lower default + log").

**1. Lower `medical_beta` Tier 2 USD cap $3 → $1/day** (`dailyCostCaps.ts`). The real hard stop is the atomic 30-msg/day Tier 2 limit added in #63; this is the tighter USD backstop for the near-free promo plan.

**2. Cap observability** to explain why the $3 cap wasn't biting in the audit (medical_beta user spent ~$22/day on T2):
- `getDailyCostCap` now logs **once per process** when a `DAILY_CAP_*` env override is active, printing the env key, override value, and the static cap it replaced. The leading hypothesis is that a high prod env override silently masked the static cap — this makes it visible in logs.
- `checkDailyCostCap` logs each evaluation when `DEBUG_COST_CAPS=1` (off by default), to confirm in prod that the cap path runs for a given user/tier and what cap-vs-used it resolved.

Files: `src/server/services/billing/dailyCostCaps.ts`, `src/server/services/billing/dailyCostAggregation.ts`.

#### 📝 补充信息 | Additional Information

Pairs with checking the Vercel `DAILY_CAP_MEDICAL_BETA_T2` env var: if the new ENV-OVERRIDE log appears for it with a high value, that confirms the root cause and the override should be removed/lowered. No behaviour change to the logging gate unless `DEBUG_COST_CAPS=1`.

https://claude.ai/code/session_01CqrRs7AC76qKxvkmAnLuoQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqrRs7AC76qKxvkmAnLuoQ)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered the `medical_beta` Tier 2 daily cap from $3 to $1 and added logging to surface env overrides and verify cap checks in production. This reduces unexpected T2 spend and makes cap behavior easier to audit.

- **Bug Fixes**
  - Set `medical_beta` Tier 2 cap to $1/day as a USD backstop; the 30 msgs/day hard limit remains.

- **New Features**
  - Log once per process when a `DAILY_CAP_*` env override is active, showing the key, override value, and static cap.
  - Opt-in detailed logs when `DEBUG_COST_CAPS=1` to print cap vs used for each check.

<sup>Written for commit 668bccb08cf4a00119515a0ec02804c00d384df8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/64?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

