### PR TITLE
🔍 fix(observability): capture real Clerk auth reason + cut Next control-flow log noise

### DIFF
--- a/src/libs/clerk-auth/index.ts
+++ b/src/libs/clerk-auth/index.ts
@@ -26,20 +26,26 @@ export class ClerkAuth {
         const clerkAuth = requestState.toAuth();
         const userId = this.getMappedUserId(clerkAuth?.userId ?? null);
 
-        // PHO auth incident (2026-06): a growing cohort gets tRPC UNAUTHORIZED +
-        // a greyed model picker because the server cannot verify their session
-        // token. authenticateRequest() carries the precise cause in `reason`
-        // (e.g. token-invalid-signature → key/instance mismatch; token-expired;
-        // token-not-active-yet → clock skew). Surface REJECTED tokens (a token
-        // was sent but failed) — not plain anonymous traffic — so the root cause
-        // is greppable in Vercel logs instead of hiding behind a generic 401.
+        // PHO auth incident (2026-06): signed-in users get tRPC UNAUTHORIZED. The
+        // server-side cause is in authenticateRequest()'s `reason`. We log it ONLY
+        // when the client actually carries a Clerk cookie (__client_uat / __session)
+        // yet we resolved NO user — i.e. a signed-in client whose token was
+        // missing/expired/invalid (the incident), excluding genuine anonymous
+        // traffic. An earlier version filtered out `*-missing` reasons, but Vercel
+        // showed no logs at all during a reproduced 401 — meaning the failure mode
+        // IS a missing/absent token reaching the server (client/SW not sending it),
+        // not a signature/version mismatch. Capture it explicitly.
         if (!userId) {
-          const reason = (requestState as any)?.reason as string | undefined;
-          if (reason && !reason.includes('missing')) {
-            console.warn('[ClerkAuth] session token rejected', {
+          const cookieHeader = request.headers?.get?.('cookie') ?? '';
+          const uat = /(?:^|;\s*)__client_uat=([^;]*)/.exec(cookieHeader)?.[1];
+          const hasClerkCookie =
+            (uat !== undefined && uat !== '0') || /(?:^|;\s*)__session=/.test(cookieHeader);
+          if (hasClerkCookie) {
+            console.warn('[ClerkAuth] signed-in client but no userId resolved', {
               message: (requestState as any)?.message,
-              reason,
+              reason: (requestState as any)?.reason,
               status: (requestState as any)?.status,
+              uat,
             });
           }
         }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -322,9 +322,24 @@ const clerkAuthMiddleware = clerkMiddleware(
 
       return response;
     } catch (error) {
-      logClerk('Clerk middleware error: %O', error);
-      console.error('Clerk middleware error:', error);
-      // Re-throw to let Clerk handle the error (e.g., redirect to login)
+      // Next.js signals 404 (notFound) and redirects by THROWING a control-flow
+      // "error" carrying a `digest` like `NEXT_HTTP_ERROR_FALLBACK;404` or
+      // `NEXT_REDIRECT;...`. These are expected outcomes — e.g. an unauthenticated
+      // user hitting a protected route (auth.protect() → redirect to /login), or a
+      // request for a non-existent page (/medical-beta-guide.html → 404). Logging
+      // them as errors floods the dashboard (~20+/8h) and buries real failures.
+      // Re-throw them silently so Next/Clerk handle them normally; only log genuine errors.
+      const digest = (error as { digest?: unknown } | null)?.digest;
+      const isNextControlFlow =
+        typeof digest === 'string' &&
+        (digest.startsWith('NEXT_REDIRECT') ||
+          digest.startsWith('NEXT_HTTP_ERROR_FALLBACK') ||
+          digest.startsWith('NEXT_NOT_FOUND'));
+      if (!isNextControlFlow) {
+        logClerk('Clerk middleware error: %O', error);
+        console.error('Clerk middleware error:', error);
+      }
+      // Re-throw to let Clerk/Next handle the error (e.g., redirect to login, render 404)
       throw error;
     }
   },


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

Follow-up diagnostics for the auth-session incident. A **reproduced 401** (login/logout test) produced **no server-side log at all** — neither `session token rejected` nor `authenticateRequest failed`. That rules out a signature/key/API-version rejection: the failure mode is a **missing/absent token reaching the server** (client/SW not sending it). Meanwhile the browser console showed a broken **service worker** (`bad-precaching-response` for `/medical-beta-guide.html` 404) serving **stale JS** — the likely reason the token isn't attached.

- **`clerk-auth`** — the earlier reason log filtered out `*-missing` reasons (exactly the failure mode). Now log the Clerk `reason` whenever a **signed-in client** (carries `__client_uat`/`__session` cookie) still resolves to **no user**, so the exact reason (e.g. `session-token-and-uat-missing`) is greppable in Vercel logs. Genuine anonymous traffic is excluded.
- **`middleware`** — stop `console.error`-ing Next.js control-flow throws (`NEXT_REDIRECT` from `auth.protect()` redirects; `NEXT_HTTP_ERROR_FALLBACK;404`, incl. the `/medical-beta-guide.html` precache 404) as `"Clerk middleware error"`. That was the **dominant** error-log spam (~20+/8h). Re-throw unchanged; only log genuine failures.

#### 📝 补充信息 | Additional Information

**Verify after deploy:** reproduce a 401, then Vercel → Logs → search `signed-in client but no userId resolved` → the `reason` field confirms whether the token is missing/expired (→ stale-SW/client-token root cause) vs invalid (→ key/version).

**Not in this PR (next step):** fix the SW precache 404 (`public/medical-beta-guide.html` exists but the route 404s) so the service worker can update cleanly and stop pinning users to stale JS — the suspected root cause of the 401s.

**CI:** the red Test CI is pre-existing on `main` (snapshot drift / docx / submodule), unrelated to these files.

https://claude.ai/code/session_01SmSDEWCNxADBDAAsZD3QiB

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmSDEWCNxADBDAAsZD3QiB)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve auth incident observability by logging the real Clerk auth failure reason for signed‑in clients that resolve to no user, and cut log noise by not error‑logging Next control‑flow throws.

- **Bug Fixes**
  - `clerk-auth`: When a request has `__client_uat` or `__session` but no `userId`, log the Clerk `reason` (plus `message`, `status`, and `uat`). This restores visibility for `*-missing` cases that were previously filtered out.
  - Middleware: Treat `NEXT_REDIRECT`, `NEXT_HTTP_ERROR_FALLBACK`, and `NEXT_NOT_FOUND` digests as expected control flow. Re-throw without `console.error`; only log real errors.

<sup>Written for commit 209edfe447f0542fdc30537e76245854e04e61ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

