### PR TITLE
⚡️ perf: chat TTFT quick wins + gateway-first pho models (slowness audit 2026-07-13)

### DIFF
--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -592,6 +592,11 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
       priorityList,
     );
 
+    // PCFIX-4: TTFT anchor. Stamped BEFORE the provider failover loop so
+    // $ai_ttft_ms covers provider attempts too (post-auth → first token),
+    // and shares one anchor with $ai_latency_ms.
+    const requestStartTime = Date.now();
+
     let lastError: any = null;
     let successfulResponse: Response | null = null;
     let actualProviderUsed = activeProvider;
@@ -741,8 +746,6 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
           `Add it to scripts/seed-model-pricing-gateway.ts and re-seed.`,
       );
     }
-
-    const requestStartTime = Date.now();
 
     if (data.stream && response.body) {
       // ── UTF-8 Repair for Anthropic via Vercel AI Gateway ──

--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -774,6 +774,9 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
       const billingTask = (async () => {
         let accumulatedText = '';
         let completed = false;
+        // PCFIX-4: time-to-first-token. Stamped on the first non-empty chunk so
+        // we can distinguish "stalled before first token" from "long stream".
+        let ttftMs: number | undefined;
 
         try {
           const reader = stream2.getReader();
@@ -782,6 +785,9 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
           for (;;) {
             const { done, value } = await reader.read();
             if (done) break;
+            if (ttftMs === undefined && value && value.length > 0) {
+              ttftMs = Date.now() - requestStartTime;
+            }
             accumulatedText += decoder.decode(value, { stream: true });
           }
           completed = true;
@@ -831,6 +837,8 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
                   planId: userPlanId,
                   provider: actualProviderUsed,
                   responseTimeMs,
+                  // PCFIX-4: TTFT (stream path only). Undefined if no chunk arrived before abort.
+                  ttftMs,
                 },
               );
             }

--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -34,6 +34,9 @@ import { createErrorResponse } from '@/utils/errorResponse';
 import { getTracePayload } from '@/utils/trace';
 
 export const maxDuration = 300;
+// Pin to the same regions as trpc/lambda — Neon lives in aws-ap-southeast-1,
+// so keep the function next to the DB (insurance against default-region drift).
+export const preferredRegion = ['sin1', 'hnd1'];
 
 // TODO: Re-enable when usage tracking is fully implemented
 // async function trackUsageAfterCompletion(params: {

--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -366,7 +366,15 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
     // ============  0.5. Credit Check (Pre-flight)   ============ //
     // Fetch credit balance once — reuse for both pre-flight and tier access checks
     let prefetchedCreditStatus: Awaited<ReturnType<typeof getUserCreditBalance>> = null;
+    let userPlanIdPromise: Promise<string> | undefined;
     if (jwtPayload.userId) {
+      // Plan lookup is independent of the credit read (and may include a Clerk
+      // network call in soft mode) — start it now, consume it in section 2.
+      // The no-op catch prevents an unhandled rejection if we return before
+      // awaiting (balance block below, body-parse failure); the real error
+      // still surfaces at the `await` in section 2.
+      userPlanIdPromise = getUserPlanIdFromDB(jwtPayload.userId);
+      userPlanIdPromise.catch(() => {});
       prefetchedCreditStatus = await getUserCreditBalance(jwtPayload.userId);
       const balance = prefetchedCreditStatus?.balance || 0;
 
@@ -443,7 +451,8 @@ export const POST = checkAuth(async (req: Request, { params, jwtPayload, createR
     if (jwtPayload.userId) {
       // PHO-241/A1.6: DB is the single source of truth for paid-plan checks.
       // Clerk publicMetadata is display cache only and must never gate authorization.
-      userPlanId = await getUserPlanIdFromDB(jwtPayload.userId);
+      // (Lookup was started in section 0.5, in parallel with the credit read.)
+      userPlanId = await (userPlanIdPromise ?? getUserPlanIdFromDB(jwtPayload.userId));
 
       // ============  2.0. Daily Request Cap (Circuit Breaker)  ============ //
       // Prevents single user from burning excessive cost in one day

--- a/src/libs/__tests__/posthog-server.test.ts
+++ b/src/libs/__tests__/posthog-server.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Never hit a real DB/Clerk even if a test omits planId and the capture path
+// falls back to getUserPlanFromDB.
+vi.mock('@/server/services/subscription/getUserPlanFromDB', () => ({
+  getUserPlanFromDB: vi.fn().mockResolvedValue({ planId: 'fallback_plan', source: 'db' }),
+}));
+
+/**
+ * PCFIX-4: pin the $ai_ttft_ms contract on the server-side `$ai_generation`
+ * capture. TTFT is what lets dashboards tell "stalled before first token" apart
+ * from "long stream" — so it must be emitted when present and absent (not null)
+ * when the caller did not measure it (e.g. non-streaming paths).
+ */
+describe('captureAiGeneration — $ai_ttft_ms (PCFIX-4)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  const baseParams = {
+    costPoints: 10,
+    inputTokens: 100,
+    latencyMs: 5000,
+    model: 'anthropic/claude-sonnet-4.6',
+    outputTokens: 800,
+    planId: 'medical_beta', // pass plan to skip the DB fallback lookup
+    provider: 'vercelaigateway',
+    tier: 2,
+    userId: 'user_123',
+  };
+
+  beforeEach(() => {
+    // POSTHOG_KEY is read at module-load time, so stub env BEFORE the dynamic import.
+    vi.stubEnv('NEXT_PUBLIC_POSTHOG_KEY', 'phc_test_key');
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, statusText: 'OK' });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  const importFresh = async () => {
+    vi.resetModules();
+    return import('../posthog-server');
+  };
+
+  const capturedProperties = async () => {
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const init = fetchMock.mock.calls[0][1] as { body: string };
+    return JSON.parse(init.body).properties;
+  };
+
+  it('emits $ai_ttft_ms when ttftMs is provided (streaming path)', async () => {
+    const { captureAiGeneration } = await importFresh();
+
+    captureAiGeneration({ ...baseParams, ttftMs: 1234 });
+
+    const props = await capturedProperties();
+    expect(props.$ai_ttft_ms).toBe(1234);
+    // total wall-clock stays available for comparison.
+    expect(props.$ai_latency_ms).toBe(5000);
+  });
+
+  it('omits $ai_ttft_ms (not null) when ttftMs is undefined (non-streaming path)', async () => {
+    const { captureAiGeneration } = await importFresh();
+
+    captureAiGeneration({ ...baseParams }); // no ttftMs
+
+    const props = await capturedProperties();
+    expect('$ai_ttft_ms' in props).toBe(false);
+    expect(props.$ai_latency_ms).toBe(5000);
+  });
+
+  it('stamps ttftMs=0 explicitly rather than dropping it', async () => {
+    const { captureAiGeneration } = await importFresh();
+
+    // A first chunk arriving in the same millisecond yields ttftMs=0; that is a
+    // real measurement and must survive (0 !== undefined).
+    captureAiGeneration({ ...baseParams, ttftMs: 0 });
+
+    const props = await capturedProperties();
+    expect(props.$ai_ttft_ms).toBe(0);
+  });
+});

--- a/src/libs/posthog-server.ts
+++ b/src/libs/posthog-server.ts
@@ -40,6 +40,13 @@ export interface CaptureAiGenerationParams {
   provider: string;
   /** PHO-246: model tier (1/2/3) for cost-per-tier breakdowns. */
   tier?: number;
+  /**
+   * PCFIX-4: time-to-first-token in ms. Streaming paths set this when the first
+   * content chunk arrives; undefined for non-streaming / unmeasured calls.
+   * `$ai_latency_ms` (total wall-clock) minus this approximates stream duration,
+   * so we can tell "stalled before first token" from "long stream".
+   */
+  ttftMs?: number;
   userId: string;
 }
 
@@ -88,6 +95,8 @@ async function emitAiGeneration(params: CaptureAiGenerationParams): Promise<void
       $ai_output_tokens: params.outputTokens,
       $ai_partial: params.partial ?? false,
       $ai_provider: params.provider,
+      // PCFIX-4: time-to-first-token (stream paths). Undefined values are dropped by JSON.stringify.
+      $ai_ttft_ms: params.ttftMs,
       ...(params.costUSD !== undefined && { $ai_cost_usd: params.costUSD }),
       // PHO-246: cost-per-plan / cost-per-tier breakdowns.
       ...(planId !== undefined && { planId }),

--- a/src/server/services/billing/credits.ts
+++ b/src/server/services/billing/credits.ts
@@ -114,6 +114,13 @@ export interface UsageLogParams {
   provider: string;
   responseTimeMs?: number;
   sessionId?: string;
+  /**
+   * PCFIX-4: time-to-first-token (ms) for streaming responses. Forwarded to
+   * PostHog as `$ai_ttft_ms` so we can tell "stalled before first token" (high
+   * TTFT) apart from "long stream" (low TTFT, high total). Undefined for
+   * non-streaming paths where the full response is buffered before metering.
+   */
+  ttftMs?: number;
 }
 
 /**
@@ -341,6 +348,7 @@ export async function processModelUsage(
         planId: usageLog.planId,
         provider: usageLog.provider,
         tier,
+        ttftMs: usageLog.ttftMs,
         userId,
       });
     }

--- a/src/server/services/phoGateway/index.ts
+++ b/src/server/services/phoGateway/index.ts
@@ -143,20 +143,24 @@ class PhoGatewayService {
       ],
     },
 
+    // 2026-07-13: gateway-first for pho-fast/pho-pro. Groq free tier throttles at
+    // 12k/6k TPM (hard 413s reached users, retry-after up to 142s), and Groq llama
+    // pricing is unseeded in model_pricing (bills at conservative fallback).
+    // Groq stays as fallback; requires a positive AI Gateway credit balance.
     'pho-fast': {
       id: 'pho-fast',
       providers: [
+        { modelId: 'google/gemini-2.0-flash', provider: 'vercelaigateway' },
         { modelId: 'llama-3.1-8b-instant', provider: 'groq' },
         { modelId: 'llama3.1-8b', provider: 'cerebras' },
-        { modelId: 'google/gemini-2.0-flash', provider: 'vercelaigateway' },
       ],
     },
 
     'pho-pro': {
       id: 'pho-pro',
       providers: [
-        { modelId: 'llama-3.3-70b-versatile', provider: 'groq' },
         { modelId: 'google/gemini-2.5-flash', provider: 'vercelaigateway' },
+        { modelId: 'llama-3.3-70b-versatile', provider: 'groq' },
       ],
     },
 

--- a/src/server/services/subscription/index.ts
+++ b/src/server/services/subscription/index.ts
@@ -210,10 +210,13 @@ export class SubscriptionService {
 
     // For free plans, check points/usage limits (legacy behavior)
     if (isFreePlan) {
-      const usage = await this.getTrialUsage(userId);
-
-      // Legacy: Check message limit only if TRIAL_CONFIG.maxMessages > 0
+      // Legacy: Check message limit only if TRIAL_CONFIG.maxMessages > 0.
+      // getTrialUsage is an unbounded COUNT/SUM over the user's entire
+      // usage_logs — only pay for it when the limit is actually enforced
+      // (with maxMessages = -1 the result was computed and discarded on
+      // every free-user message, on the pre-first-token hot path).
       if (TRIAL_CONFIG.maxMessages > 0) {
+        const usage = await this.getTrialUsage(userId);
         const messagesRemaining = Math.max(0, TRIAL_CONFIG.maxMessages - usage.messageCount);
 
         if (messagesRemaining <= 0) {

--- a/src/server/services/subscription/index.ts
+++ b/src/server/services/subscription/index.ts
@@ -208,28 +208,26 @@ export class SubscriptionService {
       }
     }
 
-    // For free plans, check points/usage limits (legacy behavior)
-    if (isFreePlan) {
-      // Legacy: Check message limit only if TRIAL_CONFIG.maxMessages > 0.
-      // getTrialUsage is an unbounded COUNT/SUM over the user's entire
-      // usage_logs — only pay for it when the limit is actually enforced
-      // (with maxMessages = -1 the result was computed and discarded on
-      // every free-user message, on the pre-first-token hot path).
-      if (TRIAL_CONFIG.maxMessages > 0) {
-        const usage = await this.getTrialUsage(userId);
-        const messagesRemaining = Math.max(0, TRIAL_CONFIG.maxMessages - usage.messageCount);
+    // For free plans, check points/usage limits (legacy behavior).
+    // Legacy message limit applies only if TRIAL_CONFIG.maxMessages > 0.
+    // getTrialUsage is an unbounded COUNT/SUM over the user's entire
+    // usage_logs — only pay for it when the limit is actually enforced
+    // (with maxMessages = -1 the result was computed and discarded on
+    // every free-user message, on the pre-first-token hot path).
+    if (isFreePlan && TRIAL_CONFIG.maxMessages > 0) {
+      const usage = await this.getTrialUsage(userId);
+      const messagesRemaining = Math.max(0, TRIAL_CONFIG.maxMessages - usage.messageCount);
 
-        if (messagesRemaining <= 0) {
-          pino.warn({ messagesUsed: usage.messageCount, planCode, userId }, 'Free tier limit reached');
-          return {
-            allowed: false,
-            allowedTiers,
-            isTrialUser: true,
-            messagesRemaining: 0,
-            planCode,
-            reason: 'Bạn đã sử dụng hết quota miễn phí. Nâng cấp để tiếp tục chat với AI.',
-          };
-        }
+      if (messagesRemaining <= 0) {
+        pino.warn({ messagesUsed: usage.messageCount, planCode, userId }, 'Free tier limit reached');
+        return {
+          allowed: false,
+          allowedTiers,
+          isTrialUser: true,
+          messagesRemaining: 0,
+          planCode,
+          reason: 'Bạn đã sử dụng hết quota miễn phí. Nâng cấp để tiếp tục chat với AI.',
+        };
       }
     }
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] ⚡️ perf
- [x] ✨ feat (observability)

#### 🔀 变更说明 | Description of Change

Fixes from the 2026-07-13 production slowness audit (paying customers affected: vn_ultimate user blocked by gateway 402s, vn_pro user with a 300s timeout — same day). Each commit is independently revertible:

1. **Ship TTFT instrumentation** — cherry-pick of never-merged `19eca1cbef` (`$ai_ttft_ms` on `$ai_generation`), plus move the anchor before the provider failover loop so TTFT ≈ post-auth → first token. Settles whether the p95 200-290s `$ai_latency_ms` is long outputs or pre-stream stalls.
2. **Pin `preferredRegion = ['sin1','hnd1']`** on the chat route (matches trpc/lambda; Neon is aws-ap-southeast-1).
3. **Gateway-first failover for pho-fast/pho-pro** — Groq free tier hard-413s (12k/6k TPM, retry-after up to 142s) reached users, and Groq llama pricing is unseeded in model_pricing. Gemini 2.0/2.5 Flash via AI Gateway become primary (both already seeded); Groq stays as fallback.
4. **Stop computing discarded trial usage** — `checkTrialAccess` ran an unbounded COUNT/SUM over the user's whole `usage_logs` on every free-user message and threw the result away (`TRIAL_CONFIG.maxMessages = -1`). Moved inside the existing guard; behavior unchanged.
5. **Parallelize plan lookup with credit read** — `getUserPlanIdFromDB` (may include a Clerk round-trip in soft mode) now starts alongside `getUserCreditBalance`; awaited at its original site, error semantics unchanged. Cost-cap → tier-slot ordering untouched.

#### 📝 补充信息 | Additional Information

- Verified: full `bun run type-check` PASS (standalone), `posthog-server.test.ts` 3/3 PASS, eslint clean on changed files. Commits used `--no-verify` because the pre-commit tsgo full-repo check OOMs on this machine (known issue; owner approved, established protocol).
- **Ops prerequisite**: top up AI Gateway credits + enable auto-reload — 402 `insufficient_funds` was still firing on 2026-07-13. Without credits, pho-* falls back to Groq but premium models keep failing.
- After deploy: `$ai_ttft_ms` should appear in PostHog taxonomy within ~1h; read p50/p95 after 3-7 days.
- Out of scope (deliberately, v1 sunset): tRPC batch streaming, pageSize caps, getUserState consolidation — recorded as V2 requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add server-side TTFT instrumentation and switch `pho-fast`/`pho-pro` to gateway-first routing to reduce stalls and avoid Groq 413s. Pin the chat route to `sin1`/`hnd1` and streamline hot-path checks to lower time-to-first-token.

- **Refactors**
  - Make `vercelaigateway` primary for `pho-fast` (`gemini-2.0-flash`) and `pho-pro` (`gemini-2.5-flash`); keep Groq as fallback.
  - Set `preferredRegion = ['sin1','hnd1']` on the chat route.
  - Only compute trial usage when `TRIAL_CONFIG.maxMessages > 0`; start plan lookup in parallel with the credit read.
  - Anchor TTFT before failover and emit `$ai_ttft_ms` from the stream path through billing to PostHog.

- **Migration**
  - Top up AI Gateway credits and enable auto-reload, or `pho-*` may fall back and premium models can fail with 402.

<sup>Written for commit f80282126e97060662e733a530b4d84cbfe2d11f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added time-to-first-token tracking for streaming responses to improve performance analytics.
  * Chat requests now use regional runtime routing for improved availability.
  * Updated model routing to prioritize the AI Gateway for faster and more reliable failover.

* **Bug Fixes**
  * Improved free-tier quota handling when message limits are disabled.
  * Reduced delays during plan and credit checks.
  * Preserved accurate analytics when streams end before producing a token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->