### PR TITLE
💚 fix(ci): remove orphan submodule + drop blocked pr-welcome action

### DIFF
--- a/.github/workflows/issue-auto-comments.yml
+++ b/.github/workflows/issue-auto-comments.yml
@@ -51,18 +51,6 @@ jobs:
             If you encounter any problems, please feel free to connect with us.\
             非常感谢您提出拉取请求并为我们的社区做出贡献，请确保您已经遵循了我们的贡献指南，我们会尽快审查它。
             如果您遇到任何问题，请随时与我们联系。
-      - name: Auto Comment on Pull Request Merged
-        uses: actions-cool/pr-welcome@main
-        if: github.event.pull_request.merged == true
-        with:
-          token: ${{ secrets.GH_TOKEN }}
-          comment: |
-            ❤️ Great PR @${{ github.event.pull_request.user.login }} ❤️
-
-            The growth of project is inseparable from user feedback and contribution, thanks for your contribution! If you are interesting with the lobehub developer community, please join our [discord](https://discord.com/invite/AYFPHvv2jT) and then dm @arvinxx or @canisminor1990. They will invite you to our private developer channel. We are talking about the lobe-chat development or sharing ai newsletter around the world.\
-            项目的成长离不开用户反馈和贡献，感谢您的贡献! 如果您对 LobeHub 开发者社区感兴趣，请加入我们的 [discord](https://discord.com/invite/AYFPHvv2jT)，然后私信 @arvinxx 或 @canisminor1990。他们会邀请您加入我们的私密开发者频道。我们将会讨论关于 Lobe Chat 的开发，分享和讨论全球范围内的 AI 消息。
-          emoji: 'hooray'
-          pr-emoji: '+1, heart'
       - name: Remove inactive
         if: github.event.issue.state == 'open' && github.actor == github.event.issue.user.login
         uses: actions-cool/issues-helper@v3


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 👷 build
- [x] 🔨 chore

#### 🔀 变更说明 | Description of Change

Fixes two **config/infra** CI reds (not test failures):

1. **Orphan submodule** — `.agent/skills/marketingskills` was committed as a submodule gitlink (mode `160000`) with **no `.gitmodules` entry**, so every CI checkout logged `fatal: No url found for submodule path '.agent/skills/marketingskills'` (git exit 128). The directory is empty and the gitlink commit is unfetchable. Removed the orphan gitlink.

2. **`run` check ("Issue Auto Comment")** — failed at `Getting action download info: Repository access blocked`. The culprit is `actions-cool/pr-welcome@main`: a `@main`-pinned, upstream‑LobeHub community-welcome step (it invites contributors to LobeHub's Discord — irrelevant to this fork) whose action repo is unavailable. Dropped that one step; the remaining `wow-actions/auto-comment` + `actions-cool/issues-helper` steps are healthy.

#### 📝 补充信息 | Additional Information

**Still red after this (separate — real test failures in `Test CI` / `test.yml`):** `Test Website` (settings snapshot drift), `Test package file-loaders` (docx `DOMParser` mimeType), `Test package web-crawler`, `Test Database`. These need a runnable dev env to fix+verify — the authoring container can't `pnpm install` (the `xlsx` tarball from `cdn.sheetjs.com` is network-blocked, 403). Recommended:
- `Test Website`: the default search/system-agent model changed `gpt-5-mini/openai → gemini-2.5-flash/vertexai`; if intentional, `pnpm vitest -u` regenerates the snapshot.
- Others: `pnpm test` locally to triage.

https://claude.ai/code/session_01SmSDEWCNxADBDAAsZD3QiB

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmSDEWCNxADBDAAsZD3QiB)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI by removing an orphan submodule and dropping a blocked PR-welcome step. This stops checkout failures and unblocks the issue auto comments workflow.

- **Bug Fixes**
  - Removed orphan gitlink at `.agent/skills/marketingskills` (no `.gitmodules` entry) to stop checkout errors.
  - Dropped `actions-cool/pr-welcome@main` from `.github/workflows/issue-auto-comments.yml` to avoid repository access errors; other steps remain.

<sup>Written for commit 2f88a94415a60d6a73d3eb670010bbddb9bc6a69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies.

* **Automation Changes**
  * Removed automatic pull request welcome comments.
  * Modified issue label automation to remove the "Inactive" label when issues remain open and the issue author is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->