### PR TITLE
🐛 fix(billing): stop un-seeded-model cost leak + raise medical_beta T2 cap to $3

### DIFF
--- a/scripts/seed-model-pricing-gateway.ts
+++ b/scripts/seed-model-pricing-gateway.ts
@@ -28,7 +28,7 @@
  *   - DeepSeek:  https://api-docs.deepseek.com/quick_start/pricing
  *
  * Run:      bunx tsx scripts/seed-model-pricing-gateway.ts
- * Verify:   SELECT count(*) FROM model_pricing WHERE id LIKE 'seed_gateway_%';  -- expect 13
+ * Verify:   SELECT count(*) FROM model_pricing WHERE id LIKE 'seed_gateway_%';  -- expect 18
  * Rollback: DELETE FROM model_pricing WHERE id LIKE 'seed_gateway_%';
  */
 import dotenv from 'dotenv';
@@ -84,6 +84,20 @@ const SEEDS: PricingSeed[] = [
   { inputUsdPer1M: 1.25, modelId: 'google/gemini-2.5-pro', outputUsdPer1M: 10, tier: 2 },
   { inputUsdPer1M: 1.75, modelId: 'openai/gpt-5.3', outputUsdPer1M: 14, tier: 2 },
   { inputUsdPer1M: 3, modelId: 'anthropic/claude-sonnet-4.5', outputUsdPer1M: 15, tier: 2 },
+
+  // PHO cost-leak fix (2026-06): these gateway IDs were ACTIVE in production but
+  // ABSENT from this seed, so getModelPricing() fell back to the MODEL_TIERS
+  // default (100/300 pts ≈ $0.004/$0.012 per 1M) — ~800x under the real rate.
+  // PostHog 30-day data: claude-sonnet-4.6 alone billed $0.12 vs $102 real cost,
+  // and the daily USD cap (which reads usage_logs.cost_usd) never fired because
+  // the recorded cost was ~0. modelIds below are the EXACT $ai_model strings
+  // observed in telemetry so the exact-match lookup at route.ts hits.
+  { inputUsdPer1M: 3, modelId: 'anthropic/claude-sonnet-4.6', outputUsdPer1M: 15, tier: 2 },
+  { inputUsdPer1M: 3, modelId: 'claude-sonnet-4-20250514', outputUsdPer1M: 15, tier: 2 },
+  { inputUsdPer1M: 1.75, modelId: 'openai/gpt-5.3-codex', outputUsdPer1M: 14, tier: 2 },
+  { inputUsdPer1M: 0.55, modelId: 'deepseek/deepseek-r1', outputUsdPer1M: 2.19, tier: 2 },
+  // Un-prefixed legacy IDs still reach getModelPricing() on some routes.
+  { inputUsdPer1M: 0.3, modelId: 'gemini-2.5-flash', outputUsdPer1M: 2.5, tier: 1 },
 
   // ============================================================================
   // Tier 3 — Premium / Expensive tier

--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -10,7 +10,7 @@ import { after } from 'next/server';
 import console from 'node:console';
 
 import { checkAuth } from '@/app/(backend)/middleware/auth';
-import { MODEL_TIERS, getModelTier } from '@/config/pricing';
+import { getModelTier } from '@/config/pricing';
 import { modelPricing } from '@/database/schemas';
 import { getServerDB } from '@/database/server';
 import { createTraceOptions, initModelRuntimeWithUserPayload } from '@/server/modules/ModelRuntime';
@@ -72,6 +72,21 @@ export const maxDuration = 300;
 //     console.error('Failed to track usage:', error);
 //   }
 // }
+
+// Conservative fail-safe pricing for models with NO `model_pricing` DB row.
+// Points/1M tokens, where points = USD/1M × 25_000 (1 pt ≈ $0.00004, the seed
+// ratio in scripts/seed-model-pricing-gateway.ts). Rates are pinned to roughly
+// the MOST EXPENSIVE model in each tier so an un-seeded model is billed ~its
+// real cost instead of leaking. PHO cost-leak fix (2026-06): the previous
+// fallback used MODEL_TIERS rates (100/300 pts ≈ $0.004/$0.012 per 1M), ~800x
+// below real flagship cost — every un-seeded model (e.g. claude-sonnet-4.6,
+// $102 real / $0.12 billed over 30 days) was effectively free AND uncapped,
+// because the daily USD cap reads usage_logs.cost_usd derived from these rates.
+const FALLBACK_TIER_PRICING_POINTS: Record<number, { inputCostPer1M: number; outputCostPer1M: number }> = {
+  1: { inputCostPer1M: 31_250, outputCostPer1M: 250_000 }, // ~$1.25 / $10 per 1M
+  2: { inputCostPer1M: 75_000, outputCostPer1M: 375_000 }, // ~$3 / $15 per 1M
+  3: { inputCostPer1M: 125_000, outputCostPer1M: 625_000 }, // ~$5 / $25 per 1M
+};
 
 async function getModelPricing(modelId: string) {
   try {
@@ -702,21 +717,28 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
 
     // Resolve correct tier via getModelTier()
     const resolvedTier = getModelTier(actualModelUsed);
-    const resolvedTierConfig = MODEL_TIERS[resolvedTier as keyof typeof MODEL_TIERS];
 
-    // Use DB pricing if available, otherwise derive from MODEL_TIERS config.
-    // PHO-223: align fallback field names with DB schema (input_cost_per_1m / output_cost_per_1m).
-    // Both DB rows and MODEL_TIERS values are points/1M tokens — consistent unit.
+    // Use DB pricing if available; otherwise fall back to a CONSERVATIVE-HIGH
+    // per-tier rate (≈ the priciest model in the tier) so an un-seeded model is
+    // billed near its real cost and the daily USD cap still fires. Do NOT use
+    // MODEL_TIERS rates here — those are legacy points-per-message estimates
+    // (100/300 pts/1M ≈ $0.004/$0.012), ~800x below real flagship cost, which
+    // is exactly the leak this fallback guards against.
+    const fallbackPricing =
+      FALLBACK_TIER_PRICING_POINTS[resolvedTier] ?? FALLBACK_TIER_PRICING_POINTS[2];
     const activePricing = pricing || {
       id: 'default',
-      inputCostPer1M: resolvedTierConfig?.inputCostPer1M ?? 100,
-      outputCostPer1M: resolvedTierConfig?.outputCostPer1M ?? 300,
+      inputCostPer1M: fallbackPricing.inputCostPer1M,
+      outputCostPer1M: fallbackPricing.outputCostPer1M,
       tier: resolvedTier,
     };
 
     if (!pricing) {
+      // Loud signal so missing models get seeded promptly (grep Vercel logs).
       console.warn(
-        `⚠️ No DB pricing for model ${data.model}, using Tier ${resolvedTier} fallback (${resolvedTierConfig?.tierName}).`,
+        `⚠️ [billing] NO DB pricing for "${actualModelUsed}" (tier ${resolvedTier}) — ` +
+          `billing at conservative fallback ${fallbackPricing.inputCostPer1M}/${fallbackPricing.outputCostPer1M} pts/1M. ` +
+          `Add it to scripts/seed-model-pricing-gateway.ts and re-seed.`,
       );
     }
 

--- a/src/server/services/billing/dailyCostCaps.ts
+++ b/src/server/services/billing/dailyCostCaps.ts
@@ -55,11 +55,14 @@ const PLAN_CAPS: Record<string, DailyCostCap> = {
   lifetime_standard: { tier1: 10, tier2: 10, tier3: 10 },
 
   // PHO-238: T3 hard-blocked at $0 — medical_beta is FREE-tier and was burning $26/hr.
-  // 2026-06 cost audit: a medical_beta user still burned ~$22/day on Tier 2 (cap was $3
-  // but this USD cap is a timing-sensitive pre-read). Lowered T2 to $1/day; the real
-  // hard stop is the atomic 30-msg/day Tier 2 limit in PLAN_MODEL_ACCESS.medical_beta.
-  // Defense-in-depth: also blocked via allowedTiers + dailyTier3Limit=0.
-  medical_beta: { tier1: 5, tier2: 1, tier3: 0 },
+  // 2026-06 cost audit (PHO-287): the "~$22/day on Tier 2" burn that forced the
+  // emergency $1 cap was NOT really a cap-value problem — it was the un-seeded-model
+  // leak. claude-sonnet-4.6 had no model_pricing row, so it billed ~$0 and this USD
+  // cap (which reads usage_logs.cost_usd) never saw the real spend. With that leak
+  // fixed (seed + conservative fallback in the chat route), the USD cap is meaningful
+  // again, so T2 is raised back to $3/day to unblock legit medical_beta usage.
+  // Backstops still in place: atomic 30-msg/day Tier 2 limit + allowedTiers + T3=$0.
+  medical_beta: { tier1: 5, tier2: 3, tier3: 0 },
 
   // VN basic (Phở Tái) — Tier 1 & 2 (30 T2 msgs/day)
   vn_basic: { tier1: 2, tier2: 3, tier3: 0 },


### PR DESCRIPTION
## Why

Investigation of a `medical_beta` user (`bachcvp1316@gmail.com`) blocked by "quota for this key has been reached" surfaced a production cost leak: **any model without a `model_pricing` DB row is billed at ~0 and is invisible to the daily USD cost cap.**

PostHog 30-day evidence (app-billed vs real catalog cost):

| Model | Tier | Calls | App billed | Real cost | Leak |
|---|---|---|---|---|---|
| anthropic/claude-sonnet-4.6 | 2 | 737 | $0.12 | $102.23 | **$102.12** |
| openai/gpt-5.3-codex | 2 | 18 | $0.00 | $3.25 | $3.24 |
| gemini-2.5-flash (unprefixed) | 1 | 35 | $0.22 | $3.70 | $3.48 |
| claude-sonnet-4-20250514 | 2 | 26 | $0.00 | $2.28 | $2.27 |
| deepseek/deepseek-r1 | 2 | 20 | $0.01 | $1.03 | $1.02 |

~59% of real spend ($112 / $190 over 30d) was invisible & uncapped. Root cause: the chat route falls back to `MODEL_TIERS` rates (Tier 2 = 100/300 pts/1M ≈ $0.004/$0.012) when a model has no `model_pricing` row — ~800x below real flagship cost. Since `checkDailyCostCap` reads `usage_logs.cost_usd` derived from that calc, the cap never fired for un-seeded models.

## Changes

1. **`route.ts`** — replace the near-zero `MODEL_TIERS` fallback with a conservative-high per-tier rate (≈ priciest model in tier) + loud `[billing] NO DB pricing` warning, so any un-seeded model is billed ~correctly instead of leaking.
2. **`seed-model-pricing-gateway.ts`** — add the 5 active-but-unseeded leaking gateway IDs (`claude-sonnet-4.6`, `claude-sonnet-4-20250514`, `gpt-5.3-codex`, `deepseek-r1`, `gemini-2.5-flash`) with real provider rates.
3. **`dailyCostCaps.ts`** — raise `medical_beta` Tier-2 daily USD cap **$1 → $3/day**. The emergency $1 cap was a response to a ~$22/day burn that this audit traced to the leak above (not the cap value); with the leak fixed, the cap is meaningful again and $3 unblocks legit medical_beta Tier-2 usage. Backstops unchanged: 30-msg/day atomic Tier-2 limit, allowedTiers, T3=$0.

These three ship together so the cap raise and the leak fix land in the same deploy — sonnet-4.6 is billed correctly (via the new fallback) even before the prod seed runs.

## Test plan

- [x] `bun run type-check` passes (exit 0)
- [ ] **Post-merge:** run `bunx tsx scripts/seed-model-pricing-gateway.ts` against prod; verify `SELECT count(*) FROM model_pricing WHERE id LIKE 'seed_gateway_%'` = 18
- [ ] Verify `medical_beta` user can send Tier-2 (gemini-2.5-pro) messages again after deploy
- [ ] Confirm `usage_logs.cost_usd` for sonnet-4.6 is now non-zero in PostHog `$ai_generation`

## Follow-ups (Linear, parent PHO-238)

- **PHO-287** — this cost-leak finding
- **PHO-288** — read actual cost from Vercel AI Gateway (proper fix, removes the price-table entirely)
- **PHO-289** — provider-native prompt caching (cost reduction; prerequisite to raising caps further)
- **PHO-290** — misleading "quota for this key" error message for all internal caps

https://claude.ai/code/session_01LoagUyHhsPg9cbQqXvWpPi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoagUyHhsPg9cbQqXvWpPi)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a billing leak that made un-seeded models nearly free and bypassed daily USD caps. Adds a conservative fallback price, seeds five missing models, and raises `medical_beta` Tier‑2 cap to $3/day. Addresses PHO‑287 under PHO‑238.

- **Bug Fixes**
  - Chat route: replace `MODEL_TIERS` fallback with conservative per‑tier pricing and log a loud warning when no DB pricing exists, so caps see real spend.
  - Seed `model_pricing` for: `anthropic/claude-sonnet-4.6`, `claude-sonnet-4-20250514`, `openai/gpt-5.3-codex`, `deepseek/deepseek-r1`, `gemini-2.5-flash`.
  - Raise `medical_beta` Tier‑2 daily cap from $1 → $3; backstops unchanged (30 T2 msgs/day, allowedTiers, T3=$0).

- **Migration**
  - Post-merge: run `bunx tsx scripts/seed-model-pricing-gateway.ts` in prod; verify `SELECT count(*) FROM model_pricing WHERE id LIKE 'seed_gateway_%'` = 18.
  - After deploy: confirm `usage_logs.cost_usd` is non-zero for `anthropic/claude-sonnet-4.6` and that `medical_beta` Tier‑2 usage is unblocked.

<sup>Written for commit 3bcf99ca820fd77c00be489016e9454e11b9809a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved billing cost calculation inconsistencies by improving model pricing database seeding and implementing conservative fallback pricing rates.
  
* **Updates**
  * Increased Tier 2 daily cost cap for the medical_beta plan from $1 to $3 per day.
  * Expanded model pricing data to cover additional gateway entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->