### PR TITLE
feat: dismissible migration notice banner (pho.chat -> v2)

### DIFF
--- a/src/app/[variants]/layout.tsx
+++ b/src/app/[variants]/layout.tsx
@@ -9,6 +9,7 @@ import { isRtlLang } from 'rtl-detect';
 import Analytics from '@/components/Analytics';
 import { DEFAULT_LANG } from '@/const/locale';
 import { isDesktop } from '@/const/version';
+import MigrationBanner from '@/features/MigrationBanner';
 import PWAInstall from '@/features/PWAInstall';
 import AuthProvider from '@/layout/AuthProvider';
 import GlobalProvider from '@/layout/GlobalProvider';
@@ -96,6 +97,9 @@ const RootLayout = async ({ children, params, modal }: RootLayoutProps) => {
             primaryColor={primaryColor}
             variants={variants}
           >
+            {/* Dismissible migration notice (pho.chat -> v2). Fixed-position top bar
+                so it does not affect the height-locked app shell layout. */}
+            <MigrationBanner />
             <AuthProvider>
               {children}
               {!isMobile && modal}

--- a/src/features/MigrationBanner/index.tsx
+++ b/src/features/MigrationBanner/index.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { createStyles } from 'antd-style';
+import { X } from 'lucide-react';
+import Link from 'next/link';
+import { memo, useEffect, useState } from 'react';
+
+// ============================================================================
+// EDIT COPY / LINK HERE — founder-editable
+// ----------------------------------------------------------------------------
+// Forward-looking wording: reads correctly BOTH before AND after the domain swap.
+// Brand rule: NO em-dashes (use periods / commas).
+// ============================================================================
+// Field guide (keys are kept alphabetical to satisfy lint sort-keys):
+//   lead ...................... opening sentence before the "try new version" link
+//   newHome / newHomeLabel / newHomeUrl ... where the new version lives (pho.chat)
+//   current / currentLabel / currentUrl / currentTail ... current app stays reachable (v1.pho.chat)
+//   cta / ctaUrl .............. primary "try new version" button + destination
+//   dismissAria ............... accessible label for the close (x) button
+const COPY = {
+  cta: 'Dùng thử bản mới',
+  // NOTE: points to v2.pho.chat FOR NOW, because pho.chat still serves v1 until
+  // the swap. AFTER the domain swap, change this to https://pho.chat.
+  ctaUrl: 'https://v2.pho.chat',
+  current: 'Bản hiện tại của bạn luôn truy cập được tại',
+  currentLabel: 'v1.pho.chat',
+  currentTail: 'với đầy đủ dữ liệu.',
+  currentUrl: 'https://v1.pho.chat',
+  dismissAria: 'Đóng thông báo',
+  lead: 'Phở Chat sắp nâng cấp lên phiên bản mới, nhanh hơn và trả lời kèm trích dẫn nguồn thật.',
+  newHome: 'Bản mới sẽ ở',
+  newHomeLabel: 'pho.chat',
+  newHomeUrl: 'https://pho.chat',
+};
+
+// localStorage key the founder can clear to re-show the banner during testing.
+const DISMISS_KEY = 'pho_migration_notice_dismissed';
+
+const JADE = '#059669';
+
+const useStyles = createStyles(({ css, token, isDarkMode, responsive }) => ({
+  bar: css`
+    position: fixed;
+    z-index: 1000;
+    inset-block-start: 0;
+    inset-inline: 0;
+
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    justify-content: center;
+
+    min-height: 40px;
+    padding-block: 6px;
+    padding-inline: 44px 44px;
+    border-block-end: 1px solid rgba(5, 150, 105, 35%);
+
+    font-size: 13px;
+    line-height: 1.4;
+    color: ${isDarkMode ? 'rgba(255,255,255,0.92)' : token.colorText};
+    text-align: center;
+
+    background: ${isDarkMode ? 'rgba(5, 150, 105, 0.14)' : 'rgba(5, 150, 105, 0.10)'};
+    backdrop-filter: blur(8px);
+
+    ${responsive.mobile} {
+      gap: 8px;
+      padding-block: 8px;
+      padding-inline: 40px 40px;
+      font-size: 12px;
+    }
+  `,
+
+  cta: css`
+    flex: none;
+
+    padding-block: 3px;
+    padding-inline: 12px;
+    border-radius: 8px;
+
+    font-weight: 600;
+    color: #fff;
+    text-decoration: none;
+    white-space: nowrap;
+
+    background: ${JADE};
+
+    transition: opacity 0.2s;
+
+    &:hover {
+      opacity: 0.88;
+    }
+  `,
+
+  dismiss: css`
+    cursor: pointer;
+
+    position: absolute;
+    inset-block-start: 50%;
+    inset-inline-end: 10px;
+    transform: translateY(-50%);
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    border: none;
+    border-radius: 6px;
+
+    color: ${token.colorTextSecondary};
+
+    background: transparent;
+
+    transition:
+      color 0.2s,
+      background 0.2s;
+
+    &:hover {
+      color: ${token.colorText};
+      background: ${isDarkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)'};
+    }
+  `,
+
+  link: css`
+    font-weight: 600;
+    color: ${JADE};
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  `,
+
+  message: css`
+    min-width: 0;
+
+    ${responsive.mobile} {
+      /* Keep the notice compact on small screens: hide the reassurance clause,
+         keep the core upgrade message + CTA. */
+      .migration-reassurance {
+        display: none;
+      }
+    }
+  `,
+}));
+
+const MigrationBanner = memo(() => {
+  const { styles } = useStyles();
+
+  // SSR-safe: render nothing until mounted so we never touch localStorage during
+  // render and never cause a hydration mismatch. Default hidden.
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    try {
+      if (localStorage.getItem(DISMISS_KEY) !== '1') setVisible(true);
+    } catch {
+      // localStorage unavailable (private mode / blocked): show anyway.
+      setVisible(true);
+    }
+  }, []);
+
+  const handleDismiss = () => {
+    try {
+      localStorage.setItem(DISMISS_KEY, '1');
+    } catch {
+      // ignore write failures; still hide for this session.
+    }
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className={styles.bar} role="region">
+      <span className={styles.message}>
+        {COPY.lead} {COPY.newHome}{' '}
+        <Link className={styles.link} href={COPY.newHomeUrl}>
+          {COPY.newHomeLabel}
+        </Link>
+        .{' '}
+        <span className="migration-reassurance">
+          {COPY.current}{' '}
+          <Link className={styles.link} href={COPY.currentUrl}>
+            {COPY.currentLabel}
+          </Link>{' '}
+          {COPY.currentTail}
+        </span>
+      </span>
+      <Link className={styles.cta} href={COPY.ctaUrl} rel="noopener" target="_blank">
+        {COPY.cta}
+      </Link>
+      <button
+        aria-label={COPY.dismissAria}
+        className={styles.dismiss}
+        onClick={handleDismiss}
+        type="button"
+      >
+        <X size={16} strokeWidth={2.5} />
+      </button>
+    </div>
+  );
+});
+
+MigrationBanner.displayName = 'MigrationBanner';
+
+export default MigrationBanner;


