### PR TITLE
🔒️ fix(security,db): close SePay compat webhook bypass + unblock user.deleted (migration 0048)

### DIFF
--- a/packages/database/migrations/0048_global_files_creator_nullable.sql
+++ b/packages/database/migrations/0048_global_files_creator_nullable.sql
@@ -1,0 +1,13 @@
+-- Fix: `global_files.creator` was declared `ON DELETE SET NULL` yet `NOT NULL`.
+--
+-- That self-contradiction aborted every `user.deleted` cascade: Postgres tried
+-- to SET creator = NULL per the FK rule, which violated the NOT NULL constraint,
+-- so the whole `DELETE FROM users` transaction rolled back. Clerk then retried
+-- the webhook indefinitely and the user was left "half-deleted" — gone in Clerk
+-- but still present in Postgres.
+--
+-- Dropping NOT NULL restores the intended semantics: when the creating user is
+-- deleted, the shared (hash-keyed, deduplicated) global file blob is orphaned
+-- and kept, not removed. It is only referenced by `files.file_hash` with
+-- `ON DELETE no action`, so orphaning does not break other users' file rows.
+ALTER TABLE "global_files" ALTER COLUMN "creator" DROP NOT NULL;

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -336,6 +336,13 @@
       "when": 1767518400000,
       "tag": "0047_promo_activations",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1767604800000,
+      "tag": "0048_global_files_creator_nullable",
+      "breakpoints": true
     }
   ],
   "version": "6"

--- a/packages/database/src/schemas/file.ts
+++ b/packages/database/src/schemas/file.ts
@@ -26,9 +26,12 @@ export const globalFiles = pgTable('global_files', {
   size: integer('size').notNull(),
   url: text('url').notNull(),
   metadata: jsonb('metadata'),
-  creator: text('creator')
-    .references(() => users.id, { onDelete: 'set null' })
-    .notNull(),
+  // Nullable on purpose: the FK is `ON DELETE SET NULL`, so when the creating
+  // user is deleted the global file is orphaned (kept — it's a shared, hash-keyed
+  // dedup blob) rather than removed. A `.notNull()` here contradicted SET NULL and
+  // aborted every `user.deleted` cascade, leaving users stuck half-deleted and
+  // Clerk retrying the webhook forever.
+  creator: text('creator').references(() => users.id, { onDelete: 'set null' }),
   createdAt: createdAt(),
   accessedAt: accessedAt(),
 });

