### PR TITLE
🐛 fix(billing): keep function alive for post-stream billing via after() (P1)

### DIFF
--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -6,6 +6,7 @@ import {
 } from '@lobechat/model-runtime';
 import { ChatErrorType } from '@lobechat/types';
 import { eq } from 'drizzle-orm';
+import { after } from 'next/server';
 import console from 'node:console';
 
 import { checkAuth } from '@/app/(backend)/middleware/auth';
@@ -739,7 +740,14 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
       // network drop) still debits the user for tokens already streamed. The
       // gateway has already charged us for those tokens; the previous silent
       // catch here let the user escape billing entirely.
-      (async () => {
+      //
+      // Run via Next's `after()` so Vercel keeps the function — and the Neon
+      // WebSocket pool connection — alive until billing completes. Previously this
+      // was a bare fire-and-forget IIFE: the function froze the instant the
+      // response was returned, severing the DB connection, so the post-stream
+      // billing query failed ("❌ Failed to process model usage: Failed query …")
+      // and silently skipped points deduction + usage logging on streamed chats.
+      after(async () => {
         let accumulatedText = '';
         let completed = false;
 
@@ -806,7 +814,7 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
             console.error('[Chat API] Billing failed after stream:', billingError);
           }
         }
-      })();
+      });
 
       const headers = new Headers(response.headers);
       headers.set('X-Pho-Provider', actualProviderUsed);

--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -741,13 +741,15 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
       // gateway has already charged us for those tokens; the previous silent
       // catch here let the user escape billing entirely.
       //
-      // Run via Next's `after()` so Vercel keeps the function — and the Neon
-      // WebSocket pool connection — alive until billing completes. Previously this
-      // was a bare fire-and-forget IIFE: the function froze the instant the
-      // response was returned, severing the DB connection, so the post-stream
-      // billing query failed ("❌ Failed to process model usage: Failed query …")
-      // and silently skipped points deduction + usage logging on streamed chats.
-      after(async () => {
+      // Read the audit stream CONCURRENTLY (so ReadableStream.tee() doesn't buffer
+      // the entire response body in memory), then hand the resulting promise to
+      // Next's `after()` so Vercel keeps the function — and the Neon WebSocket pool
+      // connection — alive until billing completes. Previously this was a bare
+      // fire-and-forget IIFE: the function froze the instant the response returned,
+      // severing the DB connection, so the post-stream billing query failed
+      // ("❌ Failed to process model usage: Failed query …") and silently skipped
+      // points deduction + usage logging on streamed chats.
+      const billingTask = (async () => {
         let accumulatedText = '';
         let completed = false;
 
@@ -814,7 +816,13 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
             console.error('[Chat API] Billing failed after stream:', billingError);
           }
         }
-      });
+      })();
+
+      // Keep the serverless function alive until billing resolves. Passing the
+      // already-running promise (not a deferred callback) means stream2 is consumed
+      // as it streams — no tee() buffering — while still surviving the post-response
+      // freeze that was severing the Neon connection mid-write.
+      after(billingTask);
 
       const headers = new Headers(response.headers);
       headers.set('X-Pho-Provider', actualProviderUsed);


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

Fixes **P1** from the production error audit: streamed chats return `200` but log `❌ Failed to process model usage: Failed query: select daily_tier*_usage …` — so **points were not deducted and usage was not logged** (revenue leak + tier limits not enforced).

**Root cause (code + driver confirmed):** the post-stream billing ran in a bare fire-and-forget IIFE **after** `return new Response(stream1)`. On Vercel the serverless function freezes the instant the response is sent; the DB uses the Neon **serverless WebSocket Pool** driver (`@neondatabase/serverless` + `drizzle-orm/neon-serverless`), so freezing severs the connection and the billing query dies mid-flight. Intermittent because it races the freeze.

**Fix:** wrap the background billing in Next 15's `after()` so Vercel keeps the function — and the Neon connection — alive until billing completes. The user-facing response/stream is unchanged (still returned immediately); only billing reliability improves. The non-streaming path already `await`ed billing before responding, so it was unaffected and is left as-is.

#### 📝 补充信息 | Additional Information

**Verify after deploy:** the `❌ Failed to process model usage` / `Failed query` errors on `/webapi/chat/*` should stop in Vercel logs, and `usage_logs` + points deduction should resume for streamed chats.

**Follow-up (separate):** add a bounded retry in `processModelUsage` for transient Neon blips as defense-in-depth.

**CI:** the red Test CI is pre-existing on `main` (snapshot drift / docx / web-crawler / submodule / Actions "Repository access blocked"), unrelated to this single-file change in the chat route.

https://claude.ai/code/session_01SmSDEWCNxADBDAAsZD3QiB

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmSDEWCNxADBDAAsZD3QiB)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure post‑stream billing completes by starting it immediately and passing its running promise to Next 15’s `after()`, so Vercel keeps the function alive without buffering the stream. Fixes the revenue leak where streamed chats returned 200 but skipped usage logging and point deductions.

- **Bug Fixes**
  - Start audit/billing concurrently and hand its promise to `after()` to avoid `ReadableStream.tee()` buffering.
  - Prevent Vercel freeze from dropping the Neon WebSocket pool connection (`@neondatabase/serverless`, `drizzle-orm/neon-serverless`).
  - Streamed chats now reliably log usage and deduct points; non‑streaming path unchanged.

<sup>Written for commit ea9209eb1d10a4e431d1ba56b1cfddb9132bc4f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where billing operations would fail during streaming chat responses, causing credit deduction to be skipped and audit data to be lost. The server now properly waits for all usage tracking and billing to complete before terminating the connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->