### PR DESCRIPTION
## What this adds

A small, dismissible **top notice bar** announcing the upcoming migration to the new version of Phở Chat. Shown across the main app.

## Files

- **New:** `src/features/MigrationBanner/index.tsx` — the `'use client'` banner component.
- **Edited:** `src/app/[variants]/layout.tsx` — one import + one render line (`<MigrationBanner />`) inside `GlobalProvider`.

Total diff: 2 files, +214 lines. No refactors, no dep changes, nothing else touched.

## Where it's injected & why

Rendered **once** in the shared `[variants]` root layout (`RootLayout`), inside `GlobalProvider`, at the top of the app tree. This is the exact slot the previously-shipped `NewYearLifetimeBanner` used (the commented-out `{/* <NewYearLifetimeBanner /> */}` line), so it is a proven host for a client-side banner and covers the whole app in a single place. No duplication across the separate Desktop/Mobile layouts.

## Layout safety (important for a live app)

The app shell is height-locked: `html, body, #__next` are `max-height: 100dvh; overflow: hidden` on desktop, and the Desktop/Mobile layouts subtract a fixed `BANNER_HEIGHT` from content height for the existing `CloudBanner`. A normal-flow banner would therefore clip the bottom of the chat.

To avoid that, `MigrationBanner` is **`position: fixed`** at the top (`z-index: 1000`), so it does **not** participate in the flow-height math. Existing `calc(100% - BANNER_HEIGHT)` layout math and the `100dvh`/`overflow:hidden` shell are untouched. This mirrors the repo's own `NewYearLifetimeBanner`, which is fixed-position for the same reason.