--- a/src/app/api/sepay/webhook/route.test.ts
+++ b/src/app/api/sepay/webhook/route.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as billingService from '@/server/services/billing/sepay';
+
+import { POST } from './route';
+
+// Mock billing services so no test ever touches the database
+vi.mock('@/server/services/billing/sepay', () => ({
+  activateUserSubscription: vi.fn(),
+  getPaymentByOrderId: vi.fn(),
+  updatePaymentStatus: vi.fn(),
+}));
+
+vi.mock('@/server/services/billing/credits', () => ({
+  addPhoCredits: vi.fn(),
+}));
+
+// Mock Sepay gateway
+vi.mock('@/libs/sepay', () => ({
+  sepayGateway: {
+    verifyWebhookSignature: vi.fn().mockReturnValue(true),
+  },
+}));
+
+// Mock payment metrics collector
+vi.mock('@/libs/monitoring/payment-metrics', () => ({
+  paymentMetricsCollector: {
+    recordError: vi.fn(),
+    recordWebhookProcessing: vi.fn(),
+  },
+}));
+
+const WEBHOOK_SECRET = 'test-webhook-secret-value';
+
+const createWebhookPayload = (overrides = {}) => ({
+  amount: 100_000,
+  currency: 'VND',
+  orderId: 'PHO_QR_123456',
+  signature: 'valid_signature_hash',
+  status: 'failed',
+  timestamp: new Date().toISOString(),
+  transactionId: 'TXN_123456',
+  ...overrides,
+});
+
+const createRequest = (body: object, headers: Record<string, string> = {}) =>
+  new Request('http://localhost/api/sepay/webhook', {
+    body: JSON.stringify(body),
+    headers,
+    method: 'POST',
+  });
+
+describe('POST /api/sepay/webhook (compat route)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('SEPAY_WEBHOOK_SECRET', WEBHOOK_SECRET);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('authentication (fail-closed)', () => {
+    it('returns 500 and does not process when SEPAY_WEBHOOK_SECRET is not configured', async () => {
+      vi.stubEnv('SEPAY_WEBHOOK_SECRET', '');
+
+      const response = await POST(createRequest(createWebhookPayload()) as any);
+
+      expect(response.status).toBe(500);
+      const data = await response.json();
+      expect(data.success).toBe(false);
+      expect(billingService.updatePaymentStatus).not.toHaveBeenCalled();
+      expect(billingService.activateUserSubscription).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 and does not process when no secret is provided', async () => {
+      const response = await POST(createRequest(createWebhookPayload()) as any);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.success).toBe(false);
+      expect(billingService.updatePaymentStatus).not.toHaveBeenCalled();
+      expect(billingService.activateUserSubscription).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when x-sepay-webhook-secret header has the wrong value', async () => {
+      const response = await POST(
+        createRequest(createWebhookPayload(), { 'x-sepay-webhook-secret': 'forged-secret' }) as any,
+      );
+
+      expect(response.status).toBe(401);
+      expect(billingService.updatePaymentStatus).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when Authorization header carries a wrong Apikey token', async () => {
+      const response = await POST(
+        createRequest(createWebhookPayload(), { authorization: 'Apikey forged-secret' }) as any,
+      );
+
+      expect(response.status).toBe(401);
+      expect(billingService.updatePaymentStatus).not.toHaveBeenCalled();
+    });
+
+    it('accepts the shared secret via x-sepay-webhook-secret header', async () => {
+      const response = await POST(
+        createRequest(createWebhookPayload(), { 'x-sepay-webhook-secret': WEBHOOK_SECRET }) as any,
+      );
+
+      expect(response.status).toBe(200);
+      expect(billingService.updatePaymentStatus).toHaveBeenCalledWith(
+        'PHO_QR_123456',
+        'failed',
+        expect.objectContaining({ transactionId: 'TXN_123456' }),
+      );
+    });
+
+    it('accepts the shared secret via Authorization: Apikey header', async () => {
+      const response = await POST(
+        createRequest(createWebhookPayload(), { authorization: `Apikey ${WEBHOOK_SECRET}` }) as any,
+      );
+
+      expect(response.status).toBe(200);
+      expect(billingService.updatePaymentStatus).toHaveBeenCalled();
+    });
+  });
+
+  describe('payload validation (after auth)', () => {
+    it('returns 400 when orderId is missing', async () => {
+      const response = await POST(
+        createRequest(createWebhookPayload({ orderId: undefined }), {
+          'x-sepay-webhook-secret': WEBHOOK_SECRET,
+        }) as any,
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.message).toContain('orderId');
+      expect(billingService.updatePaymentStatus).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when transactionId is missing', async () => {
+      const response = await POST(
+        createRequest(createWebhookPayload({ transactionId: undefined }), {
+          'x-sepay-webhook-secret': WEBHOOK_SECRET,
+        }) as any,
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.message).toContain('transactionId');
+      expect(billingService.updatePaymentStatus).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/sepay/webhook/route.ts
+++ b/src/app/api/sepay/webhook/route.ts
@@ -8,6 +8,7 @@ import {
   getPaymentByOrderId,
   updatePaymentStatus,
 } from '@/server/services/billing/sepay';
+import { timingSafeCompareStrings } from '@/utils/timingSafeCompare';
 
 /**
  * Sepay Webhook Handler - Compatibility Route
@@ -279,10 +280,46 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       '🔔 [COMPAT ROUTE] Webhook received at /api/sepay/webhook from:',
       request.headers.get('user-agent'),
     );
-    console.log(
-      '🔔 [COMPAT ROUTE] Request headers:',
-      Object.fromEntries(request.headers.entries()),
-    );
+
+    // SECURITY CHECK: verify webhook authentication before doing any work.
+    // Mirrors the canonical /api/payment/sepay/webhook route: SePay sends the
+    // shared secret either as `X-Sepay-Webhook-Secret` or `Authorization: Apikey <token>`.
+    // This closes the previous "process even on invalid/missing signature" hole
+    // that let a forged POST activate a paid subscription.
+    const webhookSecret = process.env.SEPAY_WEBHOOK_SECRET;
+
+    let providedSecret = request.headers.get('x-sepay-webhook-secret');
+    if (!providedSecret) {
+      const authHeader = request.headers.get('authorization');
+      if (authHeader && authHeader.startsWith('Apikey ')) {
+        providedSecret = authHeader.slice(7);
+      }
+    }
+
+    if (!webhookSecret) {
+      console.error('❌ [COMPAT ROUTE] SEPAY_WEBHOOK_SECRET not configured in environment');
+      return NextResponse.json(
+        { message: 'Webhook authentication not configured', success: false },
+        { status: 500 },
+      );
+    }
+
+    // Constant-time compare; returns false on missing/different-length input,
+    // so it subsumes the `!providedSecret` guard.
+    if (!providedSecret || !timingSafeCompareStrings(providedSecret, webhookSecret)) {
+      console.error('❌ [COMPAT ROUTE] Unauthorized webhook — invalid or missing secret token');
+      paymentMetricsCollector.recordError(
+        'webhook_auth_failed',
+        'Unauthorized webhook request (compat route)',
+        undefined,
+        undefined,
+        { hasSecret: !!providedSecret },
+      );
+      return NextResponse.json(
+        { message: 'Unauthorized - invalid webhook secret', success: false },
+        { status: 401 },
+      );
+    }
 
     // Parse webhook data from Sepay (only parse once!)
     body = await request.json();


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix

#### 🔀 变更说明 | Description of Change

Re-implementation of the **two P0 fixes** from unmerged commit `236c12ed` (branch `claude/audit-larg-nguyen-usage-jtaeiv`, 2026-07-02 audit), cleanly rebased onto current `main`. The llama pricing seed from that commit is **intentionally excluded** — it was handled separately on `claude/zealous-clarke-98707b` (2026-07-14).

**1. SePay compat webhook — fail-closed authentication (P0, security)**

`src/app/api/sepay/webhook/route.ts` previously processed webhooks even on invalid/missing signature ("Signature verification failed - webhook will still be processed for debugging") and logged all request headers. A forged POST could activate a paid subscription.

Now the route:
- Requires `SEPAY_WEBHOOK_SECRET` via `X-Sepay-Webhook-Secret` or `Authorization: Apikey <token>` — same contract as the canonical `/api/payment/sepay/webhook` route
- Rejects with **401** on missing/wrong secret (constant-time compare via `timingSafeCompareStrings`), **500** if the secret env var is unconfigured — fail-closed, no processing on either path
- No longer dumps request headers to logs

New `route.test.ts` covers the auth gate: 401/500 fail-closed paths, both header forms accepted, no billing side effects on rejection, and payload validation after auth (8 tests).

**2. Migration 0048 — `global_files.creator` DROP NOT NULL (P0, data integrity)**

`global_files.creator` was declared `ON DELETE SET NULL` yet `NOT NULL` — a self-contradiction that aborted every Clerk `user.deleted` cascade: Postgres tried to SET NULL, violated NOT NULL, rolled back the whole `DELETE FROM users`, and Clerk retried forever, leaving users half-deleted. Migration 0048 drops NOT NULL; the Drizzle schema (`packages/database/src/schemas/file.ts`) is updated to match, and the migration journal gains the idx-48 entry.

#### 📝 补充信息 | Additional Information

**⚠️ Requires Hien's explicit confirmation before merge** (payment-webhook change per CLAUDE.md). Pre-merge check: confirm the SePay dashboard is actually configured to send the shared secret to the compat URL — once this merges, unsigned webhooks to `/api/sepay/webhook` stop working **by design**.

**⚠️ Manual post-merge step (Hien):** run migration 0048 against the production Neon DB (project `billowing-water-53737108`):
```sql
ALTER TABLE "global_files" ALTER COLUMN "creator" DROP NOT NULL;
```

**Verification**
- `src/app/api/sepay/webhook/route.test.ts` — 8/8 pass (uses the real `timingSafeCompareStrings`, mocks all billing services)
- `packages/database` `models/__tests__/file.test.ts` — 44/44 pass with the nullable schema
- ESLint + prettier + stylelint clean on all changed files
- Local full-repo `tsgo` is not meaningful in the shared-node_modules worktree used for this work (cross-realm type mismatch vs the sibling checkout; baseline `origin/main` fails identically there) — CI typecheck on this PR is the authoritative signal
- No drift conflicts: the three touched files were byte-identical between `236c12ed~1` and current `main`; migration slot 0048 was still free (main is at 0047)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secure the SePay compat webhook by enforcing shared-secret auth (fail-closed) and fix the `global_files.creator` schema to unblock `user.deleted` cascades (migration 0048). This closes a subscription activation bypass and stops user deletions from failing.

- **Bug Fixes**
  - SePay compat webhook now requires `SEPAY_WEBHOOK_SECRET` via `X-Sepay-Webhook-Secret` or `Authorization: Apikey <token>`; returns 401 on bad/missing secret and 500 if unconfigured, and stops logging all request headers. Added tests for auth and payload validation.
  - Dropped NOT NULL on `global_files.creator` (migration 0048) and updated the Drizzle schema to match, restoring `ON DELETE SET NULL` behavior so `user.deleted` cascades succeed.

- **Migration**
  - Confirm the SePay dashboard sends the shared secret to `/api/sepay/webhook`; unsigned requests now fail by design.
  - Run migration 0048 in production: `ALTER TABLE "global_files" ALTER COLUMN "creator" DROP NOT NULL;`.

<sup>Written for commit d6898abcb4581c6815c57f561c724594804e3fb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thaohienhomes/pho-chat-v1/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

