### PR TITLE
🐛 fix(auth): don't rewrite Clerk handshake requests (fixes session-token 401 → greyed PRO models)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -80,6 +80,25 @@ const defaultMiddleware = (request: NextRequest) => {
     return new NextResponse(null, { status: 404 });
   }
 
+  // ── Clerk session handshake must NOT be rewritten ──────────────────────────
+  // When Clerk redirects back carrying its handshake nonce (`__clerk_handshake`),
+  // clerkMiddleware sets the __session/__client cookies and 307-redirects to the
+  // clean URL. The `NextResponse.rewrite()` below would swallow that redirect —
+  // Next.js ignores a `Location` header once `x-middleware-rewrite` is set — so
+  // the session token is never established and EVERY cookie-auth endpoint (tRPC +
+  // /api/subscription/*) 401s with reason `client-uat-but-no-session-token`
+  // (signed-in client, no userId → picker greys PRO/flagship models). Return a
+  // passthrough so Clerk fully owns the handshake response. Ref: clerk/javascript#6057.
+  if (
+    url.searchParams.has('__clerk_handshake') ||
+    url.searchParams.has('__clerk_handshake_nonce') ||
+    url.searchParams.has('__clerk_help') ||
+    url.searchParams.has('__clerk_db_jwt')
+  ) {
+    logDefault('Skipping rewrite for Clerk handshake: %s', url.pathname);
+    return NextResponse.next();
+  }
+
   logDefault('Processing request: %s %s', request.method, request.url);
 
   // skip all api requests


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix

#### 🔀 变更说明 | Description of Change

Fixes the production auth incident where signed-in users get **401 on every Clerk-cookie-authenticated endpoint** (`/trpc/lambda/*`, `/api/subscription/usage-stats`, `/api/subscription/models/allowed`) — which makes the model picker **grey out all PRO/flagship models** (the `nga.ntv@gmail.com` symptom). Reproduces 100% in fresh incognito, intermittently in normal browsers; affects many users.

**Root cause (confirmed from Vercel logs + code + Clerk docs):**
- Vercel logs: `[ClerkAuth] signed-in client but no userId resolved` → `reason: client-uat-but-no-session-token`, `status: signed-out`. The client has `__client_uat` (signed in) but the `__session` token is never established → `authenticateRequest()`/`auth()` resolve no userId → 401.
- The middleware's locale/variant **`NextResponse.rewrite()`** swallows Clerk's session **handshake**: when Clerk redirects back with its handshake nonce (`__clerk_handshake`), it must set the session cookies and 307-redirect to the clean URL, but **Next.js ignores a `Location` header once `x-middleware-rewrite` is set**, so the handshake is lost and `__session` never gets set. (The codebase already flags this in `src/libs/clerk-auth/index.ts:13-17`.)
- The chat endpoint is unaffected because it authenticates via the **header token**, not the cookie — exactly matching the observed symptom (chat works, picker/history/usage 401).
- Ref: [clerk/javascript#6057](https://github.com/clerk/javascript/pull/6057), [Clerk session tokens](https://clerk.com/docs/guides/sessions/session-tokens).

**Fix:** in `defaultMiddleware`, when the request carries a Clerk handshake param (`__clerk_handshake` / `__clerk_handshake_nonce` / `__clerk_help` / `__clerk_db_jwt`), return `NextResponse.next()` (skip the rewrite) so Clerk fully owns the handshake round-trip and can set `__session` + redirect.

#### 📝 补充信息 | Additional Information

⚠️ **Production auth change — please verify on the Vercel Preview before merging:**
1. Open the **Preview URL** (from the Vercel bot comment) in a **fresh incognito** window.
2. Sign in.
3. Open the model picker → the **CHUYÊN NGHIỆP / PRO / flagship models should NOT be greyed**, and selecting one should work.
4. DevTools Console → no `401 (Unauthorized)` on `/trpc/lambda/*` or `/api/subscription/*`.
5. Chat history / sessions load (no 401).

Targeted, low-risk (only affects requests carrying a Clerk handshake param). Couldn't be unit-verified in the authoring sandbox — the Preview is the verification.

https://claude.ai/code/session_01Yb6XCm4H5fL5v7wqZ18PwM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Yb6XCm4H5fL5v7wqZ18PwM)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip rewriting Clerk handshake requests in middleware so Clerk can set session cookies. This fixes cookie-auth 401s and restores PRO/flagship models in the picker.

- **Bug Fixes**
  - In `src/middleware.ts`, if the URL has `__clerk_handshake`, `__clerk_handshake_nonce`, `__clerk_help`, or `__clerk_db_jwt`, return `NextResponse.next()` and skip the rewrite.
  - Prevents Next.js from swallowing Clerk’s 307 redirect, ensuring `__session` is set so `/trpc/lambda/*` and `/api/subscription/*` no longer return 401.
  - Only affects handshake requests; all other requests keep the existing rewrite behavior.

<sup>Written for commit 2e9b1ca7b403648d153699a31527f004f533ea03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Next.js URL rewriting middleware could interfere with authentication session handshake requests. Authentication requests are now properly detected and prioritized to ensure they complete without interruption, improving the reliability of the authentication flow and preventing session establishment failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->