## Dismiss mechanism

- On mount (`useEffect`), reads `localStorage['pho_migration_notice_dismissed']`; stays hidden if it equals `'1'`.
- Clicking the `×` sets that key to `'1'` and hides the bar.
- The founder can clear that localStorage key to re-show it during testing.

## SSR-safety

- `'use client'` component; default state is **hidden** (`useState(false)`).
- `localStorage` is **only** touched inside `useEffect` (never during render), and the read is wrapped in `try/catch`.
- Renders `null` until mounted, so there is **no hydration mismatch** and no SSR flash.

## Styling

antd-style `createStyles` (the repo's styling system), on-brand dark with a jade accent (`#059669`), slim (~40px min-height), responsive (reassurance clause hides on mobile to stay compact). Accessible: `aria-label` on the close button, `role="region"` on the bar.

## Copy (Vietnamese, no em-dashes)

All copy lives in a single founder-editable `COPY` constant at the top of the component:

> Phở Chat sắp nâng cấp lên phiên bản mới, nhanh hơn và trả lời kèm trích dẫn nguồn thật. Bản mới sẽ ở **pho.chat**. Bản hiện tại của bạn luôn truy cập được tại **v1.pho.chat** với đầy đủ dữ liệu.

Plus a **"Dùng thử bản mới"** CTA and a dismiss `×`. Wording is forward-looking so it reads correctly both **before and after** the domain swap. `pho.chat` and `v1.pho.chat` are real links.

## Verification

- `type-check` (`tsgo --noEmit`) passes clean (exit 0) — ran the repo's actual type-check; zero errors, none in the touched files.
- ESLint passes clean on the new component (including the repo's `sort-keys-fix` rule).
- The full **pre-commit hook** (type-check + prettier + stylelint + eslint via lint-staged) ran and **passed** on commit — no `--no-verify`.
- Did **not** run a full `next build` (very heavy on LobeChat) and did not boot a dev server to screenshot.

## Notes

⚠️ **Do NOT merge until the founder is ready to start the migration notice period.**

The "try new version" link points to **v2.pho.chat** for now (since `pho.chat` still serves v1 until the swap). **Switch it to `pho.chat` after the domain swap** — there's a code comment on `ctaUrl` marking exactly where.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a dismissible, fixed top notice bar announcing the migration to the new Phở Chat. It is SSR-safe and remembers dismissal in `localStorage`.

- **New Features**
  - New client component `src/features/MigrationBanner`; imported and rendered once in `src/app/[variants]/layout.tsx`.
  - Fixed-position at the top; does not affect the height-locked app shell or existing layout math.
  - Hidden until mount; `localStorage` read/write only in `useEffect` with try/catch to avoid hydration issues.
  - All copy lives in a single `COPY` constant (VN). CTA points to `https://v2.pho.chat` for now.

- **Migration**
  - Do not merge until the notice period should start.
  - After the domain swap, change the CTA URL to `https://pho.chat` (noted in code).

<sup>Written for commit a3fe380a195ad48a665c40c0a68f096768071181. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dismissible top banner prompting users to try the newer version of the site.
  * The banner includes quick links to the current version and the new destination, plus a button to open the new site in a new tab.
  * Dismissal is remembered for returning visitors, with a fallback that keeps the banner visible if browser storage isn’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->