### PR TITLE
🔒️ fix(security,billing): v1 audit + close SePay compat bypass, unblock user.deleted, seed llama-3.3

### DIFF
--- a/docs/audit/audit-usage-larg-nguyen-2026-07-02.md
+++ b/docs/audit/audit-usage-larg-nguyen-2026-07-02.md
@@ -1,0 +1,69 @@
+# Audit usage — larg.nguyen@gmail.com (vn_pro) — 2026-07-02
+
+**Người dùng:** larg.nguyen@gmail.com · `user_39Y2ZW2HkbLsAOtm4w8FTVCnA3k` (chị Linh Nguyen)
+**Gói:** `vn_pro` (Phở Đặc Biệt, 199.000đ/tháng) — kích hoạt thủ công 2026-06-20 do SePay webhook fail (commit `04d6c5b`), chu kỳ 30 ngày → hết hạn ~2026-07-20.
+**Bối cảnh:** Chị hỏi lại (screenshot Zalo 19:00 ngày 02/07) về việc "Phở Pro vẫn giới hạn số lần sử dụng Tier 2" — từng có bug tier 2-3 hồi tháng 6.
+
+## Kết luận nhanh (TL;DR)
+
+1. **Bug cũ ĐÃ FIX, không tái phát.** Logs production hôm nay xác nhận plan resolve đúng `vn_pro`, Tier 2 không giới hạn số tin nhắn.
+2. **Hôm nay chị bị chặn là do daily USD cost cap hoạt động ĐÚNG thiết kế**, không phải bug:
+   - Tier 2: **$5.32 / $5.00** — chặn từ ~18:47 giờ VN
+   - Tier 3: **$5.37 / $5.00** — chặn 19:33 giờ VN (thử gọi `claude-opus-4.6`)
+   - Thời điểm chặn khớp chính xác tin nhắn 19:00 của chị.
+3. **Câu chị hỏi ("Tier 2 không giới hạn tin nhắn nhưng có hạn mức token/ngày, hết thì đợi hôm sau?") — hiểu ĐÚNG.** Cap tính theo **chi phí USD/ngày/tier** (phụ thuộc token), reset **0:00 giờ VN**.
+4. Chị là heavy user hợp lệ: chi phí provider ~**$10.7/ngày** (~$117 từ khi kích hoạt) so với giá gói ~$7.9/**tháng** → **chi phí ≈ 15× doanh thu**. Cần theo dõi unit economics (liên quan PHO-356).
+
+## 1. Bug cũ (tháng 6) — trạng thái
+
+| Sự kiện | Ngày | Commit |
+| --- | --- | --- |
+| Kích hoạt Pro thủ công (SePay webhook fail, 199k VND) | 20/06 14:36 | `04d6c5b` |
+| **Bug:** script set `medical_beta: undefined` → JSON.stringify drop key → metadata `medical_beta` cũ còn nguyên → user bị áp cap Tier 2 = 30 msg/ngày của `medical_beta` thay vì unlimited của `vn_pro` | | |
+| Fix: set `medical_beta: false` tường minh | 20/06 14:38 | `58f8d66` |
+| Fix display + BillingLimit gợi ý model đúng tier (PHO-287) | 22/06 | `ca75536` |
+
+**Verify trên production (02/07):** mọi request của user đều log `[Subscription Auth] ✅ Paid subscription validated`, `[Tier Check] ... Plan: vn_pro`, và **không có** dòng `Atomic Tier 2 Slot` nào (chỉ xuất hiện khi tier có message-limit hữu hạn) → Tier 2 đang unlimited message đúng như cấu hình `vn_pro` (`PLAN_MODEL_ACCESS.vn_pro.dailyLimits.tier2 = -1`).
+
+## 2. Usage thực tế hôm nay (02/07, log Vercel production)
+
+Nguồn: runtime logs project `pho-chat-v1`, deployment `dpl_E4W8xe99...` (branch main), cửa sổ 00:00–19:33 giờ VN (log bị phân trang, số liệu cap là số server tự báo — authoritative).
+
+- **Model chính:** `anthropic/claude-sonnet-4.6` (Tier 2) — 32+ calls ghi nhận được trong ~6,5h, tổng ~$4.69 (riêng phần log lấy được).
+- **Kích thước request:** trung bình ~20k input tokens/call (max 42k), ~5k output tokens (max 32k), có call stream 4 phút → đúng pattern "phân tích tổng hợp báo cáo phòng khám" chị nói ngày 23/06.
+- **Tier 3:** đã tiêu $5.37 trước 19:33 (các call Opus buổi sáng/trưa nằm ngoài cửa sổ log lấy được).
+- **Chặn 429:** 5 request bị `DAILY_CAP_EXCEEDED` trong 18:52–19:33 giờ VN (4 lần Tier 2, 1 lần Tier 3).
+- **Phở Points:** còn **1.988.267 / 2.000.000** — đã dùng ~11.7k điểm (~$117 chi phí thật) từ 20/06. Points KHÔNG phải điểm nghẽn; điểm nghẽn duy nhất là daily USD cap.
+- **Tier 1** (`gemini-2.5-flash`, `llama-3.3-70b`): dùng rất ít, ~$0.12.
+
+### Các lớp giới hạn đang áp lên vn_pro (để trả lời support cho chuẩn)
+
+| Lớp | Giá trị vn_pro | Reset | Trạng thái của chị hôm nay |
+| --- | --- | --- | --- |
+| Số tin nhắn Tier 2/ngày | Không giới hạn (-1) | — | OK |
+| Số tin nhắn Tier 3/ngày | 50 | 0:00 VN | Chưa chạm (bị chặn bởi cap USD trước) |
+| **Daily USD cap / tier** | **$5/tier/ngày** (`dailyCostCaps.ts`) | **0:00 VN** | **T2 $5.32 ❌ · T3 $5.37 ❌** |
+| Tổng request/ngày (circuit breaker) | 500 | 0:00 VN | Chưa chạm |
+| Phở Points tháng | 2.000.000 | Cuối tháng | Còn 99.4% |
+
+## 3. Trả lời đề xuất cho chị Linh
+
+> Chị hiểu đúng rồi ạ. Gói Pro **không giới hạn số tin nhắn** với model Tier 2, nhưng mỗi tier có **hạn mức chi phí sử dụng mỗi ngày** (tính theo token — tài liệu dài, phân tích nhiều thì tốn nhanh hơn). Khi chạm hạn mức trong ngày, hệ thống tạm khóa tier đó và **tự mở lại lúc 0:00 giờ VN** — hoặc chị chuyển sang model tier thấp hơn (vd Gemini Flash) để dùng tiếp ngay. Hôm nay chị chạy phân tích tài liệu khá nặng nên chạm mức của cả Tier 2 và Tier 3 vào buổi tối ạ.
+
+Gợi ý thêm cho founder: nếu chị cần workload phân tích lớn thường xuyên, có thể (a) nâng `vn_ultimate` (cap $10/tier/ngày), hoặc (b) cân nhắc cap riêng cho user này qua env override `DAILY_CAP_VN_PRO_T2` (ảnh hưởng toàn plan — không khuyến nghị chỉ vì 1 user).
+
+## 4. Findings phụ phát hiện trong lúc audit
+
+| # | Mức | Vấn đề | Đề xuất |
+| --- | --- | --- | --- |
+| F1 | MED | `llama-3.3-70b-versatile` chưa được seed vào `model_pricing` → bill theo fallback conservative (31250/250000 pts/1M) = **$0.1133** cho call thực tế chỉ ~$0.011 (**đắt ~10×**), trừ oan vào tier-1 cap + points của user | Thêm vào `scripts/seed-model-pricing-gateway.ts` và re-seed (log server đã tự nhắc đúng việc này) |
+| F2 | LOW | `gemini-2.5-flash` **lệch tier giữa gate và billing**: `MODEL_TIERS` (pricing.ts) xếp Tier 2 → gate check đọc bucket tier-2, nhưng `model_pricing` DB seed tier **1** → cost ghi vào bucket tier-1. Meter lệch: spend Gemini không bao giờ tính vào cap Tier 2 | Đồng bộ tier trong seed script với `MODEL_TIERS` (chọn 1 nguồn chân lý) |
+| F3 | LOW (đã biết) | Cap có thể vượt nhẹ ($5.32, $5.37 > $5.00) vì cap check là pre-flight còn cost ghi sau khi stream xong — đúng mô tả PHO-267 (backlog) | Chấp nhận best-effort (đã có budget backstop) hoặc làm atomic theo PHO-267 |
+| F4 | MED (UX) | User bị chặn nhưng vẫn nhắn hỏi support → thông báo lỗi trên UI nhiều khả năng chưa truyền tải reason tiếng Việt của `checkDailyCostCap` ("thử lại sau 0:00") — trùng scope **PHO-290** (5 loại block map chung 1 message mơ hồ) | Ưu tiên PHO-290; reason string đã có sẵn, chỉ cần surface đúng |
+| F5 | INFO | Unit economics: user này cost ~$10.7/ngày vs doanh thu ~$7.9/tháng. Với 2 tier maxed mỗi ngày, trần lỗ ~$15/ngày/user Pro | Theo dõi qua runbook free-premium-burn (PHO-356); cân nhắc giảm `monthlyPoints` hoặc cap tổng |
+
+## 5. Phạm vi & giới hạn của audit
+
+- Sandbox không có `DATABASE_URL`/`CLERK_SECRET_KEY` → không query trực tiếp `usage_logs`/Clerk; số liệu lấy từ Vercel runtime logs production (14h gần nhất + cửa sổ sáng 02/07, bị phân trang 100 entries/query).
+- Số cap-used ($5.32/$5.37) là số **server tự tính từ `usage_logs`** in ra log — đáng tin hơn tổng cộng thủ công từ log bị phân trang.
+- Muốn số liệu đầy đủ theo ngày/tháng: chạy `bunx tsx scripts/find-db-user.ts larg.nguyen@gmail.com` + query `usage_logs` theo `userId` trên Neon, hoặc GET `/api/admin/rate-limits/user_39Y2ZW2HkbLsAOtm4w8FTVCnA3k`.

--- a/docs/audit/audit-v1-toan-dien-2026-07-02.md
+++ b/docs/audit/audit-v1-toan-dien-2026-07-02.md
@@ -99,14 +99,20 @@
 
 ## 6. Hành động 7 ngày tới (tóm tắt cho founder)
 
-| Ưu tiên | Việc | Tác động | Công sức |
-|---|---|---|---|
-| 1 | Tắt/harden SePay compat route | Bịt lỗ giả mạo thanh toán | 0.5d |
-| 2 | Fix Clerk user.deleted constraint | Hết user kẹt nửa-xoá | 0.5d |
-| 3 | Alert khi SePay/Polar activation fail + retry webhook log | Hết sự cố "trả tiền không có gói" âm thầm | 1d |
-| 4 | Seed llama-3.3 + đồng bộ tier gemini | Không tính oan tiền khách | 0.5d |
-| 5 | PHO-290 message rõ ràng khi chạm cap | Giảm ticket support ngay | 1d |
-| 6 | Fix bearer token Discover/MCP | Hết 500 trang public, đỡ hại SEO | 0.5d |
-| 7 | Quyết định cap Opus + PHO-356 | Giảm 30–40% cost user nặng | quyết định + 1d |
+| Ưu tiên | Việc | Tác động | Công sức | Trạng thái |
+|---|---|---|---|---|
+| 1 | Tắt/harden SePay compat route | Bịt lỗ giả mạo thanh toán | 0.5d | ✅ **Fixed (PR này)** — enforce secret fail-closed, mirror route chuẩn |
+| 2 | Fix Clerk user.deleted constraint | Hết user kẹt nửa-xoá | 0.5d | ✅ **Fixed (PR này)** — migration `0048` bỏ NOT NULL trên `global_files.creator` |
+| 3 | Alert khi SePay/Polar activation fail + retry webhook log | Hết sự cố "trả tiền không có gói" âm thầm | 1d | ⏳ Chờ (cần thiết kế alert channel) |
+| 4 | Seed llama-3.3 + đồng bộ tier gemini | Không tính oan tiền khách | 0.5d | ✅ **Seed llama-3.3 (PR này)** — cần chạy `bunx tsx scripts/seed-model-pricing-gateway.ts` trên prod. Gemini tier để founder quyết |
+| 5 | PHO-290 message rõ ràng khi chạm cap | Giảm ticket support ngay | 1d | ⏳ Chờ |
+| 6 | Fix bearer token Discover/MCP | Hết 500 trang public, đỡ hại SEO | 0.5d | ⏳ Chờ (cần env token registry) |
+| 7 | Quyết định cap Opus + PHO-356 | Giảm 30–40% cost user nặng | quyết định + 1d | ⏳ Chờ quyết định business |
 
-Tổng ~5 ngày công cho toàn bộ P0+P1.
+**Đã fix trong PR #77 (docs→code):** mục 1, 2, và phần seed của mục 4. Còn lại cần founder quyết (gemini tier, cap Opus) hoặc setup hạ tầng (alert, env token).
+
+### ⚠️ Bước deploy thủ công sau khi merge
+
+1. **Migration `0048`**: chạy migrate prod (hoặc `ALTER TABLE "global_files" ALTER COLUMN "creator" DROP NOT NULL;` trên Neon Console) để hết vòng lặp Clerk user.deleted.
+2. **Seed giá llama-3.3**: `bunx tsx scripts/seed-model-pricing-gateway.ts` (hoặc chạy `scripts/seed-model-pricing-gateway.sql` trên Neon) để ngừng tính oan.
+3. **SePay**: xác nhận SePay dashboard đang gửi `SEPAY_WEBHOOK_SECRET` (route chuẩn đã yêu cầu secret → nếu prod đang chạy tốt nghĩa là secret ĐÃ được gửi; route compat giờ cùng yêu cầu đó). Nếu SePay chỉ trỏ route compat và chưa gửi secret, phải cấu hình secret TRƯỚC khi deploy để tránh chặn webhook thật.

--- a/docs/audit/audit-v1-toan-dien-2026-07-02.md
+++ b/docs/audit/audit-v1-toan-dien-2026-07-02.md
@@ -1,0 +1,112 @@
+# Audit toàn diện Phở Chat v1 — 2026-07-02
+
+**Phạm vi:** Toàn bộ hoạt động production v1 (pho.chat). Nguồn dữ liệu: (1) git history + docs/audit từ 15/05, (2) Vercel runtime logs/error clusters 7 ngày, (3) PostHog project Phở Chat (error tracking, $ai_generation cost, event trends 30 ngày).
+**Câu hỏi của founder:** Các vấn đề đã fix có triệt để chưa? Có tái phát không? Còn lỗ hổng gì về chi phí, cost LLM, authenticator kẹt?
+
+---
+
+## 1. Bức tranh tổng thể
+
+**Điểm tốt:** Hệ thống chống-cháy-tiền (daily USD cap, tier gating, atomic slot) đang hoạt động đúng trên production — bằng chứng trực tiếp là ca larg.nguyen hôm nay bị chặn chính xác ở $5.32/$5.00. Cả 4 sự cố lớn tháng 6 (auth lockout, paid-user-hiển-thị-free, medical_beta burn, points không cấp lại) đều đã fix và **không thấy dấu hiệu tái phát** trên logs/PostHog.
+
+**Điểm đáng lo (3 nhóm):**
+
+1. **Tiền vào (thanh toán):** chuỗi webhook SePay/Polar/Clerk đều có vết nứt đang hoạt động — route SePay cũ chấp nhận webhook không chữ ký (giả mạo được), SePay miss orderId (29/06, đúng class gây ra vụ kích hoạt tay larg.nguyen), Polar mất log webhook do Neon timeout NGAY HÔM NAY trong lúc có khách checkout gói Perpetual 3.999.000đ, Clerk user.deleted kẹt retry loop.
+2. **Tiền ra (LLM cost):** run-rate ~$13.8/ngày (~$415/tháng), 94% từ Claude Opus + Sonnet, trong khi chỉ có 3–8 người chat/ngày. Một user Pro nặng (199k/tháng ≈ $7.9) có thể đốt tới $15/ngày theo thiết kế cap hiện tại → lỗ ~15–50× trên user đó.
+3. **Trải nghiệm bị chặn:** khách chạm cap không thấy lý do rõ → nhắn support (đã 2 case) — PHO-290 chưa làm.
+
+---
+
+## 2. Scorecard: các vấn đề đã fix — có tái phát không?
+
+| # | Sự cố (khi nào) | Fix | Trạng thái 02/07 | Bằng chứng |
+|---|---|---|---|---|
+| 1 | **Auth lockout** — SW precache hỏng + middleware nuốt Clerk handshake (đầu 06) | `2c62519`, `e270596` (08–16/06) | ✅ Không tái phát | `auth_session_expired` ổn định ~12/ngày suốt 30 ngày, không spike; user đăng nhập & chat bình thường |
+| 2 | **Paid user hiển thị như free** khi session hỏng (nga.ntv) | `6483a96`, `911dc66` (08/06) | ✅ Không tái phát | Không thấy case mới; logs hôm nay đều `Paid subscription validated` |
+| 3 | **medical_beta burn $22/ngày** (root cause: model chưa seed giá, bill ~$0) | `271a83c` + caps (03–09/06) | ✅ Fix đúng root cause | USD cap giờ đọc được cost thật; DAILY CAP HIT hoạt động |
+| 4 | **larg.nguyen kẹt cap Tier 2** (metadata medical_beta sót) | `58f8d66`, `ca75536` (20–22/06) | ✅ Không tái phát | Hôm nay plan resolve `vn_pro`, T2 unlimited message (audit riêng cùng ngày) |
+| 5 | **Model chưa seed giá → leak 800×** | Seed 5 models (09/06) | ⚠️ **Tái phát biến thể mới** | `llama-3.3-70b-versatile` chưa seed → giờ tính ĐẮT oan ~10× ($0.113 vs $0.011); warning `NO DB pricing` đang bắn trong prod. Kèm `gemini-2.5-flash` lệch tier giữa gate (T2) và billing (T1) |
+| 6 | **Billing sau stream bị drop** (Vercel freeze) | `after()` (08/06) | ⚠️ Còn sót khi Neon chập | 1 lần 29/06: `Failed to process model usage` do connection timeout → call đó không trừ tiền (fail-open) |
+| 7 | **Monthly points không cấp cho plan trả phí** | Cron `grant-monthly-points` (01/06) | 🔍 Chưa verify được từ ngoài | Cần chạy `scripts/scan-drained-paid-users.ts` (dry-run) định kỳ để xác nhận |
+| 8 | **Public API /api/v1/chat bypass mọi gating** | `4f17916` (03/06) | ✅ Enforcement chạy | Log `[Tier Check]`, cap blocks xuất hiện trên traffic |
+| 9 | **Chat history rỗng sau login** (PHO-260) | `8af6d3f` (20/05) | ✅ Gần như hết | PostHog: 0–1 event/ngày (lác đác), không cluster |
+
+**Kết luận scorecard:** 6/9 fix triệt để, 2 fix còn "đuôi" (leak biến thể mới #5, billing-drop khi DB chập #6), 1 chưa verify được (#7).
+
+---
+
+## 3. Lỗ hổng ĐANG MỞ (xếp theo rủi ro business)
+
+### 🔴 P0 — rủi ro tiền trực tiếp
+
+| Vấn đề | Ý nghĩa business | Bằng chứng | Giải pháp |
+|---|---|---|---|
+| **SePay compat route chấp nhận webhook không/sai chữ ký** (`src/app/api/sepay/webhook/route.ts:334-341` — "will still be processed for debugging") | Ai biết endpoint có thể GIẢ lệnh chuyển tiền để tự kích hoạt gói trả phí — mất doanh thu vô hình | Code hiện tại trên main; route mới (`/api/payment/sepay/webhook`) thì verify đúng | Tắt hẳn route cũ (nếu SePay đã trỏ route mới) hoặc bật enforce chữ ký. **0.5 ngày** |
+| **Clerk `user.deleted` webhook lỗi constraint** (`global_files.creator` NOT NULL nhưng FK `ON DELETE SET NULL`) | User xoá tài khoản bị "kẹt nửa chừng": mất trên Clerk, còn nguyên data trong DB (rủi ro GDPR/niềm tin), Clerk retry vô hạn | 8 lỗi/3 users 29–30/06, sẽ bắn lại ở lần xoá kế | Sửa schema (nullable) hoặc xử lý global_files trước khi xoá user. **0.5 ngày** |
+
+### 🟠 P1 — rủi ro doanh thu & khách trả phí
+
+| Vấn đề | Ý nghĩa business | Bằng chứng | Giải pháp |
+|---|---|---|---|
+| **SePay miss orderId từ nội dung chuyển khoản** | Khách CHUYỂN TIỀN THẬT mà không được kích hoạt → lại phải kích hoạt tay như larg.nguyen (mỗi ca ~1 buổi support + uy tín) | 2 case, gần nhất 29/06: `❌ Could not extract orderId` | Nới regex parse + alert ngay khi fail (kèm nội dung CK) để xử lý trong phút thay vì đợi khách complain. **1 ngày** |
+| **Polar webhook mất log do Neon timeout** | Mất audit trail thanh toán đúng lúc có khách checkout **Phở Assistant Perpetual 3.999.000đ hôm nay** (11:17 UTC); nếu timeout rơi vào event kích hoạt → lặp lại class "trả tiền không có gói" | 14 lỗi `WebhookLogger failed insert`/7 ngày, đang active | Ghi log webhook qua retry/queue (hoặc after()+retry 3 lần); alert khi activation event fail. **1 ngày** |
+| **`pho-pro` (model thương hiệu) chạy Groq free-tier 12k TPM** | Khách TRẢ PHÍ chọn "Phở Pro" bị lỗi 413 khi hỏi dài — trải nghiệm tệ ở đúng model mang tên thương hiệu | Lỗi 413 `Request too large... TPM Limit 12000`, gần nhất 28/06 | Nâng Groq Dev Tier (~$?) hoặc route pho-pro sang provider khác. **0.5 ngày** |
+| **Trang Discover/MCP lỗi 401 "Missing bearer token" từ 06/03** | ~340 lỗi/30+ users; trang public bị lỗi server → hại SEO + first impression | Cluster #2/#3/#5/#7, vẫn bắn hôm nay | Set/refresh env token registry MCP. **0.5 ngày** |
+| **Thông báo chặn quota mơ hồ (PHO-290)** | Khách bị chặn không hiểu vì sao → ticket support (2 case đã ghi nhận); reason tiếng Việt "thử lại sau 0:00" ĐÃ có trong code, chỉ chưa surface | Ca larg.nguyen nhắn Zalo đúng lúc bị chặn | Map 5 loại block ra message riêng. **1 ngày, giảm ngay ticket** |
+
+### 🟡 P2 — theo dõi / nợ kỹ thuật
+
+- **Embedding/RAG chưa tính tiền** (P1-2 audit cũ, vẫn mở) — user KB nặng dùng embedding free.
+- **Chat timeout 300s**: 45 lần/7 ngày/9 users — khách chờ 5 phút rồi mất câu trả lời (đã trừ tiền chưa? cần check per-case).
+- **tool_use/tool_result corruption** (lịch sử chat gửi Anthropic bị lệch) — 16 lỗi, tập trung 1 user 29–30/06; bug reassembly lịch sử.
+- **SyntaxError "Unterminated string in JSON"** (streaming plugin/chat) — ~60 lỗi rải rác, UX degradation.
+- **tRPC UNAUTHORIZED chronic**: 509 lỗi/61 users/7 ngày, đều đặn từ tháng 2 — không phải regression spike, phần lớn là session hết hạn/anonymous gọi endpoint authed; cần chuẩn hoá client re-auth redirect thay vì retry.
+- **PHO-267 cap overshoot** (~6–7%) — chấp nhận được, đã có backstop.
+- **DB fail-open có chủ đích** ở `getDailyTierCostUSD` — chấp nhận 1 request lọt khi Neon chập; giữ nguyên nhưng cần alert nếu tần suất tăng.
+
+---
+
+## 4. Chi phí LLM & unit economics (PostHog, 15 ngày 18/06–02/07)
+
+| Model | Cost 15 ngày | % tổng |
+|---|---|---|
+| anthropic/claude-opus-4.6 | **$101.62** | 49% |
+| anthropic/claude-sonnet-4.6 | **$93.55** | 45% |
+| google/gemini-2.5-pro | $9.70 | 5% |
+| gemini-2.5-flash + còn lại | ~$2.5 | 1% |
+| **Tổng** | **~$207** (≈$13.8/ngày, ~$415/tháng run-rate) | |
+
+**Ý nghĩa business:**
+- 94% chi phí đến từ 2 model đắt nhất, trong khi số người chat thực tế chỉ **3–8 user/ngày** → chi phí tập trung vào rất ít user nặng.
+- Thiết kế cap hiện tại cho phép 1 user vn_pro đốt tối đa **$15/ngày** ($5×3 tier) = ~$450/tháng, gấp ~57× giá gói 199k. Ca thật hôm nay: larg.nguyen ~$10.7/ngày.
+- Gói vn_premium (rẻ hơn) có USD cap = vn_pro ($5/5/5) — không còn inversion nhưng cũng không có phân tầng giá trị.
+
+**Đề xuất (quyết định business, không phải code):**
+1. Hạ cap Tier 3 (Opus) của vn_pro xuống $2–3/ngày; giữ Tier 2 $5. Tiết kiệm tức thì ~30–40% cost user nặng, đa số user không cảm nhận được.
+2. Đẩy nhanh PHO-356 (%-of-cost meter, PRD đã có) — hiển thị "đã dùng X% hạn mức" như Claude.ai, khách tự điều tiết, đỡ shock khi bị chặn.
+3. Routing thông minh: mặc định Sonnet, chỉ lên Opus khi user chọn chủ động.
+
+---
+
+## 5. Quy trình giám sát đề xuất (tận dụng PostHog vừa kết nối)
+
+1. **Dashboard "Money Health"** (PostHog): LLM cost/ngày theo model · DAILY CAP HIT/ngày · webhook fail (SePay/Polar/Clerk) · auth_session_expired · `NO DB pricing` warnings.
+2. **Alert 4 điều kiện** (PostHog alert / Vercel log drain): (a) SePay/Polar activation fail, (b) `NO DB pricing` model mới, (c) LLM cost ngày > $25, (d) `plan-drift` xuất hiện.
+3. **Cron tuần:** `scan-drained-paid-users.ts --dry-run` + `audit-plan-drift.ts` → 5 phút đọc kết quả.
+4. Mỗi fix production mới: ghi kèm "recurrence signal" (log string) vào ticket — audit lần sau chỉ cần grep.
+
+---
+
+## 6. Hành động 7 ngày tới (tóm tắt cho founder)
+
+| Ưu tiên | Việc | Tác động | Công sức |
+|---|---|---|---|
+| 1 | Tắt/harden SePay compat route | Bịt lỗ giả mạo thanh toán | 0.5d |
+| 2 | Fix Clerk user.deleted constraint | Hết user kẹt nửa-xoá | 0.5d |
+| 3 | Alert khi SePay/Polar activation fail + retry webhook log | Hết sự cố "trả tiền không có gói" âm thầm | 1d |
+| 4 | Seed llama-3.3 + đồng bộ tier gemini | Không tính oan tiền khách | 0.5d |
+| 5 | PHO-290 message rõ ràng khi chạm cap | Giảm ticket support ngay | 1d |
+| 6 | Fix bearer token Discover/MCP | Hết 500 trang public, đỡ hại SEO | 0.5d |
+| 7 | Quyết định cap Opus + PHO-356 | Giảm 30–40% cost user nặng | quyết định + 1d |
+
+Tổng ~5 ngày công cho toàn bộ P0+P1.

--- a/packages/database/migrations/0048_global_files_creator_nullable.sql
+++ b/packages/database/migrations/0048_global_files_creator_nullable.sql
@@ -1,0 +1,13 @@
+-- Fix: `global_files.creator` was declared `ON DELETE SET NULL` yet `NOT NULL`.
+--
+-- That self-contradiction aborted every `user.deleted` cascade: Postgres tried
+-- to SET creator = NULL per the FK rule, which violated the NOT NULL constraint,
+-- so the whole `DELETE FROM users` transaction rolled back. Clerk then retried
+-- the webhook indefinitely and the user was left "half-deleted" — gone in Clerk
+-- but still present in Postgres.
+--
+-- Dropping NOT NULL restores the intended semantics: when the creating user is
+-- deleted, the shared (hash-keyed, deduplicated) global file blob is orphaned
+-- and kept, not removed. It is only referenced by `files.file_hash` with
+-- `ON DELETE no action`, so orphaning does not break other users' file rows.
+ALTER TABLE "global_files" ALTER COLUMN "creator" DROP NOT NULL;

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -336,6 +336,13 @@
       "when": 1767518400000,
       "tag": "0047_promo_activations",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1767604800000,
+      "tag": "0048_global_files_creator_nullable",
+      "breakpoints": true
     }
   ],
   "version": "6"

--- a/packages/database/src/schemas/file.ts
+++ b/packages/database/src/schemas/file.ts
@@ -26,9 +26,12 @@ export const globalFiles = pgTable('global_files', {
   size: integer('size').notNull(),
   url: text('url').notNull(),
   metadata: jsonb('metadata'),
-  creator: text('creator')
-    .references(() => users.id, { onDelete: 'set null' })
-    .notNull(),
+  // Nullable on purpose: the FK is `ON DELETE SET NULL`, so when the creating
+  // user is deleted the global file is orphaned (kept — it's a shared, hash-keyed
+  // dedup blob) rather than removed. A `.notNull()` here contradicted SET NULL and
+  // aborted every `user.deleted` cascade, leaving users stuck half-deleted and
+  // Clerk retrying the webhook forever.
+  creator: text('creator').references(() => users.id, { onDelete: 'set null' }),
   createdAt: createdAt(),
   accessedAt: accessedAt(),
 });

--- a/scripts/seed-model-pricing-gateway.sql
+++ b/scripts/seed-model-pricing-gateway.sql
@@ -5,7 +5,7 @@
 -- Conversion: USD/1M tokens × 25,000 = points/1M tokens
 -- Rates verified 2026-05-02 from official provider docs.
 --
--- Verify:   SELECT count(*) FROM model_pricing WHERE id LIKE 'seed_gateway_%';  -- expect 18
+-- Verify:   SELECT count(*) FROM model_pricing WHERE id LIKE 'seed_gateway_%';  -- expect 19
 -- Rollback: DELETE FROM model_pricing WHERE id LIKE 'seed_gateway_%';
 
 INSERT INTO model_pricing
@@ -35,7 +35,10 @@ VALUES
   ('seed_gateway_openai_gpt-5.3-codex',                   'openai/gpt-5.3-codex',                   43750,   350000, 0, 0, 0, 2, true),
   ('seed_gateway_deepseek_deepseek-r1',                   'deepseek/deepseek-r1',                   13750,   54750,  0, 0, 0, 2, true),
   -- Un-prefixed legacy ID still reaches getModelPricing() on some routes.
-  ('seed_gateway_gemini-2.5-flash',                       'gemini-2.5-flash',                       7500,    62500,  0, 0, 0, 1, true)
+  ('seed_gateway_gemini-2.5-flash',                       'gemini-2.5-flash',                       7500,    62500,  0, 0, 0, 1, true),
+  -- PHO audit 2026-07-02 (F1): Groq llama-3.3-70b-versatile (pho-pro backing model)
+  -- was unseeded → billed ~10x at the conservative fallback. $0.59/$0.79 per 1M × 25000.
+  ('seed_gateway_llama-3.3-70b-versatile',                'llama-3.3-70b-versatile',                14750,   19750,  0, 0, 0, 1, true)
 -- Conflict on model_id (the unique business key the route looks up), NOT id:
 -- a model can already exist under a different id from the un-prefixed PR #24
 -- seed, which would trip model_pricing_model_id_unique if we arbitrated on id.

--- a/scripts/seed-model-pricing-gateway.ts
+++ b/scripts/seed-model-pricing-gateway.ts
@@ -98,6 +98,11 @@ const SEEDS: PricingSeed[] = [
   { inputUsdPer1M: 0.55, modelId: 'deepseek/deepseek-r1', outputUsdPer1M: 2.19, tier: 2 },
   // Un-prefixed legacy IDs still reach getModelPricing() on some routes.
   { inputUsdPer1M: 0.3, modelId: 'gemini-2.5-flash', outputUsdPer1M: 2.5, tier: 1 },
+  // PHO audit 2026-07-02 (F1): `llama-3.3-70b-versatile` (Groq, the `pho-pro`
+  // backing model) was unseeded, so it billed at the conservative fallback
+  // (31250/250000 pts ≈ $0.31/$2.50 per 1M) — ~10x the real Groq rate. Seed the
+  // exact un-prefixed $ai_model string so the exact-match lookup stops overcharging.
+  { inputUsdPer1M: 0.59, modelId: 'llama-3.3-70b-versatile', outputUsdPer1M: 0.79, tier: 1 },
 
   // ============================================================================
   // Tier 3 — Premium / Expensive tier

--- a/src/app/api/sepay/webhook/route.ts
+++ b/src/app/api/sepay/webhook/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { paymentMetricsCollector } from '@/libs/monitoring/payment-metrics';
 import { SepayWebhookData, sepayGateway } from '@/libs/sepay';
+import { timingSafeCompareStrings } from '@/utils/timingSafeCompare';
 import { addPhoCredits } from '@/server/services/billing/credits';
 import {
   activateUserSubscription,
@@ -279,10 +280,46 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       '🔔 [COMPAT ROUTE] Webhook received at /api/sepay/webhook from:',
       request.headers.get('user-agent'),
     );
-    console.log(
-      '🔔 [COMPAT ROUTE] Request headers:',
-      Object.fromEntries(request.headers.entries()),
-    );
+
+    // SECURITY CHECK: verify webhook authentication before doing any work.
+    // Mirrors the canonical /api/payment/sepay/webhook route: SePay sends the
+    // shared secret either as `X-Sepay-Webhook-Secret` or `Authorization: Apikey <token>`.
+    // This closes the previous "process even on invalid/missing signature" hole
+    // that let a forged POST activate a paid subscription.
+    const webhookSecret = process.env.SEPAY_WEBHOOK_SECRET;
+
+    let providedSecret = request.headers.get('x-sepay-webhook-secret');
+    if (!providedSecret) {
+      const authHeader = request.headers.get('authorization');
+      if (authHeader && authHeader.startsWith('Apikey ')) {
+        providedSecret = authHeader.slice(7);
+      }
+    }
+
+    if (!webhookSecret) {
+      console.error('❌ [COMPAT ROUTE] SEPAY_WEBHOOK_SECRET not configured in environment');
+      return NextResponse.json(
+        { message: 'Webhook authentication not configured', success: false },
+        { status: 500 },
+      );
+    }
+
+    // Constant-time compare; returns false on missing/different-length input,
+    // so it subsumes the `!providedSecret` guard.
+    if (!providedSecret || !timingSafeCompareStrings(providedSecret, webhookSecret)) {
+      console.error('❌ [COMPAT ROUTE] Unauthorized webhook — invalid or missing secret token');
+      paymentMetricsCollector.recordError(
+        'webhook_auth_failed',
+        'Unauthorized webhook request (compat route)',
+        undefined,
+        undefined,
+        { hasSecret: !!providedSecret },
+      );
+      return NextResponse.json(
+        { message: 'Unauthorized - invalid webhook secret', success: false },
+        { status: 401 },
+      );
+    }
 
     // Parse webhook data from Sepay (only parse once!)
     body = await request.json();


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

Started as two audit reports; now also carries the P0/P1 code fixes those audits surfaced.

**Audit docs (verified against Vercel prod logs + PostHog project Phở Chat):**
- `docs/audit/audit-usage-larg-nguyen-2026-07-02.md` — per-user audit for `larg.nguyen@gmail.com` (`vn_pro`): old tier-2 cap bug is fixed & not recurring; today's blocks are the $5/tier/day USD cost cap working as designed.
- `docs/audit/audit-v1-toan-dien-2026-07-02.md` — comprehensive v1 audit: fix-recurrence scorecard (6/9 fully fixed), open risks ranked P0–P2, LLM cost (~$13.8/day, 94% Opus+Sonnet, 3–8 chat DAU), 7-day action plan.

**Code fixes (P0/P1 from the audit):**
1. **P0 — SePay compat webhook signature bypass.** `src/app/api/sepay/webhook/route.ts` processed webhooks even on invalid/missing signature ("will still be processed for debugging"), letting a forged POST activate a paid subscription. Now enforces `SEPAY_WEBHOOK_SECRET` fail-closed with a constant-time compare, mirroring the canonical `/api/payment/sepay/webhook` route; also removed the full request-header dump that logged the secret.
2. **P0 — Clerk `user.deleted` retry loop.** `global_files.creator` was `ON DELETE SET NULL` yet `NOT NULL` — a contradiction that aborted every `user.deleted` cascade and left users half-deleted while Clerk retried forever. Migration `0048_global_files_creator_nullable.sql` drops the `NOT NULL`; Drizzle schema updated to match.
3. **P1 — billing overcharge.** Seeded Groq `llama-3.3-70b-versatile` in `model_pricing` (both `.ts` and `.sql`); it was unseeded and billing ~10× at the conservative fallback.

#### 📝 补充信息 | Additional Information

**Manual post-merge steps (documented in the comprehensive audit doc):**
1. Run migration `0048` on prod (or `ALTER TABLE "global_files" ALTER COLUMN "creator" DROP NOT NULL;` on Neon).
2. Re-seed model pricing: `bunx tsx scripts/seed-model-pricing-gateway.ts` (or run the `.sql` on Neon).
3. Confirm SePay dashboard sends `SEPAY_WEBHOOK_SECRET` — the canonical route already requires it, so if prod payments work the secret is being sent; if SePay only targets the compat route without the secret, configure it before deploy.

Still open for founder decision / infra: Polar+SePay activation-fail alerting, `pho-pro` Groq Dev Tier, discover/MCP bearer token, PHO-290 quota UX, gemini-2.5-flash tier reconciliation, Opus cap tuning (PHO-356).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5Mr7nsRWsp5M3dJzwm43p