### PR TITLE
🐛 fix(billing): seed upsert must conflict on model_id, not id

### DIFF
--- a/scripts/seed-model-pricing-gateway.sql
+++ b/scripts/seed-model-pricing-gateway.sql
@@ -5,7 +5,7 @@
 -- Conversion: USD/1M tokens × 25,000 = points/1M tokens
 -- Rates verified 2026-05-02 from official provider docs.
 --
--- Verify:   SELECT count(*) FROM model_pricing WHERE id LIKE 'seed_gateway_%';  -- expect 13
+-- Verify:   SELECT count(*) FROM model_pricing WHERE id LIKE 'seed_gateway_%';  -- expect 18
 -- Rollback: DELETE FROM model_pricing WHERE id LIKE 'seed_gateway_%';
 
 INSERT INTO model_pricing
@@ -27,8 +27,19 @@ VALUES
   -- Tier 3 — mirrors of PR #24
   ('seed_gateway_openai_gpt-5.4',                         'openai/gpt-5.4',                         62500,   375000, 0, 0, 0, 3, true),
   ('seed_gateway_google_gemini-3.1-pro-preview',          'google/gemini-3.1-pro-preview',          50000,   300000, 0, 0, 0, 3, true),
-  ('seed_gateway_anthropic_claude-opus-4.6',              'anthropic/claude-opus-4.6',              125000,  625000, 0, 0, 0, 3, true)
-ON CONFLICT (id) DO UPDATE SET
+  ('seed_gateway_anthropic_claude-opus-4.6',              'anthropic/claude-opus-4.6',              125000,  625000, 0, 0, 0, 3, true),
+  -- PHO-287 cost-leak fix: active-but-unseeded gateway IDs (billed ~0 + bypassed
+  -- the daily USD cap). claude-sonnet-4.6 alone leaked $102 over 30 days.
+  ('seed_gateway_anthropic_claude-sonnet-4.6',            'anthropic/claude-sonnet-4.6',            75000,   375000, 0, 0, 0, 2, true),
+  ('seed_gateway_claude-sonnet-4-20250514',               'claude-sonnet-4-20250514',               75000,   375000, 0, 0, 0, 2, true),
+  ('seed_gateway_openai_gpt-5.3-codex',                   'openai/gpt-5.3-codex',                   43750,   350000, 0, 0, 0, 2, true),
+  ('seed_gateway_deepseek_deepseek-r1',                   'deepseek/deepseek-r1',                   13750,   54750,  0, 0, 0, 2, true),
+  -- Un-prefixed legacy ID still reaches getModelPricing() on some routes.
+  ('seed_gateway_gemini-2.5-flash',                       'gemini-2.5-flash',                       7500,    62500,  0, 0, 0, 1, true)
+-- Conflict on model_id (the unique business key the route looks up), NOT id:
+-- a model can already exist under a different id from the un-prefixed PR #24
+-- seed, which would trip model_pricing_model_id_unique if we arbitrated on id.
+ON CONFLICT (model_id) DO UPDATE SET
   input_cost_per_1m = EXCLUDED.input_cost_per_1m,
   output_cost_per_1m = EXCLUDED.output_cost_per_1m,
   tier = EXCLUDED.tier,

--- a/scripts/seed-model-pricing-gateway.ts
+++ b/scripts/seed-model-pricing-gateway.ts
@@ -140,7 +140,11 @@ async function seed() {
             outputCostPer1M: outputPts,
             tier: s.tier,
           },
-          target: modelPricing.id,
+          // Conflict on model_id (the unique business key the chat route looks
+          // up), NOT id. A model can already exist under a different id from the
+          // un-prefixed PR #24 seed (e.g. 'gemini-2.5-flash'); conflicting on id
+          // would hit the model_pricing_model_id_unique constraint and abort.
+          target: modelPricing.modelId,
         });
 
       console.log(


### PR DESCRIPTION
Follow-up to #72. While running the gateway pricing seed on prod (Neon), it failed:

```
ERROR: duplicate key value violates unique constraint "model_pricing_model_id_unique" (SQLSTATE 23505)
```

## Cause
`model_pricing` has a UNIQUE constraint on **`model_id`** (not only the `id` PK). The seed arbitrated `ON CONFLICT (id)`, but a model can already exist under a *different* `id` from the un-prefixed PR #24 seed (`seed-model-pricing.ts`) — e.g. `gemini-2.5-flash`. Inserting it under a new `seed_gateway_*` id then collides on `model_id` and aborts the whole batch.

## Fix
- **`.ts`** — `onConflictDoUpdate` target `id` → `modelId` (the unique business key the chat route looks up via `eq(modelPricing.modelId, …)`).
- **`.sql`** — same `ON CONFLICT (model_id)`; also **sync the 5 PHO-287 leak-fix rows** that #72 added only to the `.ts` (`claude-sonnet-4.6`, `claude-sonnet-4-20250514`, `gpt-5.3-codex`, `deepseek-r1`, `gemini-2.5-flash`) and bump the verify count to 18. The `.ts` and `.sql` are now back in sync.

## Verification
Already applied on **prod Neon** via the corrected `model_id` upsert — all 5 rows present with correct rates (e.g. `anthropic/claude-sonnet-4.6` = 75000/375000 pts, tier 2). This PR brings the committed scripts in line with what's now in prod so future re-seeds are idempotent.

Note: local `bun run type-check` (`tsgo`) isn't available in this environment (see prior commit notes); CI runs the real check. The change is a one-token swap to an existing Drizzle column.

Refs: PHO-287 · follow-up to #72

https://claude.ai/code/session_01LoagUyHhsPg9cbQqXvWpPi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoagUyHhsPg9cbQqXvWpPi)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix gateway pricing seed to upsert by model_id instead of id, preventing unique constraint failures and making re-seeds idempotent. Also sync five PHO-287 models into the SQL seed with correct rates.

- **Bug Fixes**
  - Change upsert conflict target from id to model_id in `seed-model-pricing-gateway.ts` and `.sql` to match the table’s unique key and the lookup path.
  - Add the 5 PHO-287 cost-leak models to the SQL seed (`claude-sonnet-4.6`, `claude-sonnet-4-20250514`, `gpt-5.3-codex`, `deepseek-r1`, `gemini-2.5-flash`) with correct tiers and prices.
  - Update the verify count comment to 18.
  - Addresses PHO-287 by ensuring active-but-unseeded gateway IDs are seeded and correctly billed.

<sup>Written for commit 534f6bfa26758076af0691c8cdcaee9e4df4f304. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

