### PR TITLE
🐛 fix(pwa): exclude 404'ing /medical-beta-guide.html from SW precache — ROOT CAUSE of auth lockout

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -551,6 +551,16 @@ const withBundleAnalyzer = process.env.ANALYZE === 'true' ? analyzer() : noWrapp
 const withPWA =
   isProd && !isDesktop
     ? withSerwistInit({
+        // Exclude /medical-beta-guide.html from the precache manifest. The file
+        // exists in public/ but its route resolves to a Next 404 at runtime, which
+        // POISONED precaching: every new service-worker install failed with
+        // `bad-precaching-response`, so clients never updated and stayed pinned to
+        // STALE JS. The stale client stopped attaching the Clerk session token →
+        // tRPC 401 + greyed model picker for logged-in paying users (the 2026-06
+        // auth incident; confirmed by incognito = no SW = works). `.map` and
+        // `manifest.js` are Serwist's default excludes, preserved here.
+        exclude: [/\.map$/, /^manifest.*\.js$/, /medical-beta-guide\.html$/],
+
         // Allow precaching of large PGLite assets for offline functionality
         // Reduced from 10MB to 5MB to optimize build memory usage on Vercel
         maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

**Confirmed root cause** of the 2026-06 "logged-in users can't use the app" incident (nga.ntv on `vn_ultimate`, huyenvu27996, et al).

`public/medical-beta-guide.html` exists but its route resolves to a **Next 404 at runtime**, so it **poisoned the Serwist precache manifest**: every *new* service-worker install failed with `bad-precaching-response`. Because the new SW could never finish installing, clients **stayed pinned to STALE cached JS**. The stale client stopped attaching the Clerk session token to tRPC requests → the server received **no token** → `401 UNAUTHORIZED` + a model picker that greyed out PRO/FLAGSHIP as if the plan was lost.

**Proof:**
- **Incognito** (no service worker / no stale cache) works perfectly and the picker is correctly gated; the **normal window** (broken SW) 401s. 🎯
- Vercel showed **zero** `session token rejected` reasons during a reproduced 401 → the token never reached the server (missing), not rejected → a **client/SW** failure, not a Clerk key/API-version mismatch.
- Browser console: `bad-precaching-response :: [{"url":".../medical-beta-guide.html","status":404}]` (sw.js).

**Fix:** exclude the file from the precache manifest via Serwist's `exclude` (defaults `.map`/`manifest.js` preserved). SW installs succeed again, so clients (already `skipWaiting` + `clientsClaim`) pick up fresh JS on next visit. **Non-destructive** — the file itself is untouched.

#### 📝 补充信息 | Additional Information

**Recovery after deploy:** stuck users self-heal on their next visit (the new SW finally installs). For immediate relief, a user can clear site data (DevTools → Application → Clear site data) or use an incognito window — see `docs/CLEAR_SERVICE_WORKER.md`.

**Companion PRs (merged):** #65 (react-virtuoso noise filter, `authError` re-login UX + self-heal), #66 (real Clerk reason logging + middleware control-flow log noise). Once #66's deploy is live, `session token rejected` logs give a server-side second confirmation.

**Follow-ups (separate):** why the public `.html` route 404s (middleware allowlist vs static serving); Clerk deprecated `afterSignInUrl`/`afterSignUpUrl` → `*FallbackRedirectUrl`; the `Failed to process model usage` Neon query failures (P1).

**CI:** red Test CI is pre-existing on `main` (snapshot drift / docx / submodule / Actions "Repository access blocked"), unrelated to this one-line config change.

https://claude.ai/code/session_01SmSDEWCNxADBDAAsZD3QiB

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmSDEWCNxADBDAAsZD3QiB)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude the 404-ing `/medical-beta-guide.html` from the `Serwist` precache to fix failed SW installs. This unblocks updates, restores fresh JS, and fixes missing auth tokens that led to 401s.

- Excluded `/medical-beta-guide.html` from `Serwist` precache (keeps default `.map` and `manifest.js` excludes).
- Prevents `bad-precaching-response` and stale SW pinning.
- New SW installs complete; clients update on next visit (`skipWaiting` + `clientsClaim` already in place).

<sup>Written for commit 2c625191d29b56111c9a60e48181e57ad8da8240. